### PR TITLE
Implement workspace selection changed notification system.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+omit =
+    presenters/interfaces/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 
 # command to run tests
 script: 
-  nosetests -v --with-coverage --cover-min-percentage=80 --cover-package=presenters,plotting.figuremanager --exclude-dir=presenters/interfaces
+  nosetests -v --with-coverage --cover-min-percentage=80 --cover-package=presenters,plotting.figuremanager
 
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 
 # command to run tests
 script: 
-  nosetests -v --with-coverage --cover-min-percentage=80 --cover-package=presenters,plotting.figuremanager
+  nosetests -v --with-coverage --cover-min-percentage=80 --cover-package=presenters,plotting.figuremanager --exclude-dir=presenters/interfaces
 
 after_success:
   coveralls

--- a/mainview.py
+++ b/mainview.py
@@ -1,12 +1,9 @@
-from presenters.main_presenter import MainPresenter
-from views.workspace_view import WorkspaceView
 
 
-class MainView:
+class MainView(object):
     def __init__(self):
-        self._workspace_manager_view = WorkspaceView()
-        workspace_manager_presenter = self._workspace_manager_view.get_presenter()
-        self._presenter = MainPresenter(self, workspace_manager_presenter)
+        pass
 
     def get_presenter(self):
-        return self._presenter
+        pass
+

--- a/mslice.py
+++ b/mslice.py
@@ -9,10 +9,10 @@ class MsliceGui(QMainWindow,Ui_MainWindow,MainView):
     def __init__(self):
         super(MsliceGui,self).__init__()
         self.setupUi(self)
+        self.wgtWorkspacemanager.set_client_handler(self)
         workspace_presenter = self.wgtWorkspacemanager.get_presenter()
         self._presenter = MainPresenter(self,workspace_presenter)
 
-        self.wgtWorkspacemanager.set_main_window(self)
         self.wgtSlice.set_workspace_selector(self)
         self.wgtPowder.set_workspace_selector(self)
 

--- a/mslice.py
+++ b/mslice.py
@@ -9,11 +9,12 @@ class MsliceGui(QMainWindow,Ui_MainWindow,MainView):
     def __init__(self):
         super(MsliceGui,self).__init__()
         self.setupUi(self)
-        self._presenter = MainPresenter(self)
 
-        self.wgtWorkspacemanager.get_presenter().register_master(self)
-        self.wgtSlice.get_presenter().register_master(self)
-        self.wgtPowder.get_presenter().register_master(self)
+        workspace_presenter = self.wgtWorkspacemanager.get_presenter()
+        slice_presenter = self.wgtSlice.get_presenter()
+        powder_presneter = self.wgtPowder.get_presenter()
+
+        self._presenter = MainPresenter(self, workspace_presenter, slice_presenter, powder_presneter)
 
     def get_presenter(self):
         return self._presenter

--- a/mslice.py
+++ b/mslice.py
@@ -9,12 +9,14 @@ class MsliceGui(QMainWindow,Ui_MainWindow,MainView):
     def __init__(self):
         super(MsliceGui,self).__init__()
         self.setupUi(self)
-        self.wgtWorkspacemanager.set_client_handler(self)
-        workspace_presenter = self.wgtWorkspacemanager.get_presenter()
-        self._presenter = MainPresenter(self,workspace_presenter)
+        self._presenter = MainPresenter(self)
 
-        self.wgtSlice.set_workspace_selector(self)
-        self.wgtPowder.set_workspace_selector(self)
+        self.wgtWorkspacemanager.get_presenter().register_master(self)
+        self.wgtSlice.get_presenter().register_master(self)
+        self.wgtPowder.get_presenter().register_master(self)
+
+    def get_presenter(self):
+        return self._presenter
 
 if __name__ == "__main__":
     qapp = QApplication([])

--- a/presenters/interfaces/main_presenter.py
+++ b/presenters/interfaces/main_presenter.py
@@ -1,0 +1,18 @@
+class MainPresenterInterface(object):
+    def __init__(self, main_view):
+        raise Exception("This class is an abstract interface and must no be instantiated")
+
+    def get_selected_workspaces(self):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def update_displayed_workspaces(self):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def notify_workspace_selection_changed(self):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def subscribe_to_workspace_selection_monitor(self, client):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def register_workspace_selector(self, workspace_selector):
+        raise NotImplementedError("This method must be overriden in implementation")

--- a/presenters/interfaces/powder_projection_presenter.py
+++ b/presenters/interfaces/powder_projection_presenter.py
@@ -1,0 +1,11 @@
+
+class PowderProjectionPresenterInterface(object):
+
+    def __init__(self, powder_view, projection_calculator):
+        raise Exception("This interface must not be instantiated")
+
+    def register_master(self, main_view):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def notify(self, command):
+        raise NotImplementedError("This method must be overriden in implementation")

--- a/presenters/interfaces/slice_plotter_presenter.py
+++ b/presenters/interfaces/slice_plotter_presenter.py
@@ -1,0 +1,12 @@
+class SlicePlotterPresenterInterface(object):
+    def __init__(self, slice_view, slice_plotter):
+        raise Exception("This interface class must not be instantiated")
+
+    def register_master(self, main_view):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def notify(self,command):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def workspace_selection_changed(self):
+        raise NotImplementedError("This method must be overriden in implementation")

--- a/presenters/interfaces/workspace_manager_presenter.py
+++ b/presenters/interfaces/workspace_manager_presenter.py
@@ -1,0 +1,15 @@
+class WorkspaceManagerPresenterInterface(object):
+    def __init__(self, workspace_view, workspace_provider):
+        raise Exception("Interface Class must not be instantiated")
+
+    def register_master(self, main_view):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def notify(self, command):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def get_selected_workspaces(self):
+        raise NotImplementedError("This method must be overriden in implementation")
+
+    def update_displayed_workspaces(self):
+        raise NotImplementedError("This method must be overriden in implementation")

--- a/presenters/main_presenter.py
+++ b/presenters/main_presenter.py
@@ -1,4 +1,4 @@
-class MainPresenter:
+class MainPresenter(object):
     def __init__(self,main_view,workspace_presenter):
         self._mainView = main_view
         self._workspace_presenter = workspace_presenter

--- a/presenters/main_presenter.py
+++ b/presenters/main_presenter.py
@@ -1,4 +1,7 @@
-class MainPresenter(object):
+from interfaces.main_presenter import MainPresenterInterface
+
+
+class MainPresenter(MainPresenterInterface):
     def __init__(self, main_view):
         self._mainView = main_view
         self._selected_workspace_listener = []
@@ -18,7 +21,7 @@ class MainPresenter(object):
         for listener in self._selected_workspace_listener:
             listener.workspace_selection_changed()
 
-    def notify_selection_changed(self):
+    def notify_workspace_selection_changed(self):
         self.broadcast_selection_changed()
 
     def subscribe_to_workspace_selection_monitor(self, client):

--- a/presenters/main_presenter.py
+++ b/presenters/main_presenter.py
@@ -1,7 +1,6 @@
 class MainPresenter(object):
