### PR TITLE
Do not clear error messages after a timeout

### DIFF
--- a/mslice.py
+++ b/mslice.py
@@ -20,9 +20,11 @@ class MsliceGui(QMainWindow,Ui_MainWindow,MainView):
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
         self.wgtWorkspacemanager.error_occurred.connect(self.show_error)
+        self.wgtPowder.error_occurred.connect(self._show_error)
 
     def show_error(self, msg):
-        self.statusbar.showMessage(msg, 2000)
+        """Show an error message on status bar. If msg ==""  the function will clear the displayed message """
+        self.statusbar.showMessage(msg)
 
     def get_presenter(self):
         return self._presenter

--- a/mslice.py
+++ b/mslice.py
@@ -20,7 +20,7 @@ class MsliceGui(QMainWindow,Ui_MainWindow,MainView):
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
         self.wgtWorkspacemanager.error_occurred.connect(self.show_error)
-        self.wgtPowder.error_occurred.connect(self._show_error)
+        self.wgtPowder.error_occurred.connect(self.show_error)
 
     def show_error(self, msg):
         """Show an error message on status bar. If msg ==""  the function will clear the displayed message """

--- a/presenters/cut_presenter.py
+++ b/presenters/cut_presenter.py
@@ -24,6 +24,7 @@ class CutPresenter(object):
 
     @require_main_presenter
     def notify(self, command):
+        self._clear_displayed_error()
         if command == Command.Plot:
             self._process_cuts(plot_over=False)
         elif command == Command.PlotOver:
@@ -174,3 +175,6 @@ class CutPresenter(object):
 
         else:
             self._cut_view.disable()
+
+    def _clear_displayed_error(self):
+        self._cut_view.clear_displayed_error()

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -26,6 +26,7 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         self._main_presenter = main_presenter
 
     def notify(self, command):
+        self._clear_displayed_error()
         if command == Command.CalculatePowderProjection:
             self._calculate_powder_projection()
         else:
@@ -48,4 +49,5 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
     def _get_main_presenter(self):
         return self._main_presenter
 
-
+    def _clear_displayed_error(self):
+        self._powder_view.clear_displayed_error()

--- a/presenters/slice_plotter_presenter.py
+++ b/presenters/slice_plotter_presenter.py
@@ -51,6 +51,7 @@ class SlicePlotterPresenter(SlicePlotterPresenterInterface):
         self._main_presenter.subscribe_to_workspace_selection_monitor(self)
 
     def notify(self, command):
+        self._clear_displayed_error()
         if command == Command.DisplaySlice:
             self._display_slice()
         else:
@@ -179,3 +180,6 @@ class SlicePlotterPresenter(SlicePlotterPresenterInterface):
             return
         self._slice_view.populate_slice_x_params(*map(lambda x: "%.5f" % x, (x_min, x_max, x_step)))
         self._slice_view.populate_slice_y_params(*map(lambda x:"%.5f"%x, (y_min, y_max, y_step)))
+
+    def _clear_displayed_error(self):
+        self._slice_view.clear_displayed_error()

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -21,6 +21,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         self._main_presenter.register_workspace_selector(self)
 
     def notify(self, command):
+        self._clear_displayed_error()
         if command == Command.LoadWorkspace:
             self._load_workspace()
         elif command == Command.SaveSelectedWorkspace:
