### PR TITLE
Implement calculate projections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,3 @@ ENV/
 
 # Rope project settings
 .ropeproject
-
-# Files I create just for debugging
-debugbug.py

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,11 +1,13 @@
 from mantid.simpleapi import ConvertToMD
 from models.projection.powder.projection_calculator import ProjectionCalculator
 
+MD_SUFFIX = '_MD'
+
 
 class MantidProjectionCalculator(ProjectionCalculator):
     def calculate_projection(self, input_workspace, output_workspace, qbinning, axis1, axis2):
         if axis1 == '|Q|' and axis2 == 'Energy':
-            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=input_workspace+'_MD',QDimensions='|Q|',
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=input_workspace + MD_SUFFIX, QDimensions='|Q|',
                         PreprocDetectorsWS='-')
         else:
             raise NotImplementedError('MSlice currently only supports projection to Energy vs |Q|')

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -5,7 +5,8 @@ from models.projection.powder.projection_calculator import ProjectionCalculator
 class MantidProjectionCalculator(ProjectionCalculator):
     def calculate_projection(self, input_workspace, output_workspace, qbinning, axis1, axis2):
         if axis1 == '|Q|' and axis2 == 'Energy':
-            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=input_workspace+'_MD',QDimensions='|Q|')
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=input_workspace+'_MD',QDimensions='|Q|',
+                        PreprocDetectorsWS='-')
         else:
             raise NotImplementedError('MSlice currently only supports projection to Energy vs |Q|')
 

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -5,9 +5,10 @@ MD_SUFFIX = '_MD'
 
 
 class MantidProjectionCalculator(ProjectionCalculator):
-    def calculate_projection(self, input_workspace, output_workspace, qbinning, axis1, axis2):
+    def calculate_projection(self, input_workspace, axis1, axis2):
+        output_workspace = input_workspace + MD_SUFFIX
         if axis1 == '|Q|' and axis2 == 'Energy':
-            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=input_workspace + MD_SUFFIX, QDimensions='|Q|',
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
                         PreprocDetectorsWS='-')
         else:
             raise NotImplementedError('MSlice currently only supports projection to Energy vs |Q|')

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,22 +1,11 @@
-from math import sqrt,cos
-
-from mantid.simpleapi import SofQWNormalisedPolygon,mtd
-
+from mantid.simpleapi import ConvertToMD
 from models.projection.powder.projection_calculator import ProjectionCalculator
 
 
 class MantidProjectionCalculator(ProjectionCalculator):
     def calculate_projection(self, input_workspace, output_workspace, qbinning, axis1, axis2):
-        if axis1 == 'Energy' and axis2 == '|Q|':
-            #TODO is EMode always direct ?
-            SofQWNormalisedPolygon(InputWorkspace=input_workspace, OutputWorkspace=output_workspace,
-                                                                QAxisBinning=qbinning,EMode='Direct')
+        if axis1 == '|Q|' and axis2 == 'Energy':
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=input_workspace+'_MD',QDimensions='|Q|')
+        else:
+            raise NotImplementedError('MSlice currently only supports projection to Energy vs |Q|')
 
-    def calculate_suggested_binning(self, input_workspace):
-        return '0,.1,10'
-        #TODO AskInstrument scientist about calculating scattering angles
-        input_workspace = mtd[input_workspace]
-        ei = float(input_workspace.getRun().getLogData('Ei').value)
-        ki = sqrt(ei/2.07)
-        kf = sqrt((ei-0.0)/2.07)
-        Qx=ki*1-cos(minTheta)*kf

--- a/models/projection/powder/projection_calculator.py
+++ b/models/projection/powder/projection_calculator.py
@@ -2,7 +2,7 @@ import abc
 
 class ProjectionCalculator(object):
     @abc.abstractmethod
-    def calculate_projection(self, input_workspace, output_workspace, qbinning, axis1, axis2):
+    def calculate_projection(self, input_workspace, axis1, axis2):
         pass
 
     def calculate_suggested_binning(self, input_workspace):

--- a/mslice.py
+++ b/mslice.py
@@ -13,8 +13,8 @@ class MsliceGui(QMainWindow,Ui_MainWindow,MainView):
         self._presenter = MainPresenter(self,workspace_presenter)
 
         self.wgtWorkspacemanager.set_main_window(self)
-        self.wgtSlice.set_main_window(self)
-        self.wgtPowder.set_main_window(self)
+        self.wgtSlice.set_workspace_selector(self)
+        self.wgtPowder.set_workspace_selector(self)
 
 if __name__ == "__main__":
     from build_all_ui_files import build_all_ui_files,script_folder