-    def __init__(self,main_view,workspace_presenter):
+    def __init__(self, main_view):
         self._mainView = main_view
-        self._workspace_presenter = workspace_presenter
         self._selected_workspace_listener = []
 
     def get_selected_workspaces(self):
@@ -19,6 +18,9 @@ class MainPresenter(object):
         for listener in self._selected_workspace_listener:
             listener.workspace_selection_changed()
 
+    def notify_selection_changed(self):
+        self.broadcast_selection_changed()
+
     def subscribe_to_workspace_selection_monitor(self, client):
         """Subcscribe a client to be notified when selected workspaces change
 
@@ -28,3 +30,5 @@ class MainPresenter(object):
         else:
             raise TypeError("The client trying to subscribe does not implement the method 'workspace_selection_changed'")
 
+    def register_workspace_selector(self, workspace_selector):
+        self._workspace_presenter = workspace_selector

--- a/presenters/main_presenter.py
+++ b/presenters/main_presenter.py
@@ -2,9 +2,11 @@ from interfaces.main_presenter import MainPresenterInterface
 
 
 class MainPresenter(MainPresenterInterface):
-    def __init__(self, main_view):
+    def __init__(self, main_view, *subpresenters):
         self._mainView = main_view
         self._selected_workspace_listener = []
+        for presenter in subpresenters:
+            presenter.register_master(self)
 
     def get_selected_workspaces(self):
         return self._workspace_presenter.get_selected_workspaces()

--- a/presenters/main_presenter.py
+++ b/presenters/main_presenter.py
@@ -1,7 +1,8 @@
-class MainPresenter():
+class MainPresenter:
     def __init__(self,main_view,workspace_presenter):
         self._mainView = main_view
         self._workspace_presenter = workspace_presenter
+        self._selected_workspace_listener = []
 
     def get_selected_workspaces(self):
         return self._workspace_presenter.get_selected_workspaces()
@@ -13,3 +14,17 @@ class MainPresenter():
         does any operation that changes the name or type of any existing workspace or creates or removes a
         workspace"""
         self._workspace_presenter.update_displayed_workspaces()
+
+    def broadcast_selection_changed(self):
+        for listener in self._selected_workspace_listener:
+            listener.workspace_selection_changed()
+
+    def subscribe_to_workspace_selection_monitor(self, client):
+        """Subcscribe a client to be notified when selected workspaces change
+
+        client.workspace_selection_changed() will be called whenever the selected workspaces change"""
+        if callable(getattr(client, "workspace_selection_changed",None)):
+            self._selected_workspace_listener.append(client)
+        else:
+            raise TypeError("The client trying to subscribe does not implement the method 'workspace_selection_changed'")
+

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -3,9 +3,10 @@ from views.powder_projection_view import PowderView
 from widgets.projection.powder.command import Command
 from validation_decorators import require_main_presenter
 from mainview import MainView
+from interfaces.powder_projection_presenter import PowderProjectionPresenterInterface
 
 
-class PowderProjectionPresenter(object):
+class PowderProjectionPresenter(PowderProjectionPresenterInterface):
 
     def __init__(self, powder_view, projection_calculator):
         self._powder_view = powder_view

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -2,6 +2,7 @@ from models.projection.powder.projection_calculator import ProjectionCalculator
 from views.powder_projection_view import PowderView
 from widgets.projection.powder.command import Command
 from validation_decorators import require_main_presenter
+from mainview import MainView
 
 
 class PowderProjectionPresenter(object):
@@ -20,6 +21,7 @@ class PowderProjectionPresenter(object):
         self._main_presenter = None
 
     def register_master(self, main_view):
+        assert (isinstance(main_view, MainView))
         self._main_presenter = main_view.get_presenter()
 
     def notify(self, command):

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -1,25 +1,26 @@
-from mainview import MainView
 from models.projection.powder.projection_calculator import ProjectionCalculator
 from views.powder_projection_view import PowderView
 from widgets.projection.powder.command import Command
+from validation_decorators import require_main_presenter
 
 
 class PowderProjectionPresenter(object):
 
-    def __init__(self,powder_view,main_view,projection_calculator):
+    def __init__(self, powder_view, projection_calculator):
         self._powder_view = powder_view
         self._projection_calculator = projection_calculator
         if not isinstance(self._powder_view,PowderView):
             raise TypeError("powder_view is not of type PowderView")
         if not isinstance(self._projection_calculator,ProjectionCalculator):
             raise TypeError("projection_calculator is not of type ProjectionCalculator")
-        if not isinstance(main_view,MainView):
-            raise TypeError("main_view is not of type MainView")
 
-        self._main_view = main_view
         #Add rest of options
         self._powder_view.populate_powder_u1(['|Q|'])
         self._powder_view.populate_powder_u2(['Energy'])
+        self._main_presenter = None
+
+    def register_master(self, main_view):
+        self._main_presenter = main_view.get_presenter()
 
     def notify(self, command):
         if command == Command.CalculatePowderProjection:
@@ -34,14 +35,14 @@ class PowderProjectionPresenter(object):
         if axis1 == axis2:
             raise NotImplementedError('equal axis')
         if not selected_workspaces:
-            pass
             raise NotImplementedError('Implement error message')
 
         for workspace in selected_workspaces:
             self._projection_calculator.calculate_projection(workspace, axis1, axis2)
         self._get_main_presenter().update_displayed_workspaces()
 
+    @require_main_presenter
     def _get_main_presenter(self):
-        # not storing this variable at construction time gives freedom of creating this before creating the
-        # the main presenter
-        return self._main_view.get_presenter()
+        return self._main_presenter
+
+

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -2,7 +2,7 @@ from models.projection.powder.projection_calculator import ProjectionCalculator
 from views.powder_projection_view import PowderView
 from widgets.projection.powder.command import Command
 from validation_decorators import require_main_presenter
-from mainview import MainView
+from presenters.interfaces.main_presenter import MainPresenterInterface
 from interfaces.powder_projection_presenter import PowderProjectionPresenterInterface
 
 
@@ -21,9 +21,9 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         self._powder_view.populate_powder_u2(['Energy'])
         self._main_presenter = None
 
-    def register_master(self, main_view):
-        assert (isinstance(main_view, MainView))
-        self._main_presenter = main_view.get_presenter()
+    def register_master(self, main_presenter):
+        assert (isinstance(main_presenter, MainPresenterInterface))
+        self._main_presenter = main_presenter
 
     def notify(self, command):
         if command == Command.CalculatePowderProjection:

--- a/presenters/slice_plotter_presenter.py
+++ b/presenters/slice_plotter_presenter.py
@@ -28,6 +28,8 @@ class SlicePlotterPresenter:
         self._slice_view = slice_view
         self._main_view = main_view
         self._slice_plotter = slice_plotter
+        # calling the _get_main_presenter_method in the constructor renders it useless
+        self._get_main_presenter().subscribe_to_workspace_selection_monitor(self)
 
     def notify(self,command):
         if command == Command.DisplaySlice:
@@ -80,3 +82,8 @@ class SlicePlotterPresenter:
         # Get the presenter when needed as opposed to initializing it as a class variable in the constructor
         # givs the flexibilty to instantiate this presenter before the main presenter
         return self._main_view.get_presenter()
