### PR TITLE
Save ASCII

### DIFF
--- a/misc/MDUtils.py
+++ b/misc/MDUtils.py
@@ -10,13 +10,13 @@ def dim2array(d):
     """
     Create a numpy array containing bin centers along the dimension d
     input: d - IMDDimension
-    return: numpy array, from min+st/2 to max-st/2 with step st  
+    return: numpy array, from min+st/2 to max-st/2 with step st
     """
     dmin = d.getMinimum()
     dmax = d.getMaximum()
     dstep = d.getX(1)-d.getX(0)
     return np.arange(dmin+dstep/2,dmax,dstep)
-    
+
 
 def SaveMDToAscii(ws,filename,IgnoreIntegrated=True,NumEvNorm=False,Format='%.6e'):
     """
@@ -24,7 +24,7 @@ def SaveMDToAscii(ws,filename,IgnoreIntegrated=True,NumEvNorm=False,Format='%.6e
     input: ws - handle to the workspace
     input: filename - path to the output filename
     input: IgnoreIntegrated - if True, the integrated dimensions are ignored (smaller files), but that information is lost
-    input: NumEvNorm - must be set to true if data was converted to MD from a histo workspace (like NXSPE) and no MDNorm... algorithms were used
+    input: NumEvNorm - set to true if data was converted to MD from a histo workspace (like NXSPE) and no MDNorm... algorithms were used
     input: Format - value to pass to numpy.savetxt
     return: nothing
     """
