### PR TITLE
Fix MD workspace saving and Add error Handling to Save/Load

### DIFF
--- a/models/workspacemanager/mantid_workspace_provider.py
+++ b/models/workspacemanager/mantid_workspace_provider.py
@@ -1,5 +1,6 @@
 from workspace_provider import WorkspaceProvider
-from mantid.simpleapi import AnalysisDataService,Load,DeleteWorkspace,Load,GroupWorkspaces,RenameWorkspace,SaveNexus
+from mantid.simpleapi import AnalysisDataService,Load,DeleteWorkspace,Load,GroupWorkspaces,RenameWorkspace,SaveNexus, SaveMD
+from mantid.api import IMDWorkspace
 
 class MantidWorkspaceProvider(WorkspaceProvider):
 
@@ -10,7 +11,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         return DeleteWorkspace(ToBeDeleted)
 
     def load(self, Filename, OutputWorkspace):
-        return Load(Filename=Filename,OutputWorkspace=OutputWorkspace)
+        return Load(Filename=Filename, OutputWorkspace=OutputWorkspace)
 
     def group_workspaces(self, InputWorkspaces, OutputWorkspace):
         return GroupWorkspaces(InputWorkspaces,OutputWorkspace)
@@ -19,7 +20,11 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         return RenameWorkspace(selected_workspace,newName)
 
     def save_nexus(self, workspace, path):
-        SaveNexus(workspace,path)
+        workspace_handle = self.get_workspace_handle(workspace)
+        if isinstance(workspace_handle, IMDWorkspace):
+            SaveMD(workspace, path)
+        else:
+            SaveNexus(workspace,path)
 
     def get_workspace_handle(self, workspace_name):
         """"Return handle to workspace given workspace_name_as_string"""

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -79,7 +79,10 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         if not path.endswith('.nxs'):
             path += '.nxs'
-        self._work_spaceprovider.save_nexus(selected_workspace, path)
+        try:
+            self._work_spaceprovider.save_nexus(selected_workspace, path)
+        except:
+            self._workspace_manger_view.error_unable_to_save()
 
     def _remove_selected_workspaces(self):
         selected_workspaces = self._workspace_manger_view.get_workspace_selected()

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -81,7 +81,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             path += '.nxs'
         try:
             self._work_spaceprovider.save_nexus(selected_workspace, path)
-        except:
+        except RuntimeError:
             self._workspace_manger_view.error_unable_to_save()
 
     def _remove_selected_workspaces(self):

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -47,6 +47,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         #TODO specify workspace name on load
         #TODO what to do on fail?
         workspace_to_load = self._workspace_manger_view.get_workspace_to_load_path()
+        if not workspace_to_load:
+            return
         base = os.path.basename(workspace_to_load)
         ws_name = os.path.splitext(base)[0]
         #confirm that user wants to overwrite an existing workspace
@@ -55,7 +57,11 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             if not confirm_overwrite:
                 self._workspace_manger_view.no_workspace_has_been_loaded()
                 return
-        self._work_spaceprovider.load(Filename=workspace_to_load, OutputWorkspace=ws_name)
+        try:
+            self._work_spaceprovider.load(Filename=workspace_to_load, OutputWorkspace=ws_name)
+        except RuntimeError:
+            self._workspace_manger_view.error_unable_to_open_file()
+            return
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
 
     def _save_selected_workspace(self):
@@ -68,6 +74,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         selected_workspace = selected_workspaces[0]
         path = self._workspace_manger_view.get_workspace_to_save_filepath()
+        if not path:
+            self._workspace_manger_view.error_invalid_save_path()
+            return
         if not path.endswith('.nxs'):
             path += '.nxs'
         self._work_spaceprovider.save_nexus(selected_workspace, path)

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -68,6 +68,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         selected_workspace = selected_workspaces[0]
         path = self._workspace_manger_view.get_workspace_to_save_filepath()
+        if not path.endswith('.nxs'):
+            path += '.nxs'
         self._work_spaceprovider.save_nexus(selected_workspace, path)
 
     def _remove_selected_workspaces(self):

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -66,6 +66,32 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
                       call(Filename=path3, OutputWorkspace=ws_name3)]
         self.workspace_provider.load.assert_has_calls(load_calls)
 