+
+    def workspace_selection_changed(self):
+        workspace_selection = self._get_main_presenter().get_selected_workspaces()
+        print ('workspace_selection changes to %s'%workspace_selection )
+        # Update drop down lists appropriately

--- a/presenters/slice_plotter_presenter.py
+++ b/presenters/slice_plotter_presenter.py
@@ -2,10 +2,10 @@ from collections import namedtuple
 
 from models.slice.slice_plotter import SlicePlotter
 from views.slice_plotter_view import SlicePlotterView
-from mainview import MainView
 from widgets.slice.command import Command
 from validation_decorators import require_main_presenter
 from interfaces.slice_plotter_presenter import SlicePlotterPresenterInterface
+from interfaces.main_presenter import MainPresenterInterface
 
 Axis = namedtuple('Axis', ['units', 'start', 'end', 'step'])
 
@@ -28,9 +28,9 @@ class SlicePlotterPresenter(SlicePlotterPresenterInterface):
         self._main_presenter = None
         self._slice_plotter = slice_plotter
 
-    def register_master(self, main_view):
-        assert (isinstance(main_view, MainView))
-        self._main_presenter = main_view.get_presenter()
+    def register_master(self, main_presenter):
+        assert (isinstance(main_presenter, MainPresenterInterface))
+        self._main_presenter = main_presenter
         self._main_presenter.subscribe_to_workspace_selection_monitor(self)
 
     def notify(self,command):

--- a/presenters/slice_plotter_presenter.py
+++ b/presenters/slice_plotter_presenter.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 from models.slice.slice_plotter import SlicePlotter
 from views.slice_plotter_view import SlicePlotterView
+from mainview import MainView
 from widgets.slice.command import Command
 from validation_decorators import require_main_presenter
 
@@ -27,6 +28,7 @@ class SlicePlotterPresenter:
         self._slice_plotter = slice_plotter
 
     def register_master(self, main_view):
+        assert (isinstance(main_view, MainView))
         self._main_presenter = main_view.get_presenter()
         self._main_presenter.subscribe_to_workspace_selection_monitor(self)
 

--- a/presenters/slice_plotter_presenter.py
+++ b/presenters/slice_plotter_presenter.py
@@ -5,6 +5,7 @@ from views.slice_plotter_view import SlicePlotterView
 from mainview import MainView
 from widgets.slice.command import Command
 from validation_decorators import require_main_presenter
+from interfaces.slice_plotter_presenter import SlicePlotterPresenterInterface
 
 Axis = namedtuple('Axis', ['units', 'start', 'end', 'step'])
 
@@ -17,7 +18,7 @@ INVALID_X_UNITS = 6
 INVALID_Y_UNITS = 7
 
 
-class SlicePlotterPresenter:
+class SlicePlotterPresenter(SlicePlotterPresenterInterface):
     def __init__(self, slice_view, slice_plotter):
         if not isinstance(slice_view, SlicePlotterView):
             raise TypeError("Parameter slice_view is not of type SlicePlotterView")

--- a/presenters/slice_plotter_presenter.py
+++ b/presenters/slice_plotter_presenter.py
@@ -1,13 +1,12 @@
 from collections import namedtuple
 
-from mainview import MainView
 from models.slice.slice_plotter import SlicePlotter
 from views.slice_plotter_view import SlicePlotterView
 from widgets.slice.command import Command
+from validation_decorators import require_main_presenter
 
 Axis = namedtuple('Axis', ['units', 'start', 'end', 'step'])
 
-#TODO askOwen ,these constants exist in both sliceplotter and the presenter, where should they be defined?
 INVALID_PARAMS = 1
 INVALID_X_PARAMS = 2
 INVALID_Y_PARAMS = 3
@@ -18,18 +17,18 @@ INVALID_Y_UNITS = 7
 
 
 class SlicePlotterPresenter:
-    def __init__(self, main_view, slice_view,slice_plotter):
-        if not isinstance(main_view, MainView):
-            raise TypeError("Parameter main_view is not of type MainView")
+    def __init__(self, slice_view, slice_plotter):
         if not isinstance(slice_view, SlicePlotterView):
             raise TypeError("Parameter slice_view is not of type SlicePlotterView")
         if not isinstance(slice_plotter, SlicePlotter):
             raise TypeError("Parameter slice_plotter is not of type SlicePlotter")
         self._slice_view = slice_view
-        self._main_view = main_view
+        self._main_presenter = None
         self._slice_plotter = slice_plotter
-        # calling the _get_main_presenter_method in the constructor renders it useless
-        self._get_main_presenter().subscribe_to_workspace_selection_monitor(self)
+
+    def register_master(self, main_view):
+        self._main_presenter = main_view.get_presenter()
+        self._main_presenter.subscribe_to_workspace_selection_monitor(self)
 
     def notify(self,command):
         if command == Command.DisplaySlice:
@@ -78,10 +77,11 @@ class SlicePlotterPresenter:
         elif status == INVALID_Y_UNITS:
             self._slice_view.error_invalid_y_units()
 
+    @require_main_presenter
     def _get_main_presenter(self):
         # Get the presenter when needed as opposed to initializing it as a class variable in the constructor
         # givs the flexibilty to instantiate this presenter before the main presenter
-        return self._main_view.get_presenter()
+        return self._main_presenter
 
     def workspace_selection_changed(self):
         workspace_selection = self._get_main_presenter().get_selected_workspaces()

--- a/presenters/validation_decorators.py
+++ b/presenters/validation_decorators.py
@@ -1,0 +1,7 @@
+def require_main_presenter(function):
+    def wrapper(*args, **kwargs):
+        if not args[0]._main_presenter:
+            raise Exception('Main presenter has not been registered, it must be registered by the register_master method'
+                          'before This presenter can be used')
+        return function(*args, **kwargs)
+    return wrapper

--- a/presenters/validation_decorators.py
+++ b/presenters/validation_decorators.py
@@ -1,4 +1,8 @@
+from functools import wraps
+
+
 def require_main_presenter(function):
