### PR TITLE
Allow axis switching in projections

### DIFF
--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -24,10 +24,10 @@ class MantidProjectionCalculator(ProjectionCalculator):
             dim0 = output_workspace_handle.getDimension(1)
             dim1 = output_workspace_handle.getDimension(0)
             # format into dimension string as expected
-            dim0 = dim0.getName() + ',' + str(dim0.getMinimum()-1) + ',' +\
-                   str(dim0.getMaximum() + 1) + ',' + str(dim0.getNBins())
-            dim1 = dim1.getName() + ',' + str(dim1.getMinimum()-1) + ',' +\
-                   str(dim1.getMaximum() + 1) + ',' + str(dim1.getNBins())
+            dim0 = dim0.getName() + ',' + str(dim0.getMinimum()) + ',' +\
+                   str(dim0.getMaximum()) + ',' + str(dim0.getNBins())
+            dim1 = dim1.getName() + ',' + str(dim1.getMinimum()) + ',' +\
+                   str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
             SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0, AlignedDim1=dim1)
 
         else:

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,16 +1,35 @@
-from mantid.simpleapi import ConvertToMD
+from mantid.simpleapi import ConvertToMD, SliceMD
 from models.projection.powder.projection_calculator import ProjectionCalculator
+from models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 
-MD_SUFFIX = '_QE'
 
 
 class MantidProjectionCalculator(ProjectionCalculator):
+    def __init__(self):
+        self._workspace_provider = MantidWorkspaceProvider()
+
     def calculate_projection(self, input_workspace, axis1, axis2):
-        output_workspace = input_workspace + MD_SUFFIX
         if axis1 == '|Q|' and axis2 == 'Energy':
+            output_workspace = input_workspace + '_QE'
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
                         PreprocDetectorsWS='-')
+
+        elif axis1 == 'Energy' and axis2 == '|Q|':
+            output_workspace = input_workspace + '_EQ'
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
+                        PreprocDetectorsWS='-')
+            output_workspace_handle = self._workspace_provider.get_workspace_handle(output_workspace)
+            # Now swapping dim0 and dim1
+            dim0 = output_workspace_handle.getDimension(1)
+            dim1 = output_workspace_handle.getDimension(0)
+            # format into dimension string as expected
+            dim0 = dim0.getName() + ',' + str(dim0.getMinimum()-1) + ',' +\
+                   str(dim0.getMaximum() + 1) + ',' + str(dim0.getNBins())
+            dim1 = dim1.getName() + ',' + str(dim1.getMinimum()-1) + ',' +\
+                   str(dim1.getMaximum() + 1) + ',' + str(dim1.getNBins())
+            SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0, AlignedDim1=dim1)
+
         else:
-            raise NotImplementedError('MSlice currently only supports projection to Energy vs |Q|')
+            raise NotImplementedError("Not implemented axis1 = %s and axis2 = %s" % (axis1, axis2))
 

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -17,8 +17,8 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
             raise TypeError("projection_calculator is not of type ProjectionCalculator")
 
         #Add rest of options
-        self._powder_view.populate_powder_u1(['|Q|'])
-        self._powder_view.populate_powder_u2(['Energy'])
+        self._available_units = ['|Q|', 'Energy']
+        self._powder_view.populate_powder_projection_axis(self._available_units)
         self._main_presenter = None
 
     def register_master(self, main_presenter):
@@ -28,6 +28,10 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
     def notify(self, command):
         if command == Command.CalculatePowderProjection:
             self._calculate_powder_projection()
+        elif command == Command.U1Changed:
+            self._axis_changed(1)
+        elif command == Command.U2Changed:
+            self._axis_changed(2)
         else:
             raise ValueError("Powder Projection Presenter received an unrecognised command")
 
@@ -48,4 +52,15 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
     def _get_main_presenter(self):
         return self._main_presenter
 
-
+    def _axis_changed(self, axis):
+        """This a private method which stops U1 from being the same as u2 on the gui at any point"""
+        if axis == 1:
+            all_axis = self._available_units[:]
+            if all_axis[0] == self._powder_view.get_powder_u1():
+                all_axis = all_axis[::-1] # reverse list pushing what selected in u1 to the bottom
+            self._powder_view.populate_powder_u2(all_axis)
+        if axis == 2:
+            all_axis = self._available_units[:]
+            if all_axis[0] == self._powder_view.get_powder_u2():
+                all_axis = all_axis[::-1] # reverse list pushing what selected in u1 to the bottom
+            self._powder_view.populate_powder_u1(all_axis)

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -7,7 +7,6 @@ from interfaces.powder_projection_presenter import PowderProjectionPresenterInte
 
 
 class PowderProjectionPresenter(PowderProjectionPresenterInterface):
-
     def __init__(self, powder_view, projection_calculator):
         self._powder_view = powder_view
         self._projection_calculator = projection_calculator

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -18,7 +18,8 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
 
         #Add rest of options
         self._available_units = ['|Q|', 'Energy']
