### PR TITLE
Indirect geometry NXSPE handling

### DIFF
--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -19,7 +19,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
     def __init__(self):
         # Stores various parameters of workspaces not stored by Mantid
         self._EfDefined = {}
-    
+
     def get_workspace_names(self):
         return AnalysisDataService.getObjectNames()
 
@@ -31,8 +31,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         ws_name = workspace if isinstance(workspace, basestring) else self.get_workspace_name(workspace)
         ws_h = self.get_workspace_handle(ws_name)
         try:
-            ef = [ws_h.getEFixed(ws_h.getDetector(i).getID()) 
-                for i in range(ws_h.getNumberHistograms())]
+            [ws_h.getEFixed(ws_h.getDetector(i).getID()) for i in range(ws_h.getNumberHistograms())]
             self._EfDefined[ws_name] = True
         except RuntimeError:
             self._EfDefined[ws_name] = False
@@ -84,4 +83,3 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         ws_handle = self.get_workspace_handle(ws_name)
         for idx in range(ws_handle.getNumberHistograms()):
             ws_handle.setEFixed(ws_handle.getDetector(idx).getID(), Ef)
-

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -65,6 +65,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 not_opened.append(ws_name)
             else:
                 loaded.append(ws_name)
+                # Checks if this workspace has efixed set. If not, prompts the user and sets it.
+                if self._work_spaceprovider.get_emode(ws_name) == 'Indirect' and not self._work_spaceprovider.has_efixed(ws_name):
+                    self._work_spaceprovider.set_efixed(ws_name, self._workspace_manger_view.get_workspace_efixed(ws_name))
         if len(not_opened) == len(ws_names):
             self._workspace_manger_view.error_unable_to_open_file()
             return

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -52,6 +52,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         not_loaded = []
         not_opened = []
         loaded = []
+        multi = len(ws_names) > 1
+        allChecked = False
         for ii, ws_name in enumerate(ws_names):
             # confirm that user wants to overwrite an existing workspace
             if ws_name in self._work_spaceprovider.get_workspace_names():
@@ -67,7 +69,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 loaded.append(ws_name)
                 # Checks if this workspace has efixed set. If not, prompts the user and sets it.
                 if self._work_spaceprovider.get_emode(ws_name) == 'Indirect' and not self._work_spaceprovider.has_efixed(ws_name):
-                    self._work_spaceprovider.set_efixed(ws_name, self._workspace_manger_view.get_workspace_efixed(ws_name))
+                    if not allChecked:
+                        Ef, allChecked = self._workspace_manger_view.get_workspace_efixed(ws_name, multi)
+                    self._work_spaceprovider.set_efixed(ws_name, Ef)
         if len(not_opened) == len(ws_names):
             self._workspace_manger_view.error_unable_to_open_file()
             return

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -40,13 +40,19 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         workspace_name = 'cde'
         self.view.get_workspace_to_load_path = mock.Mock(return_value=[path_to_nexus])
         self.workspace_provider.get_workspace_names = mock.Mock(return_value=[workspace_name])
+        self.workspace_provider.get_emode = mock.Mock(return_value='Indirect')
+        self.workspace_provider.has_efixed = mock.Mock(return_value=False)
+        self.workspace_provider.set_efixed = mock.Mock()
         self.view.get_workspace_index = mock.Mock(return_value=0)
+        self.view.get_workspace_efixed = mock.Mock(return_value=(1.845, False))
 
         self.presenter.notify(Command.LoadWorkspace)
         self.view.get_workspace_to_load_path.assert_called_once()
         self.workspace_provider.load.assert_called_with(filename=path_to_nexus, output_workspace=workspace_name)
         self.view.display_loaded_workspaces.assert_called_with([workspace_name])
         self.view.set_workspace_selected.assert_called_with([0])
+        self.view.get_workspace_efixed.assert_called_with(workspace_name, False)
+        self.workspace_provider.set_efixed.assert_called_once()
 
     def test_load_multiple_workspaces(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
@@ -62,6 +68,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             return_value=[path1, path2, path3])
         self.workspace_provider.get_workspace_names = mock.Mock(
             return_value=[ws_name1, ws_name2, ws_name3])
+        self.workspace_provider.get_emode = mock.Mock(return_value='Direct')
         # Makes the first file not load because of a name collision
         self.view.confirm_overwrite_workspace = mock.Mock(side_effect=[False, True, True])
         # Makes the second file fail to load, to check if it raise the correct error
@@ -73,6 +80,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.load.assert_has_calls(load_calls)
         self.view.error_unable_to_open_file.assert_called_once_with(ws_name2)
         self.view.no_workspace_has_been_loaded.assert_called_once_with(ws_name1)
+        self.view.get_workspace_efixed.assert_not_called()
 
     def test_load_workspace_cancelled(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)