+    def test_load_workspace_cancelled(self):
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        # Create a view that will return a path on call to get_workspace_to_load_path
+        # This assumes the view will return an empty string if the operation was cancelled
+        self.view.get_workspace_to_load_path = mock.Mock(return_value='')
+
+        self.presenter.notify(Command.LoadWorkspace)
+        self.view.get_workspace_to_load_path.assert_called_once()
+        self.workspace_provider.load.assert_not_called()
+
+    def test_load_workspace_fail(self):
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        # Create a view that will return a path on call to get_workspace_to_load_path
+        tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
+        path_to_nexus = join(tempdir,'cde.nxs')
+        workspace_name = 'cde'
+        self.view.get_workspace_to_load_path = mock.Mock(return_value=path_to_nexus)
+        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[workspace_name])
+        self.workspace_provider.load = mock.Mock(side_effect=RuntimeError)
+
+        self.presenter.notify(Command.LoadWorkspace)
+        self.view.get_workspace_to_load_path.assert_called_once()
+        self.workspace_provider.load.assert_not_called()
+        self.view.error_unable_to_open_file.assert_called_once()
+
+
     def test_rename_workspace(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
@@ -138,6 +164,22 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.error_select_one_workspace.assert_called_once_with()
         self.view.get_workspace_to_save_filepath.assert_not_called()
+        self.workspace_provider.save_nexus.assert_not_called()
+
+    def test_save_workspace_cancelled(self):
+        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
+        # to save to on calls to get_workspace_to_save_filepath
+        path_to_save_to = "" # view returns empty string to indicate operation cancelled
+        workspace_to_save = 'file1'
+        self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_save])
+        self.view.get_workspace_to_save_filepath = mock.Mock(return_value=path_to_save_to)
+
+        self.presenter.notify(Command.SaveSelectedWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.get_workspace_to_save_filepath.assert_called_once_with()
+        self.view.error_invalid_save_path.assert_called_once()
         self.workspace_provider.save_nexus.assert_not_called()
 
     def test_group_workspaces(self):

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -88,7 +88,6 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
         self.presenter.notify(Command.LoadWorkspace)
         self.view.get_workspace_to_load_path.assert_called_once()
-        self.workspace_provider.load.assert_not_called()
         self.view.error_unable_to_open_file.assert_called_once()
 
 

--- a/views/workspace_view.py
+++ b/views/workspace_view.py
@@ -36,3 +36,9 @@ class WorkspaceView(object):
 
     def no_workspace_has_been_loaded(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def error_unable_to_open_file(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def error_invalid_save_path(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/views/workspace_view.py
+++ b/views/workspace_view.py
@@ -3,7 +3,7 @@
 class WorkspaceView(object):
     def __init__(self):
         raise Exception("This abstact base class must not be instantiated")
-    
+
     def display_loaded_workspaces(self, workspaces):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
@@ -42,3 +42,7 @@ class WorkspaceView(object):
 
     def error_invalid_save_path(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def error_unable_to_save(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -93,7 +93,8 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         return str(QFileDialog.getOpenFileName())
 
     def get_workspace_to_save_filepath(self):
-        path = QFileDialog.getSaveFileName()
+        extension = 'Nexus file (*.nxs)'
+        path = QFileDialog.getSaveFileName(filter=extension)
         if not path:
             raise ValueError('Please Select a valid path to save to ')
         return str(path)

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -90,13 +90,12 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         return selected_workspaces
 
     def get_workspace_to_load_path(self):
-        return str(QFileDialog.getOpenFileName())
+        path = QFileDialog.getOpenFileName( )
+        return str( path )
 
     def get_workspace_to_save_filepath(self):
         extension = 'Nexus file (*.nxs)'
         path = QFileDialog.getSaveFileName(filter=extension)
-        if not path:
-            raise ValueError('Please Select a valid path to save to ')
         return str(path)
 
     def get_workspace_new_name(self):
@@ -112,6 +111,13 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
     def error_select_one_or_more_workspaces(self):
         self._display_error('Please select one or more workspaces the try again', 2000)
 
+
+    def error_select_one_workspace(self):
+        self._display_error('Please select a workspace then try again', 2000)
+
+    def error_unable_to_open_file(self):
+        self._display_error('MSlice was not able to load the selected file')
+
     def confirm_overwrite_workspace(self):
         reply = QMessageBox.question(self,'Confirm Overwrite','The workspace you want to load has the same name as'
                                                               'an existing workspace, Are you sure you want to '
@@ -122,11 +128,11 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         else:
             return False
 
+    def error_invalid_save_path(self):
+        self._display_error('No files were saved')
+        
     def no_workspace_has_been_loaded(self):
         self._display_error('No new workspaces have been loaded', 2000)
-
-    def error_select_one_workspace(self):
-        self._display_error('Please select a workspace then try again', 2000)
 
     def get_presenter(self):
         return self._presenter

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -132,3 +132,6 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
 
     def list_item_changed(self, *args):
         self._presenter.notify(Command.SelectionChanged)
+
+    def error_unable_to_save(self):
+        self._display_error("Something went wrong while trying to save")


### PR DESCRIPTION
Fixes bug where mslice would fail to save any MDworkspace

**To test:**
A)
1.  Load an MD workspace into MSlice.
2. Select the select the MDWorkspace loaded/created in mslice and you should be able to save it with the save button. Verify new file is created
3. Verify that the QDialog that shows  up while saving forces the .nxs extension

B)
Try to load an invalid file  non workspace file, An error message should pop uo

C)
Try to load a file and close the dialogbox without selecting anything. Nothing should happen

D)
Try to save a file and close the dialogbox without selecting anything. An appropriate message should be shown

E)
Try to save to file you do not have permission to write (or in any other way cause the mantid SaveNexus/SaveMD to fail). An appropriate blanket  'save has failed' should appear

Fixes #50 
Fixes #57

