### PR TITLE
Fix group workspaces

### DIFF
--- a/models/workspacemanager/mantid_workspace_provider.py
+++ b/models/workspacemanager/mantid_workspace_provider.py
@@ -16,7 +16,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         return Load(Filename=Filename, OutputWorkspace=OutputWorkspace)
 
     def group_workspaces(self, InputWorkspaces, OutputWorkspace):
-        return GroupWorkspaces(InputWorkspaces,OutputWorkspace)
+        return GroupWorkspaces(InputWorkspaces, OutputWorkspace=OutputWorkspace)
 
     def rename_workspace(self, selected_workspace, newName):
         return RenameWorkspace(selected_workspace,newName)

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -91,7 +91,11 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manger_view.error_select_one_or_more_workspaces()
             return
         for workspace in selected_workspaces:
-            self._work_spaceprovider.delete_workspace(workspace)
+            # If the user attempts to delete a group and the child workspaces in one go if all the child workspaces
+            # Are deleted before the group then mantid will automatically remove the empty group. This will throw an
+            # exception when deleting the group. Hence the check
+            if workspace in self._work_spaceprovider.get_workspace_names():
+                self._work_spaceprovider.delete_workspace(workspace)
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
 
     def _group_selected_workspaces(self):
@@ -101,7 +105,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         group_name = 'group' + str(self._groupCount)
         self._groupCount += 1
-        self._work_spaceprovider.group_workspaces(InputWorkspaces=selected_workspaces, OutputWorkspace=group_name)
+        self._work_spaceprovider.group_workspaces(input_workspaces=selected_workspaces,
+                                                  output_workspace_name=group_name)
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
 
     def _rename_workspace(self):

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -105,8 +105,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         group_name = 'group' + str(self._groupCount)
         self._groupCount += 1
-        self._work_spaceprovider.group_workspaces(input_workspaces=selected_workspaces,
-                                                  output_workspace_name=group_name)
+        self._work_spaceprovider.group_workspaces(selected_workspaces, group_name)
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
 
     def _rename_workspace(self):

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -218,6 +218,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         # Create a workspace that reports a single selected workspace on calls to get_workspace_selected
         workspace_to_be_removed = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_be_removed])
+        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[workspace_to_be_removed])
 
         self.presenter.notify(Command.RemoveSelectedWorkspaces)
         self.view.get_workspace_selected.assert_called_once_with()
@@ -231,6 +232,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         workspace2 = 'file2'
         workspace3 = 'file3'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace1, workspace2, workspace3])
+        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[workspace1, workspace2, workspace3])
 
         self.presenter.notify(Command.RemoveSelectedWorkspaces)
         self.view.get_workspace_selected.assert_called_once_with()


### PR DESCRIPTION
The Group workspaces was not working. This pull requests fixes it

**To test:**
1.Load multiple workspaces into mslice
2. Select them all via using `ctrl` + `click`
3. Click on the `Group Selected` button in the **Workspace Manager**
4. Verify that a new group has appeared.

Fixes #85 