### PR TITLE
Implement wavenumber conversion

### DIFF
--- a/cli/_mslice_commmands.py
+++ b/cli/_mslice_commmands.py
@@ -61,7 +61,7 @@ def _string_to_axis(string):
 
 
 
-def get_projection(input_workspace, axis1, axis2):
+def get_projection(input_workspace, axis1, axis2, units='meV'):
     """ Calculate projections of workspace.
 
     Keyword Arguments:
@@ -69,12 +69,13 @@ def get_projection(input_workspace, axis1, axis2):
         workspace name.
         axis1 -- The first axis of projection (string)
         axis2 -- The second axis of the projection (string)
+        units -- The energy units (string) [default: 'meV']
 
     """
     if isinstance(input_workspace, _Workspace):
         input_workspace = input_workspace.getName()
     output_workspace = _POWDER_PROJECTION_MODEL.calculate_projection(input_workspace=input_workspace, axis1=axis1,
-                                                                     axis2=axis2)
+                                                                     axis2=axis2, units=units)
     try:
         names = _lhs_info('names')
     except:

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -21,15 +21,14 @@ class MantidProjectionCalculator(ProjectionCalculator):
     def calculate_projection(self, input_workspace, axis1, axis2, units):
         """Calculate the projection workspace AND return a python handle to it"""
         emode = self._workspace_provider.get_workspace_handle(input_workspace).getEMode().name
-        if emode == 'Elastic': emode = 'Direct'
         if axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL:
             scale = [1, 8.06554]
-            output_workspace = input_workspace + '_QE'
+            output_workspace = input_workspace + '_QE' + ('_cm' if units == WAVENUMBER_LABEL else '')
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)
         elif axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
             scale = [8.06554, 1]
-            output_workspace = input_workspace + '_EQ'
+            output_workspace = input_workspace + '_EQ' + ('_cm' if units == WAVENUMBER_LABEL else '')
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)
             output_workspace_handle = self._workspace_provider.get_workspace_handle(output_workspace)

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,26 +1,34 @@
-from mantid.simpleapi import ConvertToMD, SliceMD
+from mantid.simpleapi import ConvertToMD, SliceMD, TransformMD
 from models.projection.powder.projection_calculator import ProjectionCalculator
 from models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 # unit labels
 MOD_Q_LABEL = '|Q|'
 DELTA_E_LABEL = 'DeltaE'
+MEV_LABEL = 'meV'
+WAVENUMBER_LABEL = 'cm-1'
 
 class MantidProjectionCalculator(ProjectionCalculator):
     def __init__(self):
         self._workspace_provider = MantidWorkspaceProvider()
 
-    def available_units(self):
+    def available_axes(self):
         return [MOD_Q_LABEL, DELTA_E_LABEL]
 
-    def calculate_projection(self, input_workspace, axis1, axis2):
+    def available_units(self):
+        return [WAVENUMBER_LABEL, MEV_LABEL]
+
+    def calculate_projection(self, input_workspace, axis1, axis2, units):
         """Calculate the projection workspace AND return a python handle to it"""
         emode = self._workspace_provider.get_workspace_handle(input_workspace).getEMode().name
+        if emode == 'Elastic': emode = 'Direct'
         if axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL:
+            scale = [1, 8.06554]
             output_workspace = input_workspace + '_QE'
-            return ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
-                               PreprocDetectorsWS='-', dEAnalysisMode=emode)
+            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
+                        PreprocDetectorsWS='-', dEAnalysisMode=emode)
         elif axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
+            scale = [8.06554, 1]
             output_workspace = input_workspace + '_EQ'
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)
@@ -33,7 +41,13 @@ class MantidProjectionCalculator(ProjectionCalculator):
                 str(dim0.getMaximum()) + ',' + str(dim0.getNBins())
             dim1 = dim1.getName() + ',' + str(dim1.getMinimum()) + ',' +\
                 str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
-            return SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
-                           AlignedDim1=dim1)
+            SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
+                    AlignedDim1=dim1)
         else:
             raise NotImplementedError("Not implemented axis1 = %s and axis2 = %s" % (axis1, axis2))
+        # Now scale the energy axis if required - ConvertToMD always gives DeltaE in meV
+        if units == WAVENUMBER_LABEL:
+            TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
+            self._workspace_provider.get_workspace_handle(output_workspace).setComment('MSlice_in_wavenumber')
+        elif units != MEV_LABEL:
+            raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -24,8 +24,8 @@ class MantidProjectionCalculator(ProjectionCalculator):
         if axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL:
             scale = [1, 8.06554]
             output_workspace = input_workspace + '_QE' + ('_cm' if units == WAVENUMBER_LABEL else '')
-            ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
-                        PreprocDetectorsWS='-', dEAnalysisMode=emode)
+            retval = ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
+                                 PreprocDetectorsWS='-', dEAnalysisMode=emode)
         elif axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
             scale = [8.06554, 1]
             output_workspace = input_workspace + '_EQ' + ('_cm' if units == WAVENUMBER_LABEL else '')
