### PR TITLE
Modified projection calculation to support Indirect mode

### DIFF
--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,4 +1,4 @@
-from mantid.simpleapi import ConvertToMD
+from mantid.simpleapi import ConvertToMD, mtd
 from models.projection.powder.projection_calculator import ProjectionCalculator
 
 
@@ -10,7 +10,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
         output_workspace = input_workspace + MD_SUFFIX
         if axis1 == '|Q|' and axis2 == 'Energy':
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
-                        PreprocDetectorsWS='-')
+                        PreprocDetectorsWS='-', dEAnalysisMode=mtd[input_workspace].getEMode().name)
         else:
             raise NotImplementedError('MSlice currently only supports projection to Energy vs |Q|')
 

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,16 +1,21 @@
-from mantid.simpleapi import ConvertToMD, mtd
+from mantid.simpleapi import ConvertToMD
 from models.projection.powder.projection_calculator import ProjectionCalculator
+from models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 
 MD_SUFFIX = '_QE'
 
 
 class MantidProjectionCalculator(ProjectionCalculator):
+    def __init__(self):
+        self._workspace_provider = MantidWorkspaceProvider()
+
     def calculate_projection(self, input_workspace, axis1, axis2):
         output_workspace = input_workspace + MD_SUFFIX
+        emode = self._workspace_provider.get_workspace_handle(input_workspace).getEMode().name
         if axis1 == '|Q|' and axis2 == 'Energy':
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
-                        PreprocDetectorsWS='-', dEAnalysisMode=mtd[input_workspace].getEMode().name)
+                        PreprocDetectorsWS='-', dEAnalysisMode=emode)
         else:
             raise NotImplementedError('MSlice currently only supports projection to Energy vs |Q|')
 


### PR DESCRIPTION
Changed projection calculation to pass `dEAnalysisMode` from input file to `ConvertToMD`. This allows support for indirect geometry data files.

**To test:**

Try to load the following file:

[iris26176_graphite002_red_nxs.zip](https://github.com/mantidproject/mslice/files/456472/iris26176_graphite002_red_nxs.zip)

It should fail without this patch and succeed with it.

<!-- Instructions for testing. -->

Fixes #65 .