@@ -52,7 +52,7 @@ def SaveMDToAscii(ws,filename,IgnoreIntegrated=True,NumEvNorm=False,Format='%.6e
     for d in newdimarrays:
         toPrint = np.c_[toPrint,d.flatten()]
     np.savetxt(filename,toPrint,fmt=Format,header=header)
-    
+
 
 def Plot1DMD(ax,ws,PlotErrors=True,NumEvNorm=False,**kwargs):
     """
@@ -60,7 +60,7 @@ def Plot1DMD(ax,ws,PlotErrors=True,NumEvNorm=False,**kwargs):
     input: ax - axis object
     input: ws - handle to the workspace
     input: PlotErrors - if True, will show error bars
-    input: NumEvNorm - must be set to true if data was converted to MD from a histo workspace (like NXSPE) and no MDNorm... algorithms were used
+    input: NumEvNorm - set to true if data was converted to MD from a histo workspace (like NXSPE) and no MDNorm... algorithms were used
     input: kwargs - arguments that are passed to plot, such as plotting symbol, color, label, etc.
     """
     dims = ws.getNonIntegratedDimensions()
@@ -90,7 +90,7 @@ def Plot2DMD(ax,ws,NumEvNorm=False,**kwargs):
     Plot a 2D slice from an MDHistoWorkspace (assume all other dimensions are 1)
     input: ax - axis object
     input: ws - handle to the workspace
-    input: NumEvNorm - must be set to true if data was converted to MD from a histo workspace (like NXSPE) and no MDNorm... algorithms were used
+    input: NumEvNorm - set to true if data was converted to MD from a histo workspace (like NXSPE) and no MDNorm... algorithms were used
     input: kwargs - arguments that are passed to plot, such as plotting symbol, color, label, etc.
     """
     dims = ws.getNonIntegratedDimensions()
@@ -120,26 +120,26 @@ def example_plots():
     #create slices and cuts
     w = Load(Filename='/SNS/HYS/IPTS-14189/shared/autoreduce/4pixel/HYS_102102_4pixel_spe.nxs')
     SetUB(w,4.53,4.53,11.2,90,90,90,"1,0,0","0,0,1")
-    mde = ConvertToMD(w, QDimensions='Q3D')       
+    mde = ConvertToMD(w, QDimensions='Q3D')
     sl1d = CutMD(InputWorkspace=mde, P1Bin='-5,5', P2Bin='-5,5', P3Bin='2,4', P4Bin='-10,0.5,15', NoPix=True)
     sl2d = CutMD(InputWorkspace=mde, P1Bin='-5,5', P2Bin='-5,5', P3Bin='-5,0.1,5', P4Bin='-10,1,15', NoPix=True)
-    
+
     #2 subplots per page
     fig,ax = plt.subplots(2,1)
     Plot1DMD(ax[0],sl1d,NumEvNorm=True,fmt='ro')
     ax[0].set_ylabel("Int(a.u.)")
     pcm = Plot2DMD(ax[1],sl2d,NumEvNorm=True)
     fig.colorbar(pcm,ax=ax[1])
-    
+
     #save to png
     plt.tight_layout(1.08)
     fig.savefig('/tmp/test.png')
 
-def example_pdf():    
+def example_pdf():
     #create slices and cuts
     w = Load(Filename='/SNS/HYS/IPTS-14189/shared/autoreduce/4pixel/HYS_102102_4pixel_spe.nxs')
     SetUB(w,4.53,4.53,11.2,90,90,90,"1,0,0","0,0,1")
-    mde = ConvertToMD(w, QDimensions='Q3D')       
+    mde = ConvertToMD(w, QDimensions='Q3D')
     with PdfPages('/tmp/multipage_pdf.pdf') as pdf:
         for i in range(4):
             llims = str(i-0.5)+','+str(i+0.5)

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -47,17 +47,14 @@ class CutPresenter(object):
             return
 
         if save_to_workspace:
-            def save_cut(params, _, __):
-                self._save_cut_to_workspace(params)
-            handler = save_cut
+            def handler(*args):
+                self._save_cut_to_workspace(args[0])
         elif save_to_file is not None:
-            def save_file(params, _, save_to_file):
+            def handler(params, _, save_to_file):
                 self._save_cut_to_file(params, save_to_file)
-            handler = save_file
         else:
-            def plot_cut(params, plot_over, _):
+            def handler(params, plot_over, _):
                 self._plot_cut(params, plot_over)
-            handler = plot_cut
         width = params[-1]
         params = params[:-1]
         if width is None:
@@ -94,7 +91,8 @@ class CutPresenter(object):
         path = QFileDialog.getSaveFileName(caption='Select File for Saving')
         return str(path)
 
-    def save_data_to_txt(self, x, y, e, output_file, header=None):
+    def save_data_to_txt(self, *args):
+        x, y, e, output_file, header = tuple(args)
         out_data = np.c_[x, y, e]
         np.savetxt(str(output_file), out_data, fmt='%12.9e', header=header)
 

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -34,7 +34,7 @@ class CutPresenter(object):
         elif command == Command.SaveToWorkspace:
             self._process_cuts(save_to_workspace=True)
         elif command == Command.SaveToAscii:
-            fname = self.get_filename_to_save()
+            fname = str(QFileDialog.getSaveFileName(caption='Select File for Saving'))
             if fname:
                 self._process_cuts(save_to_file=fname)
 
@@ -85,14 +85,6 @@ class CutPresenter(object):
         x, y, e = self._cut_algorithm.compute_cut_xye(*cut_params)
         header = 'MSlice Cut of workspace "%s" along "%s" between %f and %f' % (params[:4])
         header += ' %s normalising to unity' % ('with' if params[4] else 'without')
-        self.save_data_to_txt(x, y, e, output_file, header)
-
-    def get_filename_to_save(self):
-        path = QFileDialog.getSaveFileName(caption='Select File for Saving')
-        return str(path)
-
-    def save_data_to_txt(self, *args):
-        x, y, e, output_file, header = tuple(args)
         out_data = np.c_[x, y, e]
         np.savetxt(str(output_file), out_data, fmt='%12.9e', header=header)
 

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -87,19 +87,19 @@ class CutPresenter(object):
         x, y, e = self._cut_algorithm.compute_cut_xye(*cut_params)
         header = 'MSlice Cut of workspace "%s" along "%s" between %f and %f' % (params[:4])
         header += ' %s normalising to unity' % ('with' if params[4] else 'without')
-        self.save_data_to_txt(x, y, e, header)
+        self.save_data_to_txt(x, y, e, output_file, header)
 
     def get_filename_to_save(self):
         path = QFileDialog.getSaveFileName(caption='Select File for Saving')
         return str(path)
 
-    def save_data_to_txt(self, x, y, e, header=None):
+    def save_data_to_txt(self, x, y, e, output_file, header=None):
         out_data = np.c_[x, y, e]
         np.savetxt(str(output_file), out_data, fmt='%12.9e', header=header)
 
     def _save_cut_to_workspace(self, params):
         cut_params = params[:5]
-        cut_ws = self._cut_algorithm.compute_cut(*cut_params)
+        self._cut_algorithm.compute_cut(*cut_params)
         self._main_presenter.update_displayed_workspaces()
 
 

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -34,8 +34,7 @@ class CutPresenter(object):
         elif command == Command.SaveToWorkspace:
             self._process_cuts(save_to_workspace=True)
         elif command == Command.SaveToAscii:
-            #raise NotImplementedError('Save to ascii Not implemented')
-            fname = QFileDialog.getSaveFileName(caption='Select File for Saving')
+            fname = self.get_filename_to_save()
             self._process_cuts(save_to_file=fname)
 
     def _process_cuts(self, plot_over=False, save_to_workspace=False, save_to_file=None):
@@ -88,6 +87,13 @@ class CutPresenter(object):
         x, y, e = self._cut_algorithm.compute_cut_xye(*cut_params)
         header = 'MSlice Cut of workspace "%s" along "%s" between %f and %f' % (params[:4])
         header += ' %s normalising to unity' % ('with' if params[4] else 'without')
+        self.save_data_to_txt(x, y, e, header)
+
+    def get_filename_to_save(self):
+        path = QFileDialog.getSaveFileName(caption='Select File for Saving')
+        return str(path)
+
+    def save_data_to_txt(self, x, y, e, header=None):
         out_data = np.c_[x, y, e]
         np.savetxt(str(output_file), out_data, fmt='%12.9e', header=header)
 

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -35,7 +35,8 @@ class CutPresenter(object):
             self._process_cuts(save_to_workspace=True)
         elif command == Command.SaveToAscii:
             fname = self.get_filename_to_save()
-            self._process_cuts(save_to_file=fname)
+            if fname:
+                self._process_cuts(save_to_file=fname)
 
     def _process_cuts(self, plot_over=False, save_to_workspace=False, save_to_file=None):
         """This function handles the width parameter. If it is not specified a single cut is plotted from

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -232,4 +232,3 @@ class CutPresenterTest(unittest.TestCase):
         ]
         self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
