### PR TITLE
Theta axis implementation

### DIFF
--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,9 +1,6 @@
-<<<<<<< HEAD
 import tempfile
-from mantid.simpleapi import ConvertToMD, SliceMD, ConvertSpectrumAxis, PreprocessDetectorsToMD, DeleteWorkspace
-=======
-from mantid.simpleapi import ConvertToMD, SliceMD, TransformMD
->>>>>>> master
+from mantid.simpleapi import ConvertToMD, SliceMD, TransformMD, ConvertSpectrumAxis, PreprocessDetectorsToMD
+from mantid.simpleapi import RenameWorkspace, DeleteWorkspace
 from models.projection.powder.projection_calculator import ProjectionCalculator
 from models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
@@ -18,11 +15,11 @@ class MantidProjectionCalculator(ProjectionCalculator):
     def __init__(self):
         self._workspace_provider = MantidWorkspaceProvider()
 
-    def available_units(self):
+    def available_axes(self):
         return [MOD_Q_LABEL, THETA_LABEL, DELTA_E_LABEL]
 
     def available_units(self):
-        return [WAVENUMBER_LABEL, MEV_LABEL]
+        return [MEV_LABEL, WAVENUMBER_LABEL]
 
     def _flip_axes(self, output_workspace):
         """ Transposes the x- and y-axes """
@@ -44,16 +41,16 @@ class MantidProjectionCalculator(ProjectionCalculator):
         PreprocessDetectorsToMD(InputWorkspace=input_workspace, OutputWorkspace=wsdet)
         return wsdet
 
-    def _calcQEproj(self, input_workspace, axis1, axis2):
+    def _calcQEproj(self, input_workspace, emode, axis1, axis2):
         """ Carries out either the Q-E or E-Q projections """
         output_workspace = input_workspace + ('_QE' if axis1 == MOD_Q_LABEL else '_EQ')
         retval = ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                              PreprocDetectorsWS='-', dEAnalysisMode=emode)
         if axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
             retval = self._flip_axes(output_workspace)
-        return retval
+        return retval, output_workspace
 
-    def _calcThetaEProj(self, input_workspace, axis1, axis2):
+    def _calcThetaEproj(self, input_workspace, emode, axis1, axis2):
         """ Carries out either the 2Theta-E or E-2Theta projections """
         output_workspace = input_workspace + ('_ThE' if axis1 == THETA_LABEL else '_ETh')
         ConvertSpectrumAxis(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, Target='Theta')
@@ -65,22 +62,23 @@ class MantidProjectionCalculator(ProjectionCalculator):
             DeleteWorkspace(wsdet)
         if axis1 == THETA_LABEL and axis2 == DELTA_E_LABEL:
             retval = self._flip_axes(output_workspace)
-        return retval
+        return retval, output_workspace
 
     def calculate_projection(self, input_workspace, axis1, axis2, units):
         """Calculate the projection workspace AND return a python handle to it"""
         emode = self._workspace_provider.get_workspace_handle(input_workspace).getEMode().name
         # Calculates the projection - can have Q-E or 2theta-E or their transpose. 
         if (axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL) or (axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL):
-            retval = _calcQEproj(input_workspace, axis1, axis2)
+            retval, output_workspace = self._calcQEproj(input_workspace, emode, axis1, axis2)
         elif (axis1 == THETA_LABEL and axis2 == DELTA_E_LABEL) or (axis1 == DELTA_E_LABEL and axis2 == THETA_LABEL):
-            retval = _calcThetaEproj(input_workspace, axis1, axis2)
+            retval, output_workspace = self._calcThetaEproj(input_workspace, emode, axis1, axis2)
         else:
             raise NotImplementedError("Not implemented axis1 = %s and axis2 = %s" % (axis1, axis2))
         # Now scale the energy axis if required - ConvertToMD always gives DeltaE in meV
-        scale = [1, 8.06554] if axis2 == DELTA_E_LABEL else [8.06544, 1]
         if units == WAVENUMBER_LABEL:
+            scale = [1, 8.06554] if axis2 == DELTA_E_LABEL else [8.06544, 1]
             retval = TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
+            retval = RenameWorkspace(InputWorkspace=output_workspace, OutputWorkspace=output_workspace+'_cm')
             retval.setComment('MSlice_in_wavenumber')
         elif units != MEV_LABEL:
             raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,9 +1,10 @@
-from mantid.simpleapi import ConvertToMD, SliceMD
+from mantid.simpleapi import ConvertToMD, SliceMD, ConvertSpectrumAxis
 from models.projection.powder.projection_calculator import ProjectionCalculator
 from models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 # unit labels
 MOD_Q_LABEL = '|Q|'
+THETA_LABEL = '2Theta'
 DELTA_E_LABEL = 'DeltaE'
 
 class MantidProjectionCalculator(ProjectionCalculator):
@@ -11,7 +12,20 @@ class MantidProjectionCalculator(ProjectionCalculator):
         self._workspace_provider = MantidWorkspaceProvider()
 
     def available_units(self):