-        self._powder_view.populate_powder_projection_axis(self._available_units)
+        self._powder_view.populate_powder_u1(self._available_units)
+        self._powder_view.populate_powder_u2(self._available_units[::-1])
         self._main_presenter = None
 
     def register_master(self, main_presenter):

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -103,3 +103,34 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.powder_view.get_powder_u2.assert_called_once_with()
 
         self.projection_calculator.calculate_projection.assert_not_called()
+
+    def test_axis_switching_1(self):
+        powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
+        dropbox_contents = self.powder_view.populate_powder_u1.call_args[0][0]
+        call_args = self.powder_view.populate_powder_u1.call_args
+
+        # This changes the selection by making view return second element instead of first
+        self.powder_view.populate_powder_u1.reset_mock()
+        self.powder_view.populate_powder_u2.reset_mock()
+        self.powder_view.get_powder_u1 = mock.Mock(return_value=dropbox_contents[1])
+        self.powder_view.get_powder_u2 = mock.Mock(return_value=dropbox_contents[1])
+        powder_presenter.notify(Command.U1Changed)
+
+        self.powder_view.populate_powder_u1.assert_not_called()
+        self.assertEquals(self.powder_view.populate_powder_u2.call_args, call_args)
+
+    def test_axis_switching_2(self):
+        powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
+        dropbox_contents = self.powder_view.populate_powder_u1.call_args[0][0]
+        call_args=self.powder_view.populate_powder_u1.call_args
+
+        # This changes the selection by making view return second element instead of first
+        self.powder_view.populate_powder_u1.reset_mock()
+        self.powder_view.populate_powder_u2.reset_mock()
+        self.powder_view.get_powder_u1 = mock.Mock(return_value=dropbox_contents[0])
+        self.powder_view.get_powder_u2 = mock.Mock(return_value=dropbox_contents[0])
+        powder_presenter.notify(Command.U2Changed)
+
+
+        self.powder_view.populate_powder_u2.assert_not_called()
+        self.assertEquals(self.powder_view.populate_powder_u1.call_args, mock.call(list(reversed(call_args[0][0]))))

--- a/views/powder_projection_view.py
+++ b/views/powder_projection_view.py
@@ -13,7 +13,7 @@ class PowderView(object):
 
     def populate_powder_projection_axis(self, axis_options):
         self.populate_powder_u1(axis_options)
-        self.get_powder_u2()
+        self.populate_powder_u2(axis_options[::-1])
 
     def get_output_workspace_name(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/views/powder_projection_view.py
+++ b/views/powder_projection_view.py
@@ -11,10 +11,6 @@ class PowderView(object):
     def populate_powder_u2(self, u2_options):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def populate_powder_projection_axis(self, axis_options):
-        self.populate_powder_u1(axis_options)
-        self.populate_powder_u2(axis_options[::-1])
-
     def get_output_workspace_name(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 

--- a/widgets/projection/powder/command.py
+++ b/widgets/projection/powder/command.py
@@ -1,3 +1,4 @@
 class Command:
-
     CalculatePowderProjection = 6
+    U1Changed = 213242
+    U2Changed = 3123

--- a/widgets/projection/powder/powder.py
+++ b/widgets/projection/powder/powder.py
@@ -14,9 +14,17 @@ class PowderWidget(QWidget,Ui_Form,PowderView):
         self.setupUi(self)
         self.btnPowderCalculateProjection.clicked.connect(self._btn_clicked)
         self._presenter = PowderProjectionPresenter(self, MantidProjectionCalculator())
+        self.cmbPowderU1.currentIndexChanged.connect(self._u1_changed)
+        self.cmbPowderU2.currentIndexChanged.connect(self._u2_changed)
 
     def get_presenter(self):
         return self._presenter
+
+    def _u1_changed(self):
+        self._presenter.notify(Command.U1Changed)
+
+    def _u2_changed(self):
+        self._presenter.notify(Command.U2Changed)
 
     def _btn_clicked(self):
         self._presenter.notify(Command.CalculatePowderProjection)
@@ -29,14 +37,21 @@ class PowderWidget(QWidget,Ui_Form,PowderView):
 
 
     def populate_powder_u1(self, u1_options):
+        # Signals are blocked to prevent self._u1_changed being called here (it would be false alarm)
+        self.cmbPowderU1.blockSignals(True)
         self.cmbPowderU1.clear()
         for value in u1_options:
             self.cmbPowderU1.addItem(value)
+        self.cmbPowderU1.blockSignals(False)
+
 
     def populate_powder_u2(self, u2_options):
+        # Signals are blocked to prevent self._u2_changed being called here (it would be false alarm)
+        self.cmbPowderU2.blockSignals(True)
         self.cmbPowderU2.clear()
         for value in u2_options:
             self.cmbPowderU2.addItem(value)
+        self.cmbPowderU2.blockSignals(False)
 
     def populate_powder_projection_units(self, powder_projection_units):
         self.cmbPowderUnits.clear()


### PR DESCRIPTION
Description of work.

**To test:**
Load a file.  Try calculating the projections.
A new workspace with `_QE` suffix will appear
Switch The projection axis in the projection tab and calculate the projection again.
A new workspace with `_EQ` suffix will appear.
Plot Slices for booth and verify they are both correct

Fixes #64