### PR TITLE
Enable loading of multiple files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ before_install:
   - sudo apt-add-repository ppa:mantid/mantid -y
   - sudo apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk trusty-testing main" -y
   - sudo apt-get update -q
-  - sudo apt-get install mantidnightly -y
+  - sudo apt-get install gdebi -y
+  - wget https://sourceforge.net/projects/mantid/files/Nightly/ -O /tmp/index.html
+  - wget http://downloads.sourceforge.net/project/mantid/Nightly/$(grep mantidnightly /tmp/index.html |grep trusty1_amd64.deb | sed s/.*mantidnightly/mantidnightly/ | sed s/.deb.*/.deb/ | head -n1) -O /tmp/mtn.deb
+  - sudo gdebi --option=APT::Get::force-yes=1,APT::Get::Assume-Yes=1 -n /tmp/mtn.deb
+  #- sudo apt-get install mantidnightly -y --force-yes 
 
 install:
   - pip install -r pip-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-add-repository ppa:mantid/mantid -y
   - sudo apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk trusty-testing main" -y
   - sudo apt-get update -q
-  - sudo apt-get install mantidnightly -y --force-yes
+  - sudo apt-get install mantidnightly -y
 
 install:
   - pip install -r pip-requirements.txt

--- a/presenters/interfaces/main_presenter.py
+++ b/presenters/interfaces/main_presenter.py
@@ -5,7 +5,7 @@ class MainPresenterInterface(object):
     def get_selected_workspaces(self):
         raise NotImplementedError("This method must be overriden in implementation")
 
-    def set_selected_workspaces(self, list):
+    def set_selected_workspaces(self, workspace_list):
         raise NotImplementedError("This method must be overriden in implementation")
 
     def update_displayed_workspaces(self):

--- a/presenters/interfaces/workspace_manager_presenter.py
+++ b/presenters/interfaces/workspace_manager_presenter.py
@@ -11,7 +11,7 @@ class WorkspaceManagerPresenterInterface(object):
     def get_selected_workspaces(self):
         raise NotImplementedError("This method must be overriden in implementation")
 
-    def set_selected_workspaces(self, list):
+    def set_selected_workspaces(self, workspace_list):
         raise NotImplementedError("This method must be overriden in implementation")
 
     def update_displayed_workspaces(self):

--- a/presenters/main_presenter.py
+++ b/presenters/main_presenter.py
@@ -11,8 +11,8 @@ class MainPresenter(MainPresenterInterface):
     def get_selected_workspaces(self):
         return self._workspace_presenter.get_selected_workspaces()
 