+    @wraps(function)
     def wrapper(*args, **kwargs):
         if not args[0]._main_presenter:
             raise Exception('Main presenter has not been registered, it must be registered by the register_master method'

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -3,6 +3,7 @@ import os.path
 from mainview import MainView
 from validation_decorators import require_main_presenter
 from interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
+from interfaces.main_presenter import MainPresenterInterface
 
 #TODO tell user when file not found,file failed to load
 
@@ -14,9 +15,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         self._work_spaceprovider = workspace_provider
         self._main_presenter = None
 
-    def register_master(self, main_view):
-        assert (isinstance(main_view, MainView))
-        self._main_presenter = main_view.get_presenter()
+    def register_master(self, main_presenter):
+        assert (isinstance(main_presenter, MainPresenterInterface))
+        self._main_presenter = main_presenter
         self._main_presenter.register_workspace_selector(self)
 
     def notify(self, command):

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -1,18 +1,22 @@
 from widgets.workspacemanager.command import Command
 import os.path
-
+from validation_decorators import require_main_presenter
 
 #TODO tell user when file not found,file failed to load
 
 class WorkspaceManagerPresenter(object):
-    def __init__(self, workspace_view, workspace_provider, main_view):
+    def __init__(self, workspace_view, workspace_provider):
         #TODO add validation checks
         self._groupCount = 1
         self._workspace_manger_view = workspace_view
         self._work_spaceprovider = workspace_provider
-        self._main_view = main_view
+        self._main_presenter = None
 
-    def notify(self,command):
+    def register_master(self, main_view):
+        self._main_presenter = main_view.get_presenter()
+        self._main_presenter.register_workspace_selector(self)
+
+    def notify(self, command):
         if command == Command.LoadWorkspace:
             self._load_workspace()
         elif command == Command.SaveSelectedWorkspace:
@@ -29,10 +33,11 @@ class WorkspaceManagerPresenter(object):
             raise ValueError("Workspace Manager Presenter received an unrecognised command")
 
     def _broadcast_selected_workspaces(self):
-        self._get_main_presenter().broadcast_selection_changed()
+        self._get_main_presenter().notify_selection_changed()
 
+    @require_main_presenter
     def _get_main_presenter(self):
-        return self._main_view.get_presenter()
+        return self._main_presenter
 
     def _load_workspace(self):
         #TODO specify workspace name on load

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -1,5 +1,6 @@
 from widgets.workspacemanager.command import Command
 import os.path
+from mainview import MainView
 from validation_decorators import require_main_presenter
 
 #TODO tell user when file not found,file failed to load
@@ -13,6 +14,7 @@ class WorkspaceManagerPresenter(object):
         self._main_presenter = None
 
     def register_master(self, main_view):
+        assert (isinstance(main_view, MainView))
         self._main_presenter = main_view.get_presenter()
         self._main_presenter.register_workspace_selector(self)
 

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -2,10 +2,11 @@ from widgets.workspacemanager.command import Command
 import os.path
 from mainview import MainView
 from validation_decorators import require_main_presenter
+from interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
 
 #TODO tell user when file not found,file failed to load
 
-class WorkspaceManagerPresenter(object):
+class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
     def __init__(self, workspace_view, workspace_provider):
         #TODO add validation checks
         self._groupCount = 1
@@ -35,7 +36,7 @@ class WorkspaceManagerPresenter(object):
             raise ValueError("Workspace Manager Presenter received an unrecognised command")
 
     def _broadcast_selected_workspaces(self):
-        self._get_main_presenter().notify_selection_changed()
+        self._get_main_presenter().notify_workspace_selection_changed()
 
     @require_main_presenter
     def _get_main_presenter(self):

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -2,16 +2,15 @@ from widgets.workspacemanager.command import Command
 import os.path
 
 
-#TODO When moving to actual workspaces the tests should reflect that
-#TODO implement compose workspace
 #TODO tell user when file not found,file failed to load
 
 class WorkspaceManagerPresenter(object):
-    def __init__(self,workspace_view,workspace_provider):
+    def __init__(self, workspace_view, workspace_provider, main_view):
         #TODO add validation checks
         self._groupCount = 1
         self._workspace_manger_view = workspace_view
         self._work_spaceprovider = workspace_provider
+        self._main_view = main_view
 
     def notify(self,command):
         if command == Command.LoadWorkspace:
@@ -24,8 +23,16 @@ class WorkspaceManagerPresenter(object):
             self._group_selected_workspaces()
         elif command == Command.RenameWorkspace:
             self._rename_workspace()
+        elif command == Command.SelectionChanged:
+            self._broadcast_selected_workspaces()
         else:
             raise ValueError("Workspace Manager Presenter received an unrecognised command")
+
+    def _broadcast_selected_workspaces(self):
+        self._get_main_presenter().broadcast_selection_changed()
+
+    def _get_main_presenter(self):
+        return self._main_view.get_presenter()
 
     def _load_workspace(self):
         #TODO specify workspace name on load

--- a/tests/main_presenter_test.py
+++ b/tests/main_presenter_test.py
@@ -11,7 +11,12 @@ class MainPresenterTests(unittest.TestCase):
         self.mainview = mock.create_autospec(MainView)
         self.workspace_presenter = mock.create_autospec(WorkspaceManagerPresenterInterface)
         self.workspace_presenter.get_selected_workspaces = mock.Mock(return_value=SELECTED_WORKSPACES)
-
+    def test_consturctor_sucess(self):
+        subpresenters = [mock.Mock() for i in range(10)]
+        main_presenter = MainPresenter(self.mainview, *subpresenters)
+        for presenter in subpresenters:
+            presenter.register_master.assert_called_once_with(main_presenter)
+            
     def test_get_selected_workspaces_success(self):
         main_presenter = MainPresenter(self.mainview)
         main_presenter.register_workspace_selector(self.workspace_presenter)
@@ -28,7 +33,7 @@ class MainPresenterTests(unittest.TestCase):
         for client in clients:
             client.workspace_selection_changed.assert_not_called()
 
-        main_presenter.broadcast_selection_changed()
+        main_presenter.notify_workspace_selection_changed()
         for client in clients:
             client.workspace_selection_changed.assert_called_once()
 

--- a/tests/main_presenter_test.py
+++ b/tests/main_presenter_test.py
@@ -1,7 +1,7 @@
 import mock
 import unittest
 from presenters.main_presenter import MainPresenter
-from presenters.workspace_manager_presenter import WorkspaceManagerPresenter
+from presenters.interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
 from mainview import MainView
 SELECTED_WORKSPACES = ['a', 'b', 'c']
 
@@ -9,7 +9,7 @@ SELECTED_WORKSPACES = ['a', 'b', 'c']
 class MainPresenterTests(unittest.TestCase):
     def setUp(self):
         self.mainview = mock.create_autospec(MainView)
-        self.workspace_presenter = mock.create_autospec(WorkspaceManagerPresenter)
+        self.workspace_presenter = mock.create_autospec(WorkspaceManagerPresenterInterface)
         self.workspace_presenter.get_selected_workspaces = mock.Mock(return_value=SELECTED_WORKSPACES)
 
     def test_get_selected_workspaces_success(self):

--- a/tests/main_presenter_test.py
+++ b/tests/main_presenter_test.py
@@ -44,3 +44,8 @@ class MainPresenterTests(unittest.TestCase):
             def __init__(self):
                 self.workspace_selection_changed = 1
         self.assertRaises(TypeError,main_presenter.subscribe_to_workspace_selection_monitor, x())
+
+    def test_update_displayed_workspaces(self):
+        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        main_presenter.update_displayed_workspaces()
+        self.workspace_presenter.update_displayed_workspaces.assert_called_with()

--- a/tests/main_presenter_test.py
+++ b/tests/main_presenter_test.py
@@ -13,13 +13,14 @@ class MainPresenterTests(unittest.TestCase):
         self.workspace_presenter.get_selected_workspaces = mock.Mock(return_value=SELECTED_WORKSPACES)
 
     def test_get_selected_workspaces_success(self):
-        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        main_presenter = MainPresenter(self.mainview)
+        main_presenter.register_workspace_selector(self.workspace_presenter)
         return_value = main_presenter.get_selected_workspaces()
         self.workspace_presenter.get_selected_workspaces.assert_called()
         self.assert_(return_value == SELECTED_WORKSPACES)
 
     def test_selection_change_broadcast(self):
-        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        main_presenter = MainPresenter(self.mainview)
         clients = [mock.Mock(), mock.Mock(), mock.Mock()]
         for client in clients:
             main_presenter.subscribe_to_workspace_selection_monitor(client)
@@ -31,21 +32,22 @@ class MainPresenterTests(unittest.TestCase):
         for client in clients:
             client.workspace_selection_changed.assert_called_once()
 
-    def test_subsribe_invalid_listener_fail(self):
-        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+    def test_subscribe_invalid_listener_fail(self):
+        main_presenter = MainPresenter(self.mainview)
         class x:
             def __init__(self):
                 self.attr = 1
         self.assertRaises(TypeError,main_presenter.subscribe_to_workspace_selection_monitor, x())
 
     def test_subscribe_invalid_listener_non_callable_handle_fail(self):
-        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        main_presenter = MainPresenter(self.mainview)
         class x:
             def __init__(self):
                 self.workspace_selection_changed = 1
-        self.assertRaises(TypeError,main_presenter.subscribe_to_workspace_selection_monitor, x())
+        self.assertRaises(TypeError, main_presenter.subscribe_to_workspace_selection_monitor, x())
 
     def test_update_displayed_workspaces(self):
-        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        main_presenter = MainPresenter(self.mainview)
+        main_presenter.register_workspace_selector(self.workspace_presenter)
         main_presenter.update_displayed_workspaces()
         self.workspace_presenter.update_displayed_workspaces.assert_called_with()

--- a/tests/main_presenter_test.py
+++ b/tests/main_presenter_test.py
@@ -1,0 +1,46 @@
+import mock
+import unittest
+from presenters.main_presenter import MainPresenter
+from presenters.workspace_manager_presenter import WorkspaceManagerPresenter
+from mainview import MainView
+SELECTED_WORKSPACES = ['a', 'b', 'c']
+
+
+class MainPresenterTests(unittest.TestCase):
+    def setUp(self):
+        self.mainview = mock.create_autospec(MainView)
+        self.workspace_presenter = mock.create_autospec(WorkspaceManagerPresenter)
+        self.workspace_presenter.get_selected_workspaces = mock.Mock(return_value=SELECTED_WORKSPACES)
+
+    def test_get_selected_workspaces_success(self):
+        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        return_value = main_presenter.get_selected_workspaces()
+        self.workspace_presenter.get_selected_workspaces.assert_called()
+        self.assert_(return_value == SELECTED_WORKSPACES)
+
+    def test_selection_change_broadcast(self):
+        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        clients = [mock.Mock(), mock.Mock(), mock.Mock()]
+        for client in clients:
+            main_presenter.subscribe_to_workspace_selection_monitor(client)
+
+        for client in clients:
+            client.workspace_selection_changed.assert_not_called()
+
+        main_presenter.broadcast_selection_changed()
+        for client in clients:
+            client.workspace_selection_changed.assert_called_once()
+
+    def test_subsribe_invalid_listener_fail(self):
+        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        class x:
+            def __init__(self):
+                self.attr = 1
+        self.assertRaises(TypeError,main_presenter.subscribe_to_workspace_selection_monitor, x())
+
+    def test_subscribe_invalid_listener_non_callable_handle_fail(self):
+        main_presenter = MainPresenter(self.mainview, self.workspace_presenter)
+        class x:
+            def __init__(self):
+                self.workspace_selection_changed = 1
+        self.assertRaises(TypeError,main_presenter.subscribe_to_workspace_selection_monitor, x())

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -31,6 +31,14 @@ class PowderProjectionPresenterTest(unittest.TestCase):
     def test_constructor_incorrect_projection_calculator_fail(self):
         self.assertRaises(TypeError, PowderProjectionPresenter, self.powder_view, self.mainview, None)
 
+    def test_register_master(self):
+        powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
+        powder_presenter.register_master(self.mainview)
+
+    def test_register_master_invalid_master_fail(self):
+        powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
+        self.assertRaises(AssertionError, powder_presenter.register_master, 3)
+
     def test_calculate_projection_success(self):
         selected_workspace = 'a'
         output_workspace = 'b'

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -20,7 +20,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
 
     def test_constructor_success(self):
-        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
+        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
 
     def test_constructor_incorrect_powder_view_fail(self):
         self.assertRaises(TypeError, PowderProjectionPresenter, self.mainview, self.mainview, self.projection_calculator)
@@ -36,7 +36,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         output_workspace = 'b'
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
-        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
+        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
         u2 = '|Q|'
@@ -54,7 +54,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.main_presenter.update_displayed_workspaces.assert_called_once_with()
 
     def test_notify_presenter_with_unrecognised_command_raise_exception(self):
-        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
+        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
         unrecognised_command = 1234567
         self.assertRaises(ValueError, self.powder_presenter.notify, unrecognised_command)
 
@@ -63,7 +63,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         output_workspace = 'b'
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
-        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
+        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
         u2 = 'Energy'
@@ -80,7 +80,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         selected_workspaces = []
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=selected_workspaces)
-        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.mainview, self.projection_calculator)
+        self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
         u2 = '|Q|'

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -4,7 +4,7 @@ import mock
 
 from mainview import MainView
 from models.projection.powder.projection_calculator import ProjectionCalculator