-

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -13,6 +13,8 @@ from mslice.presenters.slice_plotter_presenter import Axis
 from mslice.widgets.cut.command import Command
 from mslice.views.cut_view import CutView
 
+from PyQt4.QtGui import QFileDialog 
+import numpy as np
 
 class CutPresenterTest(unittest.TestCase):
     def setUp(self):
@@ -90,6 +92,24 @@ class CutPresenterTest(unittest.TestCase):
 
         self.view.enable.assert_not_called()
 
+    def _create_cut(self, *args):
+        axis, processed_axis = tuple(args[0:2])
+        integration_start, integration_end, width = tuple(args[2:5])
+        intensity_start, intensity_end, is_norm = tuple(args[5:8])
+        workspace, integrated_axis = tuple(args[8:10])
+        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
+        self.view.get_cut_axis = mock.Mock(return_value=axis.units)
+        self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
+        self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
+        self.view.get_cut_axis.step = mock.Mock(return_value=axis.step)
+        self.view.get_integration_start = mock.Mock(return_value=integration_start)
+        self.view.get_integration_end = mock.Mock(return_value=integration_end)
+        self.view.get_intensity_start = mock.Mock(return_value=intensity_start)
+        self.view.get_intensity_end = mock.Mock(return_value=intensity_end)
+        self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
+        self.view.get_integration_width = mock.Mock(return_value=width)
+        self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
+
     def test_plot_single_cut_success(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
@@ -103,18 +123,8 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
-        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
-        self.view.get_cut_axis = mock.Mock(return_value=axis.units)
-        self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
-        self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
-        self.view.get_cut_axis.step = mock.Mock(return_value=axis.step)
-        self.view.get_integration_start = mock.Mock(return_value=integration_start)
-        self.view.get_integration_end = mock.Mock(return_value=integration_end)
-        self.view.get_intensity_start = mock.Mock(return_value=intensity_start)
-        self.view.get_intensity_end = mock.Mock(return_value=intensity_end)
-        self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
-        self.view.get_integration_width = mock.Mock(return_value=width)
-        self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
 
         cut_presenter.notify(Command.Plot)
         self.cut_algorithm.compute_cut.assert_not_called()
@@ -123,7 +133,29 @@ class CutPresenterTest(unittest.TestCase):
                                                      norm_to_one=is_norm, intensity_start=intensity_start,
                                                      intensity_end=intensity_end, plot_over=False)
 