--- a/mslice/views/workspace_view.py
+++ b/mslice/views/workspace_view.py
@@ -16,6 +16,9 @@ class WorkspaceView(object):
     def get_workspace_new_name(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def get_workspace_efixed(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
     def get_workspace_index(self, ws_name):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 

--- a/mslice/widgets/workspacemanager/inputdialog.py
+++ b/mslice/widgets/workspacemanager/inputdialog.py
@@ -1,0 +1,35 @@
+from PyQt4.QtGui import QDialog, QFormLayout, QLabel, QDoubleSpinBox, QPushButton, QCheckBox
+
+class EfInputDialog(QDialog):
+    def __init__(self, parent = None):
+        super(EfInputDialog, self).__init__(parent)
+        self.setWindowTitle('Indirect Ef')
+        layout = QFormLayout(self)
+        self.text = QLabel(self)
+        layout.addRow(self.text)
+        self.efspin = QDoubleSpinBox(self)
+        self.efspin.setMinimum(0.0001)
+        self.efspin.setDecimals(4)
+        layout.addRow(self.efspin)
+        okbtn = QPushButton('OK')
+        okbtn.clicked.connect(self.accept)
+        self.allchk = QCheckBox('Apply to all workspaces', self)
+        self.allchk.hide()
+        layout.addRow(self.allchk, okbtn)
+
+    def showCheck(self):
+        self.allchk.show()
+
+    def value(self):
+        return self.efspin.value(), self.allchk.isChecked()
+
+    @staticmethod
+    def getEf(workspace, hasMultipleWS=False, parent = None):
+        """Static method to get an Ef"""
+        dialog = EfInputDialog(parent)
+        dialog.text.setText('Input Fixed Final Energy in meV for %s:' % (workspace))
+        if hasMultipleWS:
+            dialog.showCheck()
+        result = dialog.exec_()
+        Ef, allChecked = dialog.value()
+        return Ef, allChecked, result == QDialog.Accepted

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -98,11 +98,19 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         return str(path)
 
     def get_workspace_new_name(self):
-        name,success = QInputDialog.getText(self,"Workspace New Name","Enter the new name for the workspace :      ")
+        name, success = QInputDialog.getText(self,"Workspace New Name","Enter the new name for the workspace :      ")
         # The message above was padded with spaces to allow the whole title to show up
         if not success:
             raise ValueError('No Valid Name supplied')
         return str(name)
+ 
+    def get_workspace_efixed(self, workspace):
+        Ef, success = QInputDialog.getDouble(None, 'Indirect Ef', 
+                                             'Input Fixed Final Energy in meV for %s:' % (workspace),
+                                             value=0., min=0.1, decimals=5)
+        if not success:
+            raise ValueError('Fixed final energy not given')
+        return Ef
 
     def error_select_only_one_workspace(self):
         self._display_error('Please select only one workspace and then try again')

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -1,10 +1,11 @@
-from PyQt4.QtGui import QWidget,QListWidgetItem,QFileDialog, QInputDialog,QMessageBox
+from PyQt4.QtGui import QWidget, QListWidgetItem, QFileDialog, QInputDialog, QMessageBox
 from PyQt4.QtCore import pyqtSignal
 
 from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.views.workspace_view import WorkspaceView
 from .command import Command
+from .inputdialog import EfInputDialog
 from .workspacemanager_ui import Ui_Form
 
 class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
@@ -103,14 +104,12 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         if not success:
             raise ValueError('No Valid Name supplied')
         return str(name)
- 
-    def get_workspace_efixed(self, workspace):
-        Ef, success = QInputDialog.getDouble(None, 'Indirect Ef', 
-                                             'Input Fixed Final Energy in meV for %s:' % (workspace),
-                                             value=0., min=0.1, decimals=5)
+
+    def get_workspace_efixed(self, workspace, hasMultipleWS=False):
+        Ef, applyToAll, success = EfInputDialog.getEf(workspace, hasMultipleWS, None)
         if not success:
             raise ValueError('Fixed final energy not given')
-        return Ef
+        return Ef, applyToAll
 
     def error_select_only_one_workspace(self):
         self._display_error('Please select only one workspace and then try again')


### PR DESCRIPTION
Checks if loaded file is for an indirect geometry instrument and if so if `Efixed` is set. NXSPE files do not store `Efixed` which is need for conversion to `Q`. If `Efixed` is not set, creates a dialog to ask the user for `Efixed` and update the workspace with information.

**To test:**

Load an indirect geometry nxspe file (e.g. here: 
[iris_nxspe.zip](https://github.com/mantidproject/mslice/files/844198/iris_nxspe.zip) and check that a dialog appears asking for `Efixed` - for Iris data, put in Efixed=1.84 meV. Then check that calculate projections work for this dataset (previously it did not work). Check that loading of all other files (direct geometry nxspe, all nxs) files still work without the dialog appearing.

Fixes #117.