-from presenters.main_presenter import MainPresenter
+from presenters.interfaces.main_presenter import MainPresenterInterface
 from presenters.powder_projection_presenter import PowderProjectionPresenter
 from views.powder_projection_view import PowderView
 from widgets.projection.powder.command import Command
@@ -15,7 +15,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Set up a mock view, presenter, main view and main presenter
         self.powder_view = mock.create_autospec(PowderView)
         self.projection_calculator = mock.create_autospec(ProjectionCalculator)
-        self.main_presenter = mock.create_autospec(MainPresenter)
+        self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.mainview = mock.create_autospec(MainView)
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
 

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -33,7 +33,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
 
     def test_register_master(self):
         powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
-        powder_presenter.register_master(self.mainview)
+        powder_presenter.register_master(self.main_presenter)
 
     def test_register_master_invalid_master_fail(self):
         powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
@@ -45,7 +45,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
-        self.powder_presenter.register_master(self.mainview)
+        self.powder_presenter.register_master(self.main_presenter)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
         u2 = '|Q|'
@@ -78,7 +78,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         u2 = 'Energy'
         self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
         self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)
-        self.powder_presenter.register_master(self.mainview)
+        self.powder_presenter.register_master(self.main_presenter)
         self.assertRaises(NotImplementedError,self.powder_presenter.notify,Command.CalculatePowderProjection)
         self.main_presenter.get_selected_workspaces.assert_called_once_with()
         self.powder_view.get_powder_u1.assert_called_once_with()