--- a/mslice.py
+++ b/mslice.py
@@ -14,6 +14,7 @@ class MsliceGui(QMainWindow,Ui_MainWindow,MainView):
 
         self.wgtWorkspacemanager.set_main_window(self)
         self.wgtSlice.set_main_window(self)
+        self.wgtPowder.set_main_window(self)
 
 if __name__ == "__main__":
     from build_all_ui_files import build_all_ui_files,script_folder

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -32,17 +32,13 @@ class PowderProjectionPresenter(object):
         axis1 = self._powder_view.get_powder_u1()
         axis2 = self._powder_view.get_powder_u2()
         if axis1 == axis2:
-            pass # TODO ask what to do
+            raise NotImplementedError('equal axis')
         if not selected_workspaces:
             pass
-            # TODO notify user? Status bar maybe?
+            raise NotImplementedError('Implement error message')
 
         for workspace in selected_workspaces:
-            # TODO if spec decides on suffix naming system then this will be calculated by the presenter!
-            output_workspace = self._powder_view.get_output_workspace_name()
-            binning = self._projection_calculator.calculate_suggested_binning(workspace)
-            # TODO should user be able to suggest own binning?
-            self._projection_calculator.calculate_projection(workspace, output_workspace, binning, axis1, axis2)
+            self._projection_calculator.calculate_projection(workspace, axis1, axis2)
         self._get_main_presenter().update_displayed_workspaces()
 
     def _get_main_presenter(self):

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -18,8 +18,8 @@ class PowderProjectionPresenter(object):
 
         self._main_view = main_view
         #Add rest of options
-        self._powder_view.populate_powder_u1(['Energy'])
-        self._powder_view.populate_powder_u2(['|Q|'])
+        self._powder_view.populate_powder_u1(['|Q|'])
+        self._powder_view.populate_powder_u2(['Energy'])
 
     def notify(self, command):
         if command == Command.CalculatePowderProjection:

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -77,13 +77,13 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.projection_calculator.calculate_projection.assert_not_called()
 
     def test_calculate_projection_multiple_selection(self):
-        selected_workspaces = ['a', 'b']
+        selected_workspaces = []
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=selected_workspaces)
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
-        u2 = 'Energy'
+        u2 = '|Q|'
         self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
         self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)
         self.assertRaises(NotImplementedError,self.powder_presenter.notify,Command.CalculatePowderProjection)

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -48,7 +48,6 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.main_presenter.get_selected_workspaces.assert_called_once_with()
         self.powder_view.get_powder_u1.assert_called_once_with()
         self.powder_view.get_powder_u2.assert_called_once_with()
-        self.powder_view.get_output_workspace_name.assert_called_with()
         # TODO edit after recieving binning specs (test binning recieved from user if appropriate)
         #TODO make test more strict after recieving binning specs
         #self.projection_calculator.calculate_projection.assert_called_once_with(input_workspace=selected_workspace,

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -34,8 +34,6 @@ class PowderProjectionPresenterTest(unittest.TestCase):
     def test_calculate_projection_success(self):
         selected_workspace = 'a'
         output_workspace = 'b'
-        # Setting up view to report output_workspace as output workspace name supplied by user
-        self.powder_view.get_output_workspace_name = mock.Mock(return_value=output_workspace)
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
@@ -59,3 +57,38 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
         unrecognised_command = 1234567
         self.assertRaises(ValueError, self.powder_presenter.notify, unrecognised_command)
+
+    def test_calculate_projection_equal_axis_error(self):
+        selected_workspace = 'a'
+        output_workspace = 'b'
+        # Setting up main presenter to report that the current selected workspace is selected_workspace
+        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
+        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
+        # Setup view to report Energy and |Q| as selected axis to project two
+        u1 = 'Energy'
+        u2 = 'Energy'
+        self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
+        self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)
+        self.assertRaises(NotImplementedError,self.powder_presenter.notify,Command.CalculatePowderProjection)
+        self.main_presenter.get_selected_workspaces.assert_called_once_with()
+        self.powder_view.get_powder_u1.assert_called_once_with()
+        self.powder_view.get_powder_u2.assert_called_once_with()
+
+        self.projection_calculator.calculate_projection.assert_not_called()
+
+    def test_calculate_projection_multiple_selection(self):
+        selected_workspaces = ['a', 'b']
+        # Setting up main presenter to report that the current selected workspace is selected_workspace
+        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=selected_workspaces)
+        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
+        # Setup view to report Energy and |Q| as selected axis to project two
+        u1 = 'Energy'
+        u2 = 'Energy'
+        self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
+        self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)
+        self.assertRaises(NotImplementedError,self.powder_presenter.notify,Command.CalculatePowderProjection)
+        self.main_presenter.get_selected_workspaces.assert_called_once_with()
+        self.powder_view.get_powder_u1.assert_called_once_with()
+        self.powder_view.get_powder_u2.assert_called_once_with()
+
+        self.projection_calculator.calculate_projection.assert_not_called()

