### PR TITLE
Keep reference to MainWindow alive

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -32,4 +32,3 @@ def startup(with_ipython):
         qapp = QApplication([])
         show_gui()
         qapp.exec_()
-

--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -2,13 +2,18 @@
 and entry points.
 """
 
+# Module-level reference to keep main window alive after show_gui has returned
+MAIN_WINDOW = None
+
 def show_gui():
     """Display the top-level main window. It assumes that the QApplication instance
     has already been started
     """
-    from mslice.app.mainwindow import MainWindow
-    win = MainWindow()
-    win.show()
+    global MAIN_WINDOW
+    if MAIN_WINDOW is None:
+        from mslice.app.mainwindow import MainWindow
+        MAIN_WINDOW = MainWindow()
+    MAIN_WINDOW.show()
 
 def startup(with_ipython):
     """Perform a full application startup, including the IPython
@@ -24,6 +29,7 @@ def startup(with_ipython):
                                "-c from mslice.app import show_gui; show_gui()"])
     else:
         from PyQt4.QtGui import QApplication
-        qapp = QApplication()
+        qapp = QApplication([])
         show_gui()
         qapp.exec_()
+


### PR DESCRIPTION
Description of work.

Fixes lifetime issue with the reference to the `MainWindow` being cleaned up before the program had exited. 

**To test:**

This only appeared to be an issue on RHEL7 with Gnome but it should have been general.

* start mslice with `./mslicedevel`
* load and calculate a projection
* plot a slice and keep the window
* change some slice parameters and plot another slice
* a new window should appear and the main GUI should stay visible.

Before this fix the main mslice window disappeared on RHEL7. 

Fixes #112 