@@ -91,7 +91,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=selected_workspaces)
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
-        self.powder_presenter.register_master(self.mainview)
+        self.powder_presenter.register_master(self.main_presenter)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
         u2 = '|Q|'

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -37,6 +37,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
+        self.powder_presenter.register_master(self.mainview)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
         u2 = '|Q|'
@@ -69,6 +70,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         u2 = 'Energy'
         self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
         self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)
+        self.powder_presenter.register_master(self.mainview)
         self.assertRaises(NotImplementedError,self.powder_presenter.notify,Command.CalculatePowderProjection)
         self.main_presenter.get_selected_workspaces.assert_called_once_with()
         self.powder_view.get_powder_u1.assert_called_once_with()
@@ -81,6 +83,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=selected_workspaces)
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
+        self.powder_presenter.register_master(self.mainview)
         # Setup view to report Energy and |Q| as selected axis to project two
         u1 = 'Energy'
         u2 = '|Q|'

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -38,6 +38,15 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         unknown_command = -1
         self.assertRaises(ValueError, self.slice_plotter_presenter.notify, unknown_command)
 
+    def test_register_master_success(self):
+        slice_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
+        slice_presenter.register_master(self.main_view)
+        self.main_presenter.subscribe_to_workspace_selection_monitor.assert_called_once_with(slice_presenter)
+
+    def test_register_master_invalid_master_fail(self):
+        slice_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
+        self.assertRaises(AssertionError, slice_presenter.register_master, 3)
+
     def test_plot_slice_successful(self):
         self.slice_plotter_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
         self.slice_plotter_presenter.register_master(self.main_view)

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -22,6 +22,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
 
     def test_constructor_success(self):
         self.slice_plotter_presenter = SlicePlotterPresenter(self.main_view, self.slice_view, self.slice_plotter)
+        self.main_presenter.subscribe_to_workspace_selection_monitor.assert_called_with(self.slice_plotter_presenter)
 
     def test_constructor_invalid_main_view_failure(self):
         self.assertRaises(TypeError, SlicePlotterPresenter, self.slice_view, self.slice_view, self.slice_plotter)

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -21,7 +21,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view = mock.create_autospec(SlicePlotterView)
 
     def test_constructor_success(self):
-        self.slice_plotter_presenter = SlicePlotterPresenter(self.main_view, self.slice_view, self.slice_plotter)
+        self.slice_plotter_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
         self.main_presenter.subscribe_to_workspace_selection_monitor.assert_called_with(self.slice_plotter_presenter)
 
     def test_constructor_invalid_main_view_failure(self):
@@ -34,14 +34,14 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.assertRaises(TypeError, SlicePlotterPresenter, self.main_view, self.slice_view, self.slice_view)
 
     def test_notify_presenter_unknown_command_raise_exception_failure(self):
-        self.slice_plotter_presenter = SlicePlotterPresenter(self.main_view, self.slice_view, self.slice_plotter)
+        self.slice_plotter_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
         unknown_command = -1
         self.assertRaises(ValueError, self.slice_plotter_presenter.notify, unknown_command)
 
     def test_plot_slice_successful(self):
-        self.slice_plotter_presenter = SlicePlotterPresenter(self.main_view, self.slice_view, self.slice_plotter)
-        x = Axis('x',0,10,1)
-        y = Axis('y',2,8,3)
+        self.slice_plotter_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
+        x = Axis('x', 0, 10 ,1)
+        y = Axis('y', 2, 8, 3)
         intensity_start = 7
         intensity_end = 8
         norm_to_one = 9

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -22,7 +22,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
 
     def test_constructor_success(self):
         self.slice_plotter_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
-        self.main_presenter.subscribe_to_workspace_selection_monitor.assert_called_with(self.slice_plotter_presenter)
+
 
     def test_constructor_invalid_main_view_failure(self):
         self.assertRaises(TypeError, SlicePlotterPresenter, self.slice_view, self.slice_view, self.slice_plotter)
@@ -40,6 +40,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
 
     def test_plot_slice_successful(self):
         self.slice_plotter_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
+        self.slice_plotter_presenter.register_master(self.main_view)
         x = Axis('x', 0, 10 ,1)
         y = Axis('y', 2, 8, 3)
         intensity_start = 7

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -4,7 +4,7 @@ import mock
 
 from mainview import MainView
 from models.slice.slice_plotter import SlicePlotter
-from presenters.main_presenter import MainPresenter
+from presenters.interfaces.main_presenter import MainPresenterInterface
 from presenters.slice_plotter_presenter import SlicePlotterPresenter,Axis
 from views.slice_plotter_view import SlicePlotterView
 from widgets.slice.command import Command
@@ -14,7 +14,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
     def setUp(self):
         # Setting up main tool presenter and view
         self.main_view = mock.create_autospec(MainView)
-        self.main_presenter = mock.create_autospec(MainPresenter)
+        self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.main_view.get_presenter = mock.Mock(return_value=self.main_presenter)
         # Setting up view for slice plotter window
         self.slice_plotter = mock.create_autospec(SlicePlotter)

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -40,7 +40,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
 
     def test_register_master_success(self):
         slice_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
-        slice_presenter.register_master(self.main_view)
+        slice_presenter.register_master(self.main_presenter)
         self.main_presenter.subscribe_to_workspace_selection_monitor.assert_called_once_with(slice_presenter)
 
     def test_register_master_invalid_master_fail(self):
@@ -49,7 +49,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
 
     def test_plot_slice_successful(self):
         self.slice_plotter_presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
-        self.slice_plotter_presenter.register_master(self.main_view)
+        self.slice_plotter_presenter.register_master(self.main_presenter)
         x = Axis('x', 0, 10 ,1)
         y = Axis('y', 2, 8, 3)
         intensity_start = 7

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -7,6 +7,7 @@ from models.workspacemanager.workspace_provider import WorkspaceProvider
 from presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from views.workspace_view import WorkspaceView
 from widgets.workspacemanager.command import Command
+from mainview import MainView
 from tempfile import gettempdir
 from os.path import join
 
@@ -17,9 +18,12 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
     def setUp(self):
         self.workspace_provider = mock.create_autospec(spec=WorkspaceProvider)
         self.view = mock.create_autospec(spec=WorkspaceView)
+        self.mainview = mock.create_autospec(MainView)
+        self.main_presenter= mock.Mock()
+        self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
 
     def test_load_one_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that will return a path on call to get_workspace_to_load_path
         tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
         path_to_nexus = join(tempdir,'cde.nxs')