--- a/widgets/projection/powder/powder.py
+++ b/widgets/projection/powder/powder.py
@@ -13,8 +13,10 @@ class PowderWidget(QWidget,Ui_Form,PowderView):
         self.setupUi(self)
         self.btnPowderCalculateProjection.clicked.connect(self._btn_clicked)
 
-    def set_main_window(self, main_window):
-        self._presenter = PowderProjectionPresenter(self, main_window, MantidProjectionCalculator())
+    def set_workspace_selector(self, workspace_selector):
+        # Currently will raise an error if a workspace_selector does not implement mainView
+        # The code needs to be refactored and proper interface needs to be defined.
+        self._presenter = PowderProjectionPresenter(self, workspace_selector, MantidProjectionCalculator())
 
     def _btn_clicked(self):
         self._presenter.notify(Command.CalculatePowderProjection)

--- a/widgets/projection/powder/powder.py
+++ b/widgets/projection/powder/powder.py
@@ -1,8 +1,44 @@
 from powder_ui import Ui_Form
 from PyQt4.QtGui import QWidget
+from presenters.powder_projection_presenter import PowderProjectionPresenter
+from models.projection.powder.mantid_projection_calculator import MantidProjectionCalculator
+from views.powder_projection_view import PowderView
+from command import Command
 
 
-class PowderWidget(QWidget,Ui_Form):
+class PowderWidget(QWidget,Ui_Form,PowderView):
+    """This widget is not usable without a main window which implements mainview"""
     def __init__(self,*args, **kwargs):
         super(PowderWidget,self).__init__(*args, **kwargs)
         self.setupUi(self)
+        self.btnPowderCalculateProjection.clicked.connect(self._btn_clicked)
+
+    def set_main_window(self, main_window):
+        self._presenter = PowderProjectionPresenter(self, main_window, MantidProjectionCalculator())
+
+    def _btn_clicked(self):
+        self._presenter.notify(Command.CalculatePowderProjection)
+
+    def get_powder_u1(self):
+        return str(self.cmbPowderU1.currentText())
+
+    def get_powder_u2(self):
+        return str(self.cmbPowderU2.currentText())
+
+    def populate_powder_u1(self, u1_options):
+        self.cmbPowderU1.clear()
+        for value in u1_options:
+            self.cmbPowderU1.addItem(value)
+
+    def populate_powder_u2(self, u2_options):
+        self.cmbPowderU2.clear()
+        for value in u2_options:
+            self.cmbPowderU2.addItem(value)
+
+    def populate_powder_projection_units(self, powder_projection_units):
+        self.cmbPowderUnits.clear()
+        for unit in powder_projection_units:
+            self.cmbPowderUnits.addItem(unit)
+
+    def get_powder_units(self):
+        return str(self.cmbPowderUnits.currentText())

--- a/widgets/slice/slice.py
+++ b/widgets/slice/slice.py
@@ -20,12 +20,16 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
     def _btn_clicked(self):
         self._presenter.notify(Command.DisplaySlice)
 
-    def set_main_window(self,main_window):
-        self._presenter = SlicePlotterPresenter(main_view=main_window, slice_view=self,
+    def set_workspace_selector(self, workspace_selector):
+        # Currently will raise an error if a workspace_selector does not implement mainView
+        # The code needs to be refactored and proper interface needs to be defined.
+        self._presenter = SlicePlotterPresenter(main_view=workspace_selector, slice_view=self,
                                                 slice_plotter=MatplotlibSlicePlotter())
-        self._main_window = main_window
+        # O
+        self._main_window = workspace_selector
 
     def _display_error(self, error_string, timeout_ms):
+        # Should be replaced to emit signal containing the error message
         if self.display_errors_to_statusbar:
             self._main_window.statusBar().showMessage(error_string, timeout_ms)
         else:

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -32,6 +32,7 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         self._main_window = None
 
     def set_main_window(self,main_window):
+        # TODO refactor to emit errors as signals
         """Set a main window to display status bar messages to.
 
          If no main window is set any errors will be displayed to QDialogBoxes"""


### PR DESCRIPTION
Will transform the current selected workspace to MD workspace if user clicks on calculate powder projection

**To Test:**
Load a workspace 2d into mslice, select the checkbox next to it in the workspace manager
And click on the calculate projections button on the powder tab
A new workspace should appear in the in the workspacemanager tab with the suffix 'MD'

resolves #11 