@@ -128,3 +129,5 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         workspace"""
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
 
+    def _clear_displayed_error(self):
+        self._workspace_manger_view.clear_displayed_error()

--- a/tests/cut_presenter_test.py
+++ b/tests/cut_presenter_test.py
@@ -38,6 +38,18 @@ class CutPresenterTest(unittest.TestCase):
                 else:
                     getattr(self.view, attribute).assert_not_called()
 
+    def test_notify_presenter_clears_error(self):
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.plotting_module)
+        cut_presenter.register_master(self.main_presenter)
+        # This unit test will verify that notifying cut presenter will cause the error to be cleared on the view.
+        # The actual subsequent procedure will fail, however this irrelevant to this. Hence the try, except blocks
+        for command in filter(lambda x: x[0] != "_", dir(Command)):
+            try:
+                cut_presenter.notify(command)
+            except:
+                pass
+            self.view.clear_displayed_error.assert_called()
+            self.view.reset_mock()
 
     def test_workspace_selection_changed_single_cuttable_workspace(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.plotting_module)

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -103,3 +103,17 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.powder_view.get_powder_u2.assert_called_once_with()
 
         self.projection_calculator.calculate_projection.assert_not_called()
+
+    def test_notify_presenter_clears_error(self):
+        presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
+        presenter.register_master(self.main_presenter)
+        # This unit test will verify that notifying cut presenter will cause the error to be cleared on the view.
+        # The actual subsequent procedure will fail, however this irrelevant to this. Hence the try, except blocks
+        for command in filter(lambda x: x[0] != "_", dir(Command)):
+            try:
+                presenter.notify(command)
+            except:
+                pass
+            self.powder_view.clear_displayed_error.assert_called()
+            self.powder_view.reset_mock()
+

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -301,3 +301,16 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.populate_slice_y_options.assert_called()
         self.slice_plotter.get_available_axis.assert_called()
         self.slice_plotter.get_axis_range.assert_called()
+
+    def test_notify_presenter_clears_error(self):
+        presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter, self.plotting_module)
+        presenter.register_master(self.main_presenter)
+        # This unit test will verify that notifying cut presenter will cause the error to be cleared on the view.
+        # The actual subsequent procedure will fail, however this irrelevant to this. Hence the try, except blocks
+        for command in filter(lambda x: x[0] != "_", dir(Command)):
+            try:
+                presenter.notify(command)
+            except:
+                pass
+            self.slice_view.clear_displayed_error.assert_called()
+            self.slice_view.reset_mock()

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -260,5 +260,19 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         unknown_command = 10
         self.assertRaises(ValueError,self.presenter.notify, unknown_command)
 
+    def test_notify_presenter_clears_error(self):
+        presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        presenter.register_master(self.main_presenter)
+        # This unit test will verify that notifying cut presenter will cause the error to be cleared on the view.
+        # The actual subsequent procedure will fail, however this irrelevant to this. Hence the try, except blocks
+        for command in filter(lambda x: x[0] != "_", dir(Command)):
+            try:
+                presenter.notify(command)
+            except:
+                pass
+            self.view.clear_displayed_error.assert_called()
+            self.view.reset_mock()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/views/cut_view.py
+++ b/views/cut_view.py
@@ -78,3 +78,6 @@ class CutView:
 
     def clear_input_fields(self):
         pass
+
+    def clear_displayed_error(self):
+        pass

--- a/views/powder_projection_view.py
+++ b/views/powder_projection_view.py
@@ -30,6 +30,10 @@ class PowderView(object):
     def get_powder_units(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def clear_displayed_error(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+
 
 
 

--- a/views/slice_plotter_view.py
+++ b/views/slice_plotter_view.py
@@ -85,5 +85,7 @@ class SlicePlotterView:
     def clear_input_fields(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def clear_displayed_error(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
 

--- a/views/workspace_view.py
+++ b/views/workspace_view.py
@@ -46,3 +46,6 @@ class WorkspaceView(object):
     def error_unable_to_save(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def clear_displayed_error(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+

--- a/widgets/cut/cut.py
+++ b/widgets/cut/cut.py
@@ -167,3 +167,6 @@ class CutWidget(QWidget, CutView, Ui_Form):
 
     def error_invalid_intensity_parameters(self):
         self._display_error("Invalid intensity range")
+
+    def clear_displayed_error(self):
+        self._display_error("")

--- a/widgets/projection/powder/powder.py
+++ b/widgets/projection/powder/powder.py
@@ -1,5 +1,6 @@
 from powder_ui import Ui_Form
 from PyQt4.QtGui import QWidget
+from PyQt4.QtCore import pyqtSignal
 from presenters.powder_projection_presenter import PowderProjectionPresenter
 
 from models.projection.powder.mantid_projection_calculator import MantidProjectionCalculator
@@ -9,6 +10,9 @@ from command import Command
 
 class PowderWidget(QWidget,Ui_Form,PowderView):
     """This widget is not usable without a main window which implements mainview"""
+
+    error_occurred = pyqtSignal('QString')
+
     def __init__(self,*args, **kwargs):
         super(PowderWidget,self).__init__(*args, **kwargs)
         self.setupUi(self)
@@ -26,7 +30,6 @@ class PowderWidget(QWidget,Ui_Form,PowderView):
 
     def get_powder_u2(self):
         return str(self.cmbPowderU2.currentText())
-
 
     def populate_powder_u1(self, u1_options):
         self.cmbPowderU1.clear()
@@ -46,3 +49,8 @@ class PowderWidget(QWidget,Ui_Form,PowderView):
     def get_powder_units(self):
         return str(self.cmbPowderUnits.currentText())
 
+    def clear_displayed_error(self):
+        self._display_error("")
+
+    def _display_error(self, error_string):
+        self.error_occurred.emit(error_string)

--- a/widgets/slice/slice.py
+++ b/widgets/slice/slice.py
@@ -133,3 +133,7 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
         self.lneSliceIntensityEnd.setText("")
         self.lneSliceSmoothing.setText("")
         self.rdoSliceNormToOne.setChecked(0)
+
+
+    def clear_displayed_error(self):
+        self._display_error("")

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -135,3 +135,6 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
 
     def error_unable_to_save(self):
         self._display_error("Something went wrong while trying to save")
+
+    def clear_displayed_error(self):
+        self._display_error("")


### PR DESCRIPTION
Errors will stay in the statusbar until a button is clicked

**To test:**

1. Launch the mslice GUI.
2. Click on remove workspace without any workspace selected. An error will appear
3. Clicking on any other button will cause the error to disappear. 

Fixes #75