@@ -33,7 +37,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_with([workspace_name])
 
     def test_load_multiple_workspaces(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that will return three filepaths on on 3 subsequent calls to get_workspace_to_load_path
         tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
         path1 = join(tempdir,'file1.nxs')
@@ -53,7 +57,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.load.assert_has_calls(load_calls)
 
     def test_rename_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
         # name on call to get_workspace_new_name
         old_workspace_name = 'file1'
@@ -69,7 +73,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_rename_workspace_multiple_workspace_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
         selected_workspaces = ['ws1', 'ws2']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
@@ -80,7 +84,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.rename_workspace.assert_not_called()
 
     def test_rename_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -90,7 +94,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.rename_workspace.assert_not_called()
 
     def test_save_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path\save.nxs'
@@ -105,7 +109,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.save_nexus.assert_called_once_with(workspace_to_save, path_to_save_to)
 
     def test_save_workspace_multiple_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         #Create a view that reports multiple workspaces are selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=['file1','file2'])
 
@@ -116,7 +120,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.save_nexus.assert_not_called()
 
     def test_save_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         #Create a view that reports no workspaces arw selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -127,7 +131,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.save_nexus.assert_not_called()
 
     def test_group_workspaces(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create view that reports two workspaces are selected on calls two get_workspace_selected
         workspaces_to_group = ['file1', 'file2']
         self.view.get_workspace_selected = mock.Mock(return_value=workspaces_to_group)
@@ -138,7 +142,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_group_single_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that reports a single selected workspace on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=['file1'])
 
@@ -148,7 +152,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_group_workspaces_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that reports no workspace selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -159,7 +163,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_not_called()
 
     def test_remove_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a workspace that reports a single selected workspace on calls to get_workspace_selected
         workspace_to_be_removed = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_be_removed])
