### PR TITLE
Remember cut parameters

### DIFF
--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -19,6 +19,9 @@ class CutPresenter(object):
         self._cut_plotter = cut_plotter
         self._acting_on = None
         self._cut_view.disable()
+        self._saved_parameters = dict()
+        self._previous_cut = None
+        self._previous_axis = None
 
     def register_master(self, main_presenter):
         self._main_presenter = main_presenter
@@ -37,6 +40,8 @@ class CutPresenter(object):
             fname = str(QFileDialog.getSaveFileName(caption='Select File for Saving'))
             if fname:
                 self._process_cuts(save_to_file=fname)
+        elif command == Command.AxisChanged:
+            self._cut_axis_changed()
 
     def _process_cuts(self, plot_over=False, save_to_workspace=False, save_to_file=None):
         """This function handles the width parameter. If it is not specified a single cut is plotted from
@@ -159,18 +164,31 @@ class CutPresenter(object):
         return float(x)
 
     def workspace_selection_changed(self):
+        if self._previous_cut is not None and self._previous_axis is not None:
+            if self._previous_cut not in self._saved_parameters.keys():
+                self._saved_parameters[self._previous_cut] = dict()
+            self._saved_parameters[self._previous_cut][self._previous_axis] = self._cut_view.get_input_fields()
+
         self._cut_view.clear_input_fields()
         workspace_selection = self._main_presenter.get_selected_workspaces()
 
         if len(workspace_selection) != 1:
             self._cut_view.disable()
+            self._previous_cut = None
+            self._previous_axis = None
             return
 
         workspace = workspace_selection[0]
+
         if self._cut_algorithm.is_cuttable(workspace):
             axis = self._cut_algorithm.get_available_axis(workspace)
             self._cut_view.populate_cut_axis_options(axis)
             self._cut_view.enable()
+            if workspace in self._saved_parameters.keys():
+                if axis[0] in self._saved_parameters[workspace].keys():
+                    self._cut_view.populate_input_fields(self._saved_parameters[workspace][axis[0]])
+            self._previous_cut = workspace
+            self._previous_axis = axis[0]
 
         elif self._cut_algorithm.is_cut(workspace):
             self._cut_view.plotting_params_only()
@@ -185,6 +203,21 @@ class CutPresenter(object):
 
         else:
             self._cut_view.disable()
+            self._previous_cut = None
+            self._previous_axis = None
+
+    def _cut_axis_changed(self):
+        if self._previous_axis is not None:
+            if self._previous_cut not in self._saved_parameters.keys():
+                self._saved_parameters[self._previous_cut] = dict()
+            self._saved_parameters[self._previous_cut][self._previous_axis] = self._cut_view.get_input_fields()
+        self._cut_view.clear_input_fields(keep_axes=True)
+        if self._previous_cut is not None:
+            self._previous_axis = self._cut_view.get_cut_axis()
+            if self._previous_axis in self._saved_parameters[self._previous_cut].keys():
+                self._cut_view.populate_input_fields(self._saved_parameters[self._previous_cut][self._previous_axis])
+        else:
+            self._cut_view.clear_input_fields()
 
     def _clear_displayed_error(self):
         self._cut_view.clear_displayed_error()

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -169,10 +169,10 @@ class CutPresenter(object):
                 self._saved_parameters[self._previous_cut] = dict()
             self._saved_parameters[self._previous_cut][self._previous_axis] = self._cut_view.get_input_fields()
 
-        self._cut_view.clear_input_fields()
         workspace_selection = self._main_presenter.get_selected_workspaces()
 
         if len(workspace_selection) != 1:
+            self._cut_view.clear_input_fields()
             self._cut_view.disable()
             self._previous_cut = None
             self._previous_axis = None
@@ -182,13 +182,18 @@ class CutPresenter(object):
 
         if self._cut_algorithm.is_cuttable(workspace):
             axis = self._cut_algorithm.get_available_axis(workspace)
+            current_axis = axis[0]
+            if self._previous_cut is not None and self._previous_axis is not None:
+                if axis == self._saved_parameters[self._previous_cut][self._previous_axis]['axes']:
+                    current_axis = self._cut_view.get_cut_axis()
             self._cut_view.populate_cut_axis_options(axis)
             self._cut_view.enable()
+            self._cut_view.set_cut_axis(current_axis)
             if workspace in self._saved_parameters.keys():
-                if axis[0] in self._saved_parameters[workspace].keys():
-                    self._cut_view.populate_input_fields(self._saved_parameters[workspace][axis[0]])
+                if current_axis in self._saved_parameters[workspace].keys():
+                    self._cut_view.populate_input_fields(self._saved_parameters[workspace][current_axis])
             self._previous_cut = workspace
-            self._previous_axis = axis[0]
+            self._previous_axis = current_axis
 
         elif self._cut_algorithm.is_cut(workspace):
             self._cut_view.plotting_params_only()
@@ -202,6 +207,7 @@ class CutPresenter(object):
             self._cut_view.populate_integration_params(*format_(*integration_limits))
 
         else:
+            self._cut_view.clear_input_fields()
             self._cut_view.disable()
             self._previous_cut = None
             self._previous_axis = None

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -37,6 +37,9 @@ class CutView:
     def get_presenter(self):
         pass
 
+    def set_cut_axis(self, axis_name):
+        pass
+
     def error_select_a_workspace(self):
         pass
 
@@ -82,7 +85,7 @@ class CutView:
     def populate_input_fields(self, saved_input):
         pass
 
-    def clear_input_fields(self):
+    def clear_input_fields(self, **kwargs):
         pass
 
     def clear_displayed_error(self):

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -76,6 +76,12 @@ class CutView:
     def force_normalization(self):
         pass
 
+    def get_input_fields(self):
+        pass
+
+    def populate_input_fields(self, saved_input):
+        pass
+
     def clear_input_fields(self):
         pass
 

--- a/mslice/widgets/cut/command.py
+++ b/mslice/widgets/cut/command.py
@@ -13,3 +13,4 @@ class Command(object):
     PlotOver = -998
     SaveToWorkspace = -997
     SaveToAscii = -996
+    AxisChanged = -995

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -83,6 +83,13 @@ class CutWidget(QWidget, CutView, Ui_Form):
     def get_smoothing(self):
         return str(self.lneCutSmoothing.text())
 
+    def set_cut_axis(self, axis_name):
+        index = [ind for ind in range(self.cmbCutAxis.count()) if str(self.cmbCutAxis.itemText(ind)) == axis_name]
+        if index:
+            self.cmbCutAxis.blockSignals(True)
+            self.cmbCutAxis.setCurrentIndex(index[0])
+            self.cmbCutAxis.blockSignals(False)
+
     def populate_cut_axis_options(self, options):
         self.cmbCutAxis.blockSignals(True)
         self.cmbCutAxis.clear()
@@ -122,6 +129,7 @@ class CutWidget(QWidget, CutView, Ui_Form):
 
     def get_input_fields(self):
         saved_input = dict()
+        saved_input['axes'] = [str(self.cmbCutAxis.itemText(ind)) for ind in range(self.cmbCutAxis.count())]
         saved_input['cut_parameters'] = [self.get_cut_axis_start(),
                                          self.get_cut_axis_end(),
                                          self.get_cut_axis_step()]

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -46,7 +46,7 @@ class CutWidget(QWidget, CutView, Ui_Form):
 
     def axis_changed(self, *args):
         self._presenter.notify(Command.AxisChanged)
-        
+
     def get_presenter(self):
         return self._presenter
 


### PR DESCRIPTION
Stores previously entered parameters for cuts (along which axis, from, to, step, integration range, smoothing level, whether to normalise to unity) in an attribute of `CutPresenter`. When the user changes back to a previously defined cut/workspace pair (or a new workspace with the same axes), will repopulate the fields in the `Cut` tab with the previously defined values.

**To test:**

Load several data files and calculate several sets of projections (convert to MDWorkspace) for each dataset, ensuring that you have at least two of the same type (e.g. two `_QE` and one `_EQ` or whatever). Make some cuts, and check that when you select another workspace or axis, and then select the previous one again, that the correct values for the previous cut reappear.

Fixes #106 