-    def test_cut_single_save_to_worksapce(self):
+    def test_plot_over_cut_fail(self):
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        axis = Axis("units", "0", "100", "1")
+        processed_axis = Axis("units", 0, 100, 1)
+        integration_start = 3
+        integration_end = 5
+        width = ""
+        intensity_start = ""
+        intensity_end = 30
+        is_norm = True
+        workspace = "workspace"
+        integrated_axis = 'integrated axis'
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.PlotOver)
+        self.cut_algorithm.compute_cut.assert_not_called()
+        self.cut_plotter.plot_cut.assert_called_with(selected_workspace=workspace, cut_axis=processed_axis,
+                                                     integration_start=integration_start, integration_end=integration_end,
+                                                     norm_to_one=is_norm, intensity_start=None,
+                                                     intensity_end=intensity_end, plot_over=True)
+
+    def test_cut_single_save_to_workspace(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
         axis = Axis("units", "0", "100", "1")
@@ -136,19 +168,9 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
-        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
-        self.view.get_cut_axis = mock.Mock(return_value=axis.units)
-        self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
-        self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
-        self.view.get_cut_axis.step = mock.Mock(return_value=axis.step)
-        self.view.get_integration_start = mock.Mock(return_value=integration_start)
-        self.view.get_integration_end = mock.Mock(return_value=integration_end)
-        self.view.get_intensity_start = mock.Mock(return_value=intensity_start)
-        self.view.get_intensity_end = mock.Mock(return_value=intensity_end)
-        self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
-        self.view.get_integration_width = mock.Mock(return_value=width)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=('x', 'y', 'e'))
-        self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
         cut_presenter.notify(Command.SaveToWorkspace)
         self.cut_algorithm.compute_cut.assert_called_with(workspace, processed_axis, integration_start,
                                                           integration_end, is_norm)
@@ -167,29 +189,22 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         # Create a view that will return a path on call to get_workspace_to_load_path
         tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
         path_to_savefile = join(tempdir,'out.txt')
-        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
-        self.view.get_cut_axis = mock.Mock(return_value=axis.units)
-        self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
-        self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
-        self.view.get_cut_axis.step = mock.Mock(return_value=axis.step)
-        self.view.get_integration_start = mock.Mock(return_value=integration_start)
-        self.view.get_integration_end = mock.Mock(return_value=integration_end)
-        self.view.get_intensity_start = mock.Mock(return_value=intensity_start)
-        self.view.get_intensity_end = mock.Mock(return_value=intensity_end)
-        self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
-        self.view.get_integration_width = mock.Mock(return_value=width)
-        self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=('x', 'y', 'e'))
-        self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
-        cut_presenter.get_filename_to_save = mock.Mock(return_value=[path_to_savefile])
-        cut_presenter.save_data_to_txt = mock.Mock()
+        x = np.array([1, 2, 3])
+        y = np.array([1, 4, 9])
+        e = np.array([1, 1, 1])
+        self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=(x, y, e))
+        QFileDialog.getSaveFileName = mock.Mock(return_value=path_to_savefile)
+        np.savetxt = mock.Mock()
         cut_presenter.notify(Command.SaveToAscii)
-        cut_presenter.get_filename_to_save.assert_called_once()
         self.cut_algorithm.compute_cut_xye.assert_called_with(workspace, processed_axis, integration_start,
                                                               integration_end, is_norm)
-        cut_presenter.save_data_to_txt.assert_called_once()
+        QFileDialog.getSaveFileName.assert_called_once()
+        np.savetxt.assert_called_once()
         self.cut_plotter.plot_cut.assert_not_called()
 
     def test_plot_multiple_cuts_with_width(self):