-    def set_selected_workspaces(self, list):
-        self._workspace_presenter.set_selected_workspaces(list)
+    def set_selected_workspaces(self, workspace_list):
+        self._workspace_presenter.set_selected_workspaces(workspace_list)
 
     def update_displayed_workspaces(self):
         """Update the workspaces shown to user.

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -68,17 +68,17 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manger_view.error_unable_to_open_file()
             return
         elif len(not_opened) > 0:
-            errmsg = not_opened if len(not_opened)==1 else ",".join(not_opened)
+            errmsg = not_opened[0] if len(not_opened)==1 else ",".join(not_opened)
             self._workspace_manger_view.error_unable_to_open_file(errmsg)
         if len(not_loaded) == len(ws_names):
             self._workspace_manger_view.no_workspace_has_been_loaded()
             return
         elif len(not_loaded) > 0:
-            errmsg = not_loaded if len(not_loaded)==1 else ",".join(not_loaded)
+            errmsg = not_loaded[0] if len(not_loaded)==1 else ",".join(not_loaded)
             self._workspace_manger_view.no_workspace_has_been_loaded(errmsg)
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
         self._workspace_manger_view.set_workspace_selected(
-                [self._workspace_manger_view.get_workspace_index(ld_name) for ld_name in loaded])
+            [self._workspace_manger_view.get_workspace_index(ld_name) for ld_name in loaded])
 
     def _save_selected_workspace(self):
         selected_workspaces = self._workspace_manger_view.get_workspace_selected()

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -48,23 +48,35 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         if not workspace_to_load:
             return
         ws_names = [os.path.splitext(os.path.basename(base))[0] for base in workspace_to_load]
+        not_loaded = []
+        not_opened = []
         loaded = []
-        #confirm that user wants to overwrite an existing workspace
         for ii, ws_name in enumerate(ws_names):
+            # confirm that user wants to overwrite an existing workspace
             if ws_name in self._work_spaceprovider.get_workspace_names():
                 confirm_overwrite = self._workspace_manger_view.confirm_overwrite_workspace()
                 if not confirm_overwrite:
-                    self._workspace_manger_view.no_workspace_has_been_loaded()
-                    return
+                    not_loaded.append(ws_name)
+                    continue
             try:
                 self._work_spaceprovider.load(filename=workspace_to_load[ii], output_workspace=ws_name)
             except RuntimeError:
+                not_opened.append(ws_name)
                 pass
             else:
                 loaded.append(ws_name)
-        if len(loaded) == 0:
+        if len(not_opened) == len(ws_names):
             self._workspace_manger_view.error_unable_to_open_file()
             return
+        elif len(not_opened) > 0:
+            errmsg = not_opened if len(not_opened)==1 else ",".join(not_opened)
+            self._workspace_manger_view.error_unable_to_open_file(errmsg)
+        if len(not_loaded) == len(ws_names):
+            self._workspace_manger_view.no_workspace_has_been_loaded()
+            return
+        elif len(not_loaded) > 0:
+            errmsg = not_loaded if len(not_loaded)==1 else ",".join(not_loaded)
+            self._workspace_manger_view.no_workspace_has_been_loaded(errmsg)
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
         #self._workspace_manger_view.set_workspace_selected(
         #        [self._workspace_manger_view.get_workspace_index(ld_name) for ld_name in loaded])

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -62,7 +62,6 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 self._work_spaceprovider.load(filename=workspace_to_load[ii], output_workspace=ws_name)
             except RuntimeError:
                 not_opened.append(ws_name)
-                pass
             else:
                 loaded.append(ws_name)
         if len(not_opened) == len(ws_names):

--- a/presenters/workspace_manager_presenter.py
+++ b/presenters/workspace_manager_presenter.py
@@ -47,20 +47,27 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         workspace_to_load = self._workspace_manger_view.get_workspace_to_load_path()
         if not workspace_to_load:
             return
-        base = os.path.basename(workspace_to_load)
-        ws_name = os.path.splitext(base)[0]
+        ws_names = [os.path.splitext(os.path.basename(base))[0] for base in workspace_to_load]
+        loaded = []
         #confirm that user wants to overwrite an existing workspace
-        if ws_name in self._work_spaceprovider.get_workspace_names():
-            confirm_overwrite = self._workspace_manger_view.confirm_overwrite_workspace()
-            if not confirm_overwrite:
-                self._workspace_manger_view.no_workspace_has_been_loaded()
-                return
-        try:
-            self._work_spaceprovider.load(filename=workspace_to_load, output_workspace=ws_name)
-        except RuntimeError:
+        for ii, ws_name in enumerate(ws_names):
+            if ws_name in self._work_spaceprovider.get_workspace_names():
+                confirm_overwrite = self._workspace_manger_view.confirm_overwrite_workspace()
+                if not confirm_overwrite:
+                    self._workspace_manger_view.no_workspace_has_been_loaded()
+                    return
+            try:
+                self._work_spaceprovider.load(filename=workspace_to_load[ii], output_workspace=ws_name)
+            except RuntimeError:
+                pass
+            else:
+                loaded.append(ws_name)
+        if len(loaded) == 0:
             self._workspace_manger_view.error_unable_to_open_file()
             return
         self._workspace_manger_view.display_loaded_workspaces(self._work_spaceprovider.get_workspace_names())
+        #self._workspace_manger_view.set_workspace_selected(
+        #        [self._workspace_manger_view.get_workspace_index(ld_name) for ld_name in loaded])
 
     def _save_selected_workspace(self):
         selected_workspaces = self._workspace_manger_view.get_workspace_selected()

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -38,7 +38,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
         path_to_nexus = join(tempdir,'cde.nxs')
         workspace_name = 'cde'
-        self.view.get_workspace_to_load_path = mock.Mock(return_value=path_to_nexus)
+        self.view.get_workspace_to_load_path = mock.Mock(return_value=[path_to_nexus])
         self.workspace_provider.get_workspace_names = mock.Mock(return_value=[workspace_name])
 
         self.presenter.notify(Command.LoadWorkspace)
@@ -57,10 +57,10 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         ws_name2 = 'file2'
         ws_name3 = 'file3'
         self.view.get_workspace_to_load_path = mock.Mock(
-            side_effect=[path1, path2, path3])
-        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[])
-        for i in range(3):
-            self.presenter.notify(Command.LoadWorkspace)
+            return_value=[path1, path2, path3])
+        self.workspace_provider.get_workspace_names = mock.Mock(
+            return_value=[ws_name1, ws_name2, ws_name3])
+        self.presenter.notify(Command.LoadWorkspace)
         load_calls = [call(filename=path1, output_workspace=ws_name1),
                       call(filename=path2, output_workspace=ws_name2),
                       call(filename=path3, output_workspace=ws_name3)]

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -40,7 +40,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         workspace_name = 'cde'
         self.view.get_workspace_to_load_path = mock.Mock(return_value=[path_to_nexus])
         self.workspace_provider.get_workspace_names = mock.Mock(return_value=[workspace_name])
-        self.view.get_workspace_index = mock.Mock(return_value=[0])
+        self.view.get_workspace_index = mock.Mock(return_value=0)
 
         self.presenter.notify(Command.LoadWorkspace)
         self.view.get_workspace_to_load_path.assert_called_once()
@@ -83,7 +83,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
         path = join(tempdir,'file.nxs')
         ws_name = 'file'
-        self.view.get_workspace_to_load_path = mock.Mock(return_value=path)
+        self.view.get_workspace_to_load_path = mock.Mock(return_value=[path])
         self.workspace_provider.get_workspace_names = mock.Mock(return_value=[ws_name])
         self.view.confirm_overwrite_workspace = mock.Mock(return_value=False)
 

--- a/views/workspace_view.py
+++ b/views/workspace_view.py
@@ -40,10 +40,10 @@ class WorkspaceView(object):
     def confirm_overwrite_workspace(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def no_workspace_has_been_loaded(self):
+    def no_workspace_has_been_loaded(self, filename=None):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def error_unable_to_open_file(self):
+    def error_unable_to_open_file(self, filename=None):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_save_path(self):

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -77,8 +77,8 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         return list(selected_workspaces)
 
     def get_workspace_to_load_path(self):
-        path = QFileDialog.getOpenFileName()
-        return str( path )
+        paths = QFileDialog.getOpenFileNames()
+        return [str(filename) for filename in paths]
 
     def get_workspace_to_save_filepath(self):
         extension = 'Nexus file (*.nxs)'

--- a/widgets/workspacemanager/workspacemanager.py
+++ b/widgets/workspacemanager/workspacemanager.py
@@ -101,8 +101,8 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
     def error_select_one_workspace(self):
         self._display_error('Please select a workspace then try again')
 
-    def error_unable_to_open_file(self):
-        self._display_error('MSlice was not able to load the selected file')
+    def error_unable_to_open_file(self, filename=None):
+        self._display_error('MSlice was not able to load %s' % ('the selected file' if filename is None else filename))
 
     def confirm_overwrite_workspace(self):
         reply = QMessageBox.question(self,'Confirm Overwrite', 'The workspace you want to load has the same name as'
@@ -117,8 +117,11 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
     def error_invalid_save_path(self):
         self._display_error('No files were saved')
 
-    def no_workspace_has_been_loaded(self):
-        self._display_error('No new workspaces have been loaded')
+    def no_workspace_has_been_loaded(self, filename=None):
+        if filename is None:
+            self._display_error('No new workspaces have been loaded')
+        else:
+            self._display_error('File %s has not been loaded' % (filename))
 
     def get_presenter(self):
         return self._presenter


### PR DESCRIPTION
This allows multiple files to be selected in the `Load` dialog box (using `getOpenFileNames` - allowin shift-select and also left-click-and-drag), and for all selected files to be loaded into the workspace manager.

**To test:**

Click `Load` and select multiple files. Check that all the files which can be loaded are loaded into the workspace manager. Files which cannot be loaded should be listed in the error bar at the bottom. Files which have the same names as existing workspaces should bring up a prompt asking if user wants to overwrite (one for each name conflict).

Fixes #100 