@@ -40,13 +40,14 @@ class MantidProjectionCalculator(ProjectionCalculator):
                 str(dim0.getMaximum()) + ',' + str(dim0.getNBins())
             dim1 = dim1.getName() + ',' + str(dim1.getMinimum()) + ',' +\
                 str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
-            SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
-                    AlignedDim1=dim1)
+            retval = SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
+                             AlignedDim1=dim1)
         else:
             raise NotImplementedError("Not implemented axis1 = %s and axis2 = %s" % (axis1, axis2))
         # Now scale the energy axis if required - ConvertToMD always gives DeltaE in meV
         if units == WAVENUMBER_LABEL:
-            TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
+            retval = TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
             self._workspace_provider.get_workspace_handle(output_workspace).setComment('MSlice_in_wavenumber')
         elif units != MEV_LABEL:
             raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))
+        return retval

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -47,7 +47,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
         # Now scale the energy axis if required - ConvertToMD always gives DeltaE in meV
         if units == WAVENUMBER_LABEL:
             retval = TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
-            self._workspace_provider.get_workspace_handle(output_workspace).setComment('MSlice_in_wavenumber')
+            retval.setComment('MSlice_in_wavenumber')
         elif units != MEV_LABEL:
             raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))
         return retval

--- a/models/projection/powder/projection_calculator.py
+++ b/models/projection/powder/projection_calculator.py
@@ -2,9 +2,13 @@ import abc
 
 class ProjectionCalculator(object):
     @abc.abstractmethod
+    def available_axes(self):
+        pass
+
+    @abc.abstractmethod
     def available_units(self):
         pass
 
     @abc.abstractmethod
-    def calculate_projection(self, input_workspace, axis1, axis2):
+    def calculate_projection(self, input_workspace, axis1, axis2, units):
         pass

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -16,9 +16,11 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
             raise TypeError("projection_calculator is not of type ProjectionCalculator")
 
         #Add rest of options
+        self._available_axes = projection_calculator.available_axes()
         self._available_units = projection_calculator.available_units()
-        self._powder_view.populate_powder_u1(self._available_units)
-        self._powder_view.populate_powder_u2(self._available_units[::-1])
+        self._powder_view.populate_powder_u1(self._available_axes)
+        self._powder_view.populate_powder_u2(self._available_axes[::-1])
+        self._powder_view.populate_powder_projection_units(self._available_units[::-1])
         self._main_presenter = None
 
     def register_master(self, main_presenter):
@@ -43,10 +45,11 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         if axis1 == axis2:
             raise NotImplementedError('equal axis')
         if not selected_workspaces:
-            raise NotImplementedError('Implement error message')
+            raise NotImplementedError('no workspaces selected')
+        units = self._powder_view.get_powder_units()
 
         for workspace in selected_workspaces:
-            self._projection_calculator.calculate_projection(workspace, axis1, axis2)
+            self._projection_calculator.calculate_projection(workspace, axis1, axis2, units)
         self._get_main_presenter().update_displayed_workspaces()
 
     @require_main_presenter
@@ -59,12 +62,12 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
     def _axis_changed(self, axis):
         """This a private method which stops U1 from being the same as u2 on the gui at any point"""
         if axis == 1:
-            all_axis = self._available_units[:]
+            all_axis = self._available_axes[:]
             if all_axis[0] == self._powder_view.get_powder_u1():
                 all_axis = all_axis[::-1] # reverse list pushing what selected in u1 to the bottom
             self._powder_view.populate_powder_u2(all_axis)
         if axis == 2:
-            all_axis = self._available_units[:]
+            all_axis = self._available_axes[:]
             if all_axis[0] == self._powder_view.get_powder_u2():
                 all_axis = all_axis[::-1] # reverse list pushing what selected in u1 to the bottom
             self._powder_view.populate_powder_u1(all_axis)

--- a/tests/powder_projection_presenter_test.py
+++ b/tests/powder_projection_presenter_test.py
@@ -14,7 +14,8 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         # Set up a mock view, presenter, main view and main presenter
         self.powder_view = mock.create_autospec(PowderView)
         self.projection_calculator = mock.create_autospec(ProjectionCalculator)
-        self.projection_calculator.configure_mock(**{'available_units.return_value': ['|Q|', 'DeltaE']})
+        self.projection_calculator.configure_mock(**{'available_axes.return_value': ['|Q|', 'DeltaE']})
+        self.projection_calculator.configure_mock(**{'available_units.return_value': ['meV', 'cm-1']})
         self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.mainview = mock.create_autospec(MainView)
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)


### PR DESCRIPTION
Added wavenumbers `cm-1` as a possible energy unit. 

**To test:**

Load a dataset and select `cm-1` from the `units` combo box, and calculate projection. Check that the resulting MD workspace has energy which is scaled by 8.066 compared to the MD workspace created with `units=meV`. The new workspaces should have a `_cm` suffix.

Fixes #63.