-        return [MOD_Q_LABEL, DELTA_E_LABEL]
+        return [MOD_Q_LABEL, THETA_LABEL, DELTA_E_LABEL]
+
+    def _flip_axes(self, output_workspace):
+        output_workspace_handle = self._workspace_provider.get_workspace_handle(output_workspace)
+        # Now swapping dim0 and dim1
+        dim0 = output_workspace_handle.getDimension(1)
+        dim1 = output_workspace_handle.getDimension(0)
+        # format into dimension string as expected
+        dim0 = dim0.getName() + ',' + str(dim0.getMinimum()) + ',' +\
+            str(dim0.getMaximum()) + ',' + str(dim0.getNBins())
+        dim1 = dim1.getName() + ',' + str(dim1.getMinimum()) + ',' +\
+            str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
+        return SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
+                       AlignedDim1=dim1)
 
     def calculate_projection(self, input_workspace, axis1, axis2):
         """Calculate the projection workspace AND return a python handle to it"""
@@ -24,16 +38,17 @@ class MantidProjectionCalculator(ProjectionCalculator):
             output_workspace = input_workspace + '_EQ'
             ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                         PreprocDetectorsWS='-', dEAnalysisMode=emode)
-            output_workspace_handle = self._workspace_provider.get_workspace_handle(output_workspace)
-            # Now swapping dim0 and dim1
-            dim0 = output_workspace_handle.getDimension(1)
-            dim1 = output_workspace_handle.getDimension(0)
-            # format into dimension string as expected
-            dim0 = dim0.getName() + ',' + str(dim0.getMinimum()) + ',' +\
-                str(dim0.getMaximum()) + ',' + str(dim0.getNBins())
-            dim1 = dim1.getName() + ',' + str(dim1.getMinimum()) + ',' +\
-                str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
-            return SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
-                           AlignedDim1=dim1)
+            return self._flip_axes(output_workspace)
+        elif axis1 == THETA_LABEL and axis2 == DELTA_E_LABEL:
+            output_workspace = input_workspace + '_ThE'
+            ConvertSpectrumAxis(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, Target='Theta')
+            ConvertToMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, QDimensions='CopyToMD',
+                        PreprocDetectorsWS='-', dEAnalysisMode=emode)
+            return self._flip_axes(output_workspace)
+        elif axis1 == DELTA_E_LABEL and axis2 == THETA_LABEL:
+            output_workspace = input_workspace + '_ETh'
+            ConvertSpectrumAxis(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, Target='Theta')
+            return ConvertToMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, QDimensions='CopyToMD',
+                               PreprocDetectorsWS='-', dEAnalysisMode=emode)
         else:
             raise NotImplementedError("Not implemented axis1 = %s and axis2 = %s" % (axis1, axis2))

--- a/models/projection/powder/mantid_projection_calculator.py
+++ b/models/projection/powder/mantid_projection_calculator.py
@@ -1,4 +1,4 @@
-import tempfile
+import uuid
 from mantid.simpleapi import ConvertToMD, SliceMD, TransformMD, ConvertSpectrumAxis, PreprocessDetectorsToMD
 from mantid.simpleapi import RenameWorkspace, DeleteWorkspace
 from models.projection.powder.projection_calculator import ProjectionCalculator
@@ -37,7 +37,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
 
     def _getDetWS(self, input_workspace):
         """ Precalculates the detector workspace for ConvertToMD - workaround for bug for indirect geometry """
-        wsdet = next(tempfile._get_candidate_names())
+        wsdet = str(uuid.uuid4().hex)
         PreprocessDetectorsToMD(InputWorkspace=input_workspace, OutputWorkspace=wsdet)
         return wsdet
 
@@ -67,7 +67,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
     def calculate_projection(self, input_workspace, axis1, axis2, units):
         """Calculate the projection workspace AND return a python handle to it"""
         emode = self._workspace_provider.get_workspace_handle(input_workspace).getEMode().name
-        # Calculates the projection - can have Q-E or 2theta-E or their transpose. 
+        # Calculates the projection - can have Q-E or 2theta-E or their transpose.
         if (axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL) or (axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL):
             retval, output_workspace = self._calcQEproj(input_workspace, emode, axis1, axis2)
         elif (axis1 == THETA_LABEL and axis2 == DELTA_E_LABEL) or (axis1 == DELTA_E_LABEL and axis2 == THETA_LABEL):

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -21,6 +21,7 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         self._powder_view.populate_powder_u1(self._available_axes)
         self._powder_view.populate_powder_u2(self._available_axes)
         self._powder_view.set_powder_u2(self._available_axes[-1])
+        self._powder_view.populate_powder_projection_units(self._available_units)
         self._main_presenter = None
 
     def register_master(self, main_presenter):

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -71,5 +71,3 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         # Assuming DeltaE is always the last axes option.
         if axes[curr_axis] != self._available_units[-1] and axes[other_axis] != self._available_units[-1]:
             axes_set[other_axis](self._available_units[-1])
-
-        

--- a/presenters/powder_projection_presenter.py
+++ b/presenters/powder_projection_presenter.py
@@ -18,7 +18,8 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         #Add rest of options
         self._available_units = projection_calculator.available_units()
         self._powder_view.populate_powder_u1(self._available_units)