@@ -205,18 +220,8 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
-        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
-        self.view.get_cut_axis = mock.Mock(return_value=axis.units)
-        self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
-        self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
-        self.view.get_cut_axis.step = mock.Mock(return_value=axis.step)
-        self.view.get_integration_start = mock.Mock(return_value=integration_start)
-        self.view.get_integration_end = mock.Mock(return_value=integration_end)
-        self.view.get_intensity_start = mock.Mock(return_value=intensity_start)
-        self.view.get_intensity_end = mock.Mock(return_value=intensity_end)
-        self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
-        self.view.get_integration_width = mock.Mock(return_value=width)
-        self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
 
         cut_presenter.notify(Command.Plot)
         call_list = [
@@ -232,3 +237,40 @@ class CutPresenterTest(unittest.TestCase):
         ]
         self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
+
+    def test_multiple_cut_save_ascii(self):
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        axis = Axis("units", "0", "100", "1")
+        processed_axis = Axis("units", 0, 100, 1)
+        integration_start = 3
+        integration_end = 8
+        width = "2"
+        intensity_start = 11
+        intensity_end = 30
+        is_norm = True
+        workspace = "workspace"
+        integrated_axis = 'integrated axis'
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        # Create a view that will return a path on call to get_workspace_to_load_path
+        tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
+        path_to_savefile = join(tempdir,'out.txt')
+        x = np.array([1, 2, 3])
+        y = np.array([1, 4, 9])
+        e = np.array([1, 1, 1])
+        self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=(x, y, e))
+        QFileDialog.getSaveFileName = mock.Mock(return_value=path_to_savefile)
+        np.savetxt = mock.Mock()
+        cut_presenter.notify(Command.SaveToAscii)
+        QFileDialog.getSaveFileName.assert_called_once()
+        w = float(width)
+        call_list = [
+            call(workspace, processed_axis, integration_start, integration_start+w, is_norm),
+            call(workspace, processed_axis, integration_start+w, integration_start+w+w, is_norm),
+            call(workspace, processed_axis, integration_start+w+w, integration_end, is_norm),
+        ]
+        self.cut_algorithm.compute_cut_xye.assert_has_calls(call_list)
+        callargs = np.savetxt.call_args[0]
+        self.assertEquals(callargs[0], join(tempdir, 'out_2.txt'))  # Indexed from zero
+        self.cut_plotter.plot_cut.assert_not_called()

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -1,6 +1,9 @@
 import mock
 from mock import call
 import unittest
+from tempfile import gettempdir
+from os.path import join
+
 
 from mslice.models.cut.cut_algorithm import CutAlgorithm
 from mslice.models.cut.cut_plotter import CutPlotter
@@ -151,6 +154,44 @@ class CutPresenterTest(unittest.TestCase):
                                                           integration_end, is_norm)
         self.cut_plotter.plot_cut.assert_not_called()
 
+    def test_cut_save_ascii(self):
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        axis = Axis("units", "0", "100", "1")
+        processed_axis = Axis("units", 0, 100, 1)
+        integration_start = 3
+        integration_end = 5
+        width = ""
+        intensity_start = 11
+        intensity_end = 30
+        is_norm = True
+        workspace = "workspace"
+        integrated_axis = 'integrated axis'
+        # Create a view that will return a path on call to get_workspace_to_load_path
+        tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
+        path_to_savefile = join(tempdir,'out.txt')
+        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
+        self.view.get_cut_axis = mock.Mock(return_value=axis.units)
+        self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
+        self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
+        self.view.get_cut_axis.step = mock.Mock(return_value=axis.step)
+        self.view.get_integration_start = mock.Mock(return_value=integration_start)
+        self.view.get_integration_end = mock.Mock(return_value=integration_end)
+        self.view.get_intensity_start = mock.Mock(return_value=intensity_start)
+        self.view.get_intensity_end = mock.Mock(return_value=intensity_end)
+        self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
+        self.view.get_integration_width = mock.Mock(return_value=width)
+        self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=('x', 'y', 'e'))
+        self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
+        cut_presenter.get_filename_to_save = mock.Mock(return_value=[path_to_savefile])
+        cut_presenter.save_data_to_txt = mock.Mock()
+        cut_presenter.notify(Command.SaveToAscii)
+        cut_presenter.get_filename_to_save.assert_called_once()
+        self.cut_algorithm.compute_cut_xye.assert_called_with(workspace, processed_axis, integration_start,
+                                                              integration_end, is_norm)
+        cut_presenter.save_data_to_txt.assert_called_once()
+        self.cut_plotter.plot_cut.assert_not_called()
+
     def test_plot_multiple_cuts_with_width(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
@@ -191,3 +232,4 @@ class CutPresenterTest(unittest.TestCase):
         ]
         self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