@@ -170,7 +174,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_remove_multiple_workspaces(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that reports 3 selected workspaces on calls to get_workspace_selected
         workspace1 = 'file1'
         workspace2 = 'file2'
@@ -184,7 +188,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_remove_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         # Create a view that reports no workspace selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -194,11 +198,16 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.delete_workspace.assert_not_called()
         self.view.display_loaded_workspaces.assert_not_called()
 
+    def test_broadcast_success(self):
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter.notify(Command.SelectionChanged)
+        self.mainview.get_presenter.assert_called()
+        self.main_presenter.broadcast_selection_changed()
+
     def test_call_presenter_with_unknown_command(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
         unknown_command = 10
         self.assertRaises(ValueError,self.presenter.notify, unknown_command)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -22,6 +22,14 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.main_presenter= mock.Mock()
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
 
+    def test_register_master_success(self):
+        workspace_presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        workspace_presenter.register_master(self.mainview)
+        self.main_presenter.register_workspace_selector.assert_called_once_with(workspace_presenter)
+
+    def test_register_master_invalid_master_fail(self):
+        workspace_presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.assertRaises(AssertionError ,workspace_presenter.register_master, 3)
     def test_load_one_workspace(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that will return a path on call to get_workspace_to_load_path

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -25,12 +25,13 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_register_master_success(self):
         workspace_presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
-        workspace_presenter.register_master(self.mainview)
+        workspace_presenter.register_master(self.main_presenter)
         self.main_presenter.register_workspace_selector.assert_called_once_with(workspace_presenter)
 
     def test_register_master_invalid_master_fail(self):
         workspace_presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         self.assertRaises(AssertionError ,workspace_presenter.register_master, 3)
+
     def test_load_one_workspace(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that will return a path on call to get_workspace_to_load_path
@@ -209,7 +210,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_broadcast_success(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
-        self.presenter.register_master(self.mainview)
+        self.presenter.register_master(self.main_presenter)
         self.presenter.notify(Command.SelectionChanged)
         self.main_presenter.notify_workspace_selection_changed()
 

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -23,7 +23,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
 
     def test_load_one_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that will return a path on call to get_workspace_to_load_path
         tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
         path_to_nexus = join(tempdir,'cde.nxs')
@@ -37,7 +37,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_with([workspace_name])
 
     def test_load_multiple_workspaces(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that will return three filepaths on on 3 subsequent calls to get_workspace_to_load_path
         tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
         path1 = join(tempdir,'file1.nxs')
@@ -57,7 +57,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.load.assert_has_calls(load_calls)
 
     def test_rename_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
         # name on call to get_workspace_new_name
         old_workspace_name = 'file1'
@@ -73,7 +73,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_rename_workspace_multiple_workspace_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
         selected_workspaces = ['ws1', 'ws2']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
@@ -84,7 +84,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.rename_workspace.assert_not_called()
 
     def test_rename_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -94,7 +94,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.rename_workspace.assert_not_called()
 
     def test_save_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path\save.nxs'
@@ -109,7 +109,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.save_nexus.assert_called_once_with(workspace_to_save, path_to_save_to)
 
     def test_save_workspace_multiple_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         #Create a view that reports multiple workspaces are selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=['file1','file2'])
 
@@ -120,7 +120,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.save_nexus.assert_not_called()
 
     def test_save_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         #Create a view that reports no workspaces arw selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -131,7 +131,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.save_nexus.assert_not_called()
 
     def test_group_workspaces(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create view that reports two workspaces are selected on calls two get_workspace_selected
         workspaces_to_group = ['file1', 'file2']
         self.view.get_workspace_selected = mock.Mock(return_value=workspaces_to_group)
@@ -142,7 +142,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_group_single_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that reports a single selected workspace on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=['file1'])
 
@@ -152,7 +152,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_group_workspaces_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that reports no workspace selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -163,7 +163,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_not_called()
 
     def test_remove_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a workspace that reports a single selected workspace on calls to get_workspace_selected
         workspace_to_be_removed = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_be_removed])
@@ -174,7 +174,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_remove_multiple_workspaces(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that reports 3 selected workspaces on calls to get_workspace_selected
         workspace1 = 'file1'
         workspace2 = 'file2'
@@ -188,7 +188,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_remove_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that reports no workspace selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -199,13 +199,13 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_not_called()
 
     def test_broadcast_success(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         self.presenter.notify(Command.SelectionChanged)
         self.mainview.get_presenter.assert_called()
         self.main_presenter.broadcast_selection_changed()
 
     def test_call_presenter_with_unknown_command(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider, self.mainview)
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         unknown_command = 10
         self.assertRaises(ValueError,self.presenter.notify, unknown_command)
 

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -200,6 +200,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_broadcast_success(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter.register_master(self.mainview)
         self.presenter.notify(Command.SelectionChanged)
         self.mainview.get_presenter.assert_called()
         self.main_presenter.broadcast_selection_changed()

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -5,6 +5,7 @@ from mock import call
 
 from models.workspacemanager.workspace_provider import WorkspaceProvider
 from presenters.workspace_manager_presenter import WorkspaceManagerPresenter
+from presenters.interfaces.main_presenter import MainPresenterInterface
 from views.workspace_view import WorkspaceView
 from widgets.workspacemanager.command import Command
 from mainview import MainView
@@ -19,7 +20,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider = mock.create_autospec(spec=WorkspaceProvider)
         self.view = mock.create_autospec(spec=WorkspaceView)
         self.mainview = mock.create_autospec(MainView)
-        self.main_presenter= mock.Mock()
+        self.main_presenter= mock.create_autospec(MainPresenterInterface)
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
 
     def test_register_master_success(self):
@@ -210,8 +211,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         self.presenter.register_master(self.mainview)
         self.presenter.notify(Command.SelectionChanged)
-        self.mainview.get_presenter.assert_called()
-        self.main_presenter.broadcast_selection_changed()
+        self.main_presenter.notify_workspace_selection_changed()
 
     def test_call_presenter_with_unknown_command(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)

--- a/views/powder_projection_view.py
+++ b/views/powder_projection_view.py
@@ -1,39 +1,34 @@
-#import abc
+
 
 
 class PowderView(object):
+    def __init__(self):
+        raise Exception("This abstract class should not be instantiated")
 
-    #@abc.abstractmethod
     def populate_powder_u1(self, u1_options):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    #@abc.abstractmethod
     def populate_powder_u2(self, u2_options):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def populate_powder_projection_axis(self, axis_options):
         self.populate_powder_u1(axis_options)
         self.get_powder_u2()
 
-    #@abc.abstractmethod
     def get_output_workspace_name(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    #@abc.abstractmethod
     def populate_powder_projection_units(self, powder_projection_units):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    #@abc.abstractmethod
     def get_powder_u1(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    #@abc.abstractmethod
     def get_powder_u2(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    #@abc.abstractmethod
     def get_powder_units(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
 
 

--- a/views/slice_plotter_view.py
+++ b/views/slice_plotter_view.py
@@ -1,63 +1,68 @@
+
+
 class SlicePlotterView:
+    def __init__(self):
+        raise Exception("This abstract class must not be instantiated")
+
     def get_slice_x_axis(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_x_start(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_x_end(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_x_step(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_y_start(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_y_axis(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_y_end(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_y_step(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_intensity_start(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_intensity_end(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_is_norm_to_one(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_smoothing(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_colourmap(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_x_params(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_y_params(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_intensity_params(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_smoothing_params(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_x_units(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_y_units(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_select_one_workspace(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_plot_parameters(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/views/workspace_view.py
+++ b/views/workspace_view.py
@@ -1,35 +1,38 @@
 
 
 class WorkspaceView(object):
+    def __init__(self):
+        raise Exception("This abstact base class must not be instantiated")
+    
     def display_loaded_workspaces(self, workspaces):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_workspace_to_load_path(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_workspace_to_save_filepath(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_workspace_new_name(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_workspace_selected(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_select_only_one_workspace(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_select_one_workspace(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_select_one_or_more_workspaces(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_presenter(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def confirm_overwrite_workspace(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def no_workspace_has_been_loaded(self):
-        pass
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/widgets/projection/powder/powder.py
+++ b/widgets/projection/powder/powder.py
@@ -12,11 +12,10 @@ class PowderWidget(QWidget,Ui_Form,PowderView):
         super(PowderWidget,self).__init__(*args, **kwargs)
         self.setupUi(self)
         self.btnPowderCalculateProjection.clicked.connect(self._btn_clicked)
+        self._presenter = PowderProjectionPresenter(self, MantidProjectionCalculator())
 
-    def set_workspace_selector(self, workspace_selector):
-        # Currently will raise an error if a workspace_selector does not implement mainView
-        # The code needs to be refactored and proper interface needs to be defined.
-        self._presenter = PowderProjectionPresenter(self, workspace_selector, MantidProjectionCalculator())
+    def get_presenter(self):
+        return self._presenter
 
     def _btn_clicked(self):
         self._presenter.notify(Command.CalculatePowderProjection)

--- a/widgets/slice/slice.py
+++ b/widgets/slice/slice.py
@@ -16,17 +16,10 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
         self.setupUi(self)
         self.btnSliceDisplay.clicked.connect(self._btn_clicked)
         self.display_errors_to_statusbar = True
+        self._presenter = SlicePlotterPresenter(self, MatplotlibSlicePlotter())
 
     def _btn_clicked(self):
         self._presenter.notify(Command.DisplaySlice)
-
-    def set_workspace_selector(self, workspace_selector):
-        # Currently will raise an error if a workspace_selector does not implement mainView
-        # The code needs to be refactored and proper interface needs to be defined.
-        self._presenter = SlicePlotterPresenter(main_view=workspace_selector, slice_view=self,
-                                                slice_plotter=MatplotlibSlicePlotter())
-        # O
-        self._main_window = workspace_selector
 
     def _display_error(self, error_string, timeout_ms):
         # Should be replaced to emit signal containing the error message
@@ -40,3 +33,6 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
 
     def error_select_one_workspace(self):
         self._display_error('Please select a workspace to slice', 2000)
+
+    def get_presenter(self):
+        return self._presenter

--- a/widgets/workspacemanager/command.py
+++ b/widgets/workspacemanager/command.py
@@ -5,3 +5,4 @@ class Command:
     GroupSelectedWorkSpaces =4
     ComposeWorkspace = 5 #On hold for now
     RenameWorkspace = 1000
+    SelectionChanged = -1799

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -30,14 +30,7 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
                                 }
         self._main_window = None
         self.lstWorkspaces.itemChanged.connect(self.list_item_changed)
-
-    def set_client_handler(self, main_window):
-        # The client handler will broadcast changes in selected workspaces as appropriate
-        """Set a main window to display status bar messages to.
-
-         If no main window is set any errors will be displayed to QDialogBoxes"""
-        self._main_window = main_window
-        self._presenter = WorkspaceManagerPresenter(self,MantidWorkspaceProvider(), main_window)
+        self._presenter = WorkspaceManagerPresenter(self, MantidWorkspaceProvider())
 
     def _display_error(self, error_string, timeout_ms):
         if self._main_window:

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -15,7 +15,6 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
     def __init__(self,parent):
         super(WorkspaceManagerWidget,self).__init__(parent)
         self.setupUi(self)
-        self._presenter = WorkspaceManagerPresenter(self,MantidWorkspaceProvider())
         self.btnWorkspaceSave.clicked.connect(self._btn_clicked)
         self.btnLoad.clicked.connect(self._btn_clicked)
         self.btnWorkspaceCompose.clicked.connect(self._btn_clicked)
@@ -30,13 +29,15 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
                                 self.btnRename: Command.RenameWorkspace
                                 }
         self._main_window = None
+        self.lstWorkspaces.itemChanged.connect(self.list_item_changed)
 
-    def set_main_window(self,main_window):
-        # TODO refactor to emit errors as signals
+    def set_client_handler(self, main_window):
+        # The client handler will broadcast changes in selected workspaces as appropriate
         """Set a main window to display status bar messages to.
 
          If no main window is set any errors will be displayed to QDialogBoxes"""
         self._main_window = main_window
+        self._presenter = WorkspaceManagerPresenter(self,MantidWorkspaceProvider(), main_window)
 
     def _display_error(self, error_string, timeout_ms):
         if self._main_window:
@@ -135,3 +136,6 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
 
     def get_presenter(self):
         return self._presenter
+
+    def list_item_changed(self, *args):
+        self._presenter.notify(Command.SelectionChanged)


### PR DESCRIPTION
Implements a system that when the currently selected workspace is changed will notify all subscribed 'listeners'
This allows things like the tabs to update the contents of its combo boxes according to the currently selected worskpace

**To test:**

Load (preferably multiple workspaces) to the work space manager. Any changes to the currently selected worskpaces will be printed to the console. This print call is from a subscribed listener (the slice presenter)

Fixes #19 .
Fixes #33 