-        self._powder_view.populate_powder_u2(self._available_units[::-1])
+        self._powder_view.populate_powder_u2(self._available_units)
+        self._powder_view.set_powder_u2(self._available_units[-1])
         self._main_presenter = None
 
     def register_master(self, main_presenter):
@@ -57,14 +58,18 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         self._powder_view.clear_displayed_error()
 
     def _axis_changed(self, axis):
-        """This a private method which stops U1 from being the same as u2 on the gui at any point"""
-        if axis == 1:
-            all_axis = self._available_units[:]
-            if all_axis[0] == self._powder_view.get_powder_u1():
-                all_axis = all_axis[::-1] # reverse list pushing what selected in u1 to the bottom
-            self._powder_view.populate_powder_u2(all_axis)
-        if axis == 2:
-            all_axis = self._available_units[:]
-            if all_axis[0] == self._powder_view.get_powder_u2():
-                all_axis = all_axis[::-1] # reverse list pushing what selected in u1 to the bottom
-            self._powder_view.populate_powder_u1(all_axis)
+        """This is a private method which makes sure u1 and u2 are always different and one is always DeltaE"""
+        curr_axis = axis - 1
+        other_axis = axis % 2
+        num_items = len(self._available_units)
+        axes = [self._powder_view.get_powder_u1(), self._powder_view.get_powder_u2()]
+        axes_set = [self._powder_view.set_powder_u1, self._powder_view.set_powder_u2]
+        name_to_index = dict((val,id) for id, val in enumerate(self._available_units))
+        if axes[curr_axis] == axes[other_axis]:
+            new_index = (name_to_index[axes[other_axis]] + 1) % num_items
+            axes_set[other_axis](self._available_units[new_index])
+        # Assuming DeltaE is always the last axes option.
+        if axes[curr_axis] != self._available_units[-1] and axes[other_axis] != self._available_units[-1]:
+            axes_set[other_axis](self._available_units[-1])
+
+        

--- a/views/powder_projection_view.py
+++ b/views/powder_projection_view.py
@@ -26,5 +26,14 @@ class PowderView(object):
     def get_powder_units(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def name_to_index(self, name):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def set_powder_u1(self, name):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def set_powder_u2(self, name):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
     def clear_displayed_error(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/views/powder_projection_view.py
+++ b/views/powder_projection_view.py
@@ -26,9 +26,6 @@ class PowderView(object):
     def get_powder_units(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def name_to_index(self, name):
-        raise NotImplementedError("This method must be implemented in a concrete view before being called")
-
     def set_powder_u1(self, name):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 

--- a/widgets/projection/powder/powder.py
+++ b/widgets/projection/powder/powder.py
@@ -39,14 +39,28 @@ class PowderWidget(QWidget,Ui_Form,PowderView):
     def get_powder_u2(self):
         return str(self.cmbPowderU2.currentText())
 
+    def set_powder_u1(self, name):
+        # Signals are blocked to prevent self._u1_changed being called here (it would be false alarm)
+        self.cmbPowderU1.blockSignals(True)
+        self.cmbPowderU1.setCurrentIndex(self._name_to_index[name])
+        self.cmbPowderU1.blockSignals(False)
+
+    def set_powder_u2(self, name):
+        # Signals are blocked to prevent self._u2_changed being called here (it would be false alarm)
+        self.cmbPowderU2.blockSignals(True)
+        self.cmbPowderU2.setCurrentIndex(self._name_to_index[name])
+        self.cmbPowderU2.blockSignals(False)
+
     def populate_powder_u1(self, u1_options):
         # Signals are blocked to prevent self._u1_changed being called here (it would be false alarm)
         self.cmbPowderU1.blockSignals(True)
         self.cmbPowderU1.clear()
-        for value in u1_options:
+        # Assuming that u1 and u2 both have the same possible units.
+        self._name_to_index = {}
+        for idx, value in enumerate(u1_options):
             self.cmbPowderU1.addItem(value)
+            self._name_to_index[value] = idx
         self.cmbPowderU1.blockSignals(False)
-
 
     def populate_powder_u2(self, u2_options):
         # Signals are blocked to prevent self._u2_changed being called here (it would be false alarm)


### PR DESCRIPTION
This PR adds a `2Theta` axis to the list of possible *x*-, or *y*-axes (`u1` or `u2`). The implementation uses `ConvertSpectrumAxis` on the input workspace and the `ConvertToMD` with the `CopyToMD` method. (Note: For indirect geometry instrument data, `PreprocessDetectorsWS` which is run by `ConvertToMD` doesn't work on the output of `ConvertSpectrumAxis` for some reason - probably a bug. However, if it's run first on the original input workspace, then the detector workspace is used in `ConvertToMD`, a valid `MDWorkspace` is created. This work-around is used in this PR).

**To test:**

In the mslice GUI, load a file, and select `2Theta` as `u1` and `DeltaE` as `u2` (or vice versa). Calculate projection and plot the slice - check that the `2Theta` axis is in `Degrees` and the data looks reasonable.

Fixes #92.

