### PR TITLE
Remove misleading references of energy from mslice.

### DIFF
--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -2,23 +2,26 @@ from mantid.simpleapi import ConvertToMD, SliceMD
 from models.projection.powder.projection_calculator import ProjectionCalculator
 from models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
-
-
+# unit labels
+MOD_Q_LABEL = '|Q|'
+DELTA_E_LABEL = 'DeltaE'
 
 class MantidProjectionCalculator(ProjectionCalculator):
     def __init__(self):
         self._workspace_provider = MantidWorkspaceProvider()
 
+    def available_units(self):
+        return [MOD_Q_LABEL, DELTA_E_LABEL]
+
     def calculate_projection(self, input_workspace, axis1, axis2):
         emode = self._workspace_provider.get_workspace_handle(input_workspace).getEMode().name
-        if axis1 == '|Q|' and axis2 == 'DeltaE':
+        if axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL:
             output_workspace = input_workspace + '_QE'
-            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)
-
-        elif axis1 == 'DeltaE' and axis2 == '|Q|':
+        elif axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
             output_workspace = input_workspace + '_EQ'
-            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)
             output_workspace_handle = self._workspace_provider.get_workspace_handle(output_workspace)
             # Now swapping dim0 and dim1
@@ -31,7 +34,6 @@ class MantidProjectionCalculator(ProjectionCalculator):
                    str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
             SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
                     AlignedDim1=dim1)
-
         else:
             raise NotImplementedError("Not implemented axis1 = %s and axis2 = %s" % (axis1, axis2))
 

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -11,12 +11,12 @@ class MantidProjectionCalculator(ProjectionCalculator):
 
     def calculate_projection(self, input_workspace, axis1, axis2):
         emode = self._workspace_provider.get_workspace_handle(input_workspace).getEMode().name
-        if axis1 == '|Q|' and axis2 == 'Energy':
+        if axis1 == '|Q|' and axis2 == 'DeltaE':
             output_workspace = input_workspace + '_QE'
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)
 
-        elif axis1 == 'Energy' and axis2 == '|Q|':
+        elif axis1 == 'DeltaE' and axis2 == '|Q|':
             output_workspace = input_workspace + '_EQ'
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions='|Q|',
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)

--- a/models/projection/powder/projection_calculator.py
+++ b/models/projection/powder/projection_calculator.py
@@ -2,6 +2,10 @@ import abc
 
 class ProjectionCalculator(object):
     @abc.abstractmethod
+    def available_units(self):
+        pass
+
+    @abc.abstractmethod
     def calculate_projection(self, input_workspace, axis1, axis2):
         pass
 

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -16,7 +16,7 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
             raise TypeError("projection_calculator is not of type ProjectionCalculator")
 
         #Add rest of options
-        self._available_units = ['|Q|', 'DeltaE']
+        self._available_units = projection_calculator.available_units()
         self._powder_view.populate_powder_u1(self._available_units)
         self._powder_view.populate_powder_u2(self._available_units[::-1])
         self._main_presenter = None

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -16,7 +16,7 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
             raise TypeError("projection_calculator is not of type ProjectionCalculator")
 
         #Add rest of options
-        self._available_units = ['|Q|', 'Energy']
+        self._available_units = ['|Q|', 'DeltaE']
         self._powder_view.populate_powder_u1(self._available_units)
         self._powder_view.populate_powder_u2(self._available_units[::-1])
         self._main_presenter = None

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -46,8 +46,8 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
         self.powder_presenter.register_master(self.main_presenter)
-        # Setup view to report Energy and |Q| as selected axis to project two
-        u1 = 'Energy'
+        # Setup view to report DeltaE and |Q| as selected axis to project two
+        u1 = 'DeltaE'
         u2 = '|Q|'
         self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
         self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)
@@ -73,9 +73,9 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Setting up main presenter to report that the current selected workspace is selected_workspace
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[selected_workspace])
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
-        # Setup view to report Energy and |Q| as selected axis to project two
-        u1 = 'Energy'
-        u2 = 'Energy'
+        # Setup view to report DeltaE and |Q| as selected axis to project two
+        u1 = 'DeltaE'
+        u2 = 'DeltaE'
         self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
         self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)
         self.powder_presenter.register_master(self.main_presenter)
@@ -92,8 +92,8 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=selected_workspaces)
         self.powder_presenter = PowderProjectionPresenter(self.powder_view, self.projection_calculator)
         self.powder_presenter.register_master(self.main_presenter)
-        # Setup view to report Energy and |Q| as selected axis to project two
-        u1 = 'Energy'
+        # Setup view to report DeltaE and |Q| as selected axis to project two
+        u1 = 'DeltaE'
         u2 = '|Q|'
         self.powder_view.get_powder_u1 = mock.Mock(return_value=u1)
         self.powder_view.get_powder_u2 = mock.Mock(return_value=u2)

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -15,6 +15,7 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Set up a mock view, presenter, main view and main presenter
         self.powder_view = mock.create_autospec(PowderView)
         self.projection_calculator = mock.create_autospec(ProjectionCalculator)
+        self.projection_calculator.configure_mock(**{'available_units.return_value': ['|Q|', 'DeltaE']})
         self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.mainview = mock.create_autospec(MainView)
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)

--- a/widgets/projection/powder/powder.ui
+++ b/widgets/projection/powder/powder.ui
@@ -33,33 +33,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QComboBox" name="cmbPowderU1">
-          <item>
-           <property name="text">
-            <string>Energy</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>|Q|</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2Theta</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Det Group Number</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Time Channel</string>
-           </property>
-          </item>
-         </widget>
+         <widget class="QComboBox" name="cmbPowderU1"/>
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_210">
@@ -69,33 +43,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QComboBox" name="cmbPowderU2">
-          <item>
-           <property name="text">
-            <string>Energy</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>|Q|</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2Theta</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Det Group Number</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Time Channel</string>
-           </property>
-          </item>
-         </widget>
+         <widget class="QComboBox" name="cmbPowderU2"/>
         </item>
         <item row="1" column="2">
          <widget class="QLabel" name="label">


### PR DESCRIPTION
In the projections tab the term energy was used an input even though output workspace was in DeltaE vs |Q|. Although the resulting plots did have correct legends this may become a source of confusion in MSlice if more units are added.

**To test:**
1. Open Mslice. 
2. Verify that the projections tab dropdown menu has a `|Q|` entry and a `DeltaE` entry and that is does not have an `Energy` entry.

Fixes #82