+

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -110,6 +110,91 @@ class CutPresenterTest(unittest.TestCase):
         self.view.get_integration_width = mock.Mock(return_value=width)
         self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
 
+    def test_cut_parse_input_errors(self):
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        # Invalid workspace
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        # Defines good values
+        axis = Axis("units", "0", "100", "1")
+        processed_axis = Axis("units", 0, 100, 1)
+        integration_start = 3
+        integration_end = 8
+        width = "2"
+        intensity_start = 11
+        intensity_end = 30
+        is_norm = True
+        workspace = "workspace"
+        integrated_axis = 'integrated axis'
+        # Wrong units
+        axis = Axis("", "0", "100", "1")
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        # Bad cut axis
+        axis = Axis("units", "a", "100", "1")
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        # Invalid axis range
+        axis = Axis("units", "100", "0", "1")
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        axis = Axis("units", "0", "100", "1")
+        # Bad integration
+        integration_start = "a"
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        # Invalid integration range 
+        integration_start = 30
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        integration_start = 3
+        # Bad intensity 
+        intensity_start = "a"
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        # Invalid intensity range 
+        intensity_start = 100
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        intensity_start = 11
+        # Wrong width
+        width = "a"
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        cut_presenter.notify(Command.Plot)
+        self.assertRaises(ValueError)
+        
     def test_plot_single_cut_success(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -13,7 +13,7 @@ from mslice.presenters.slice_plotter_presenter import Axis
 from mslice.widgets.cut.command import Command
 from mslice.views.cut_view import CutView
 
-from PyQt4.QtGui import QFileDialog 
+from PyQt4.QtGui import QFileDialog
 import numpy as np
 
 class CutPresenterTest(unittest.TestCase):
@@ -160,7 +160,7 @@ class CutPresenterTest(unittest.TestCase):
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         cut_presenter.notify(Command.Plot)
         self.assertRaises(ValueError)
-        # Invalid integration range 
+        # Invalid integration range
         integration_start = 30
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
@@ -169,7 +169,7 @@ class CutPresenterTest(unittest.TestCase):
         cut_presenter.notify(Command.Plot)
         self.assertRaises(ValueError)
         integration_start = 3
-        # Bad intensity 
+        # Bad intensity
         intensity_start = "a"
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
@@ -177,7 +177,7 @@ class CutPresenterTest(unittest.TestCase):
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         cut_presenter.notify(Command.Plot)
         self.assertRaises(ValueError)
-        # Invalid intensity range 
+        # Invalid intensity range
         intensity_start = 100
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
@@ -194,7 +194,7 @@ class CutPresenterTest(unittest.TestCase):
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         cut_presenter.notify(Command.Plot)
         self.assertRaises(ValueError)
-        
+
     def test_plot_single_cut_success(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -124,6 +124,7 @@ class CutWidget(QWidget, CutView, Ui_Form):
         self.btnCutPlot.setEnabled(False)
         self.btnCutPlotOver.setEnabled(False)
 
+        self.btnCutSaveAscii.setEnabled(True)
         self.btnCutSaveToWorkspace.setEnabled(True)
         self.btnCutPlot.setEnabled(True)
         self.btnCutPlotOver.setEnabled(True)
@@ -142,6 +143,7 @@ class CutWidget(QWidget, CutView, Ui_Form):
         self.lneCutIntensityEnd.setEnabled(False)
         self.rdoCutNormToOne.setEnabled(False)
 
+        self.btnCutSaveAscii.setEnabled(False)
         self.btnCutSaveToWorkspace.setEnabled(False)
         self.btnCutPlot.setEnabled(False)
         self.btnCutPlotOver.setEnabled(False)


### PR DESCRIPTION
Enables the saving of cuts to text files in a three-column `x`, `y`, `e` format. 

If multiple cuts area selected, each will be saved to a separate file with the same starting prefix.

**To test:**

Open a data file, make a cut and click `Save ASCII` in the `Cut` tab. Select a file name and check that the correct data (and header, indicating the limits of the cut and original workspace name) is written to that file. Select multiple cuts and check that the correct number of files are written with the correct data. 

Fixes #108.
