### PR TITLE
Bin step size limits and using SofQW3 to Q conversion

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -20,6 +20,10 @@ class MainWindow(QMainWindow, Ui_MainWindow, MainView):
         cut_presenter = self.wgtCut.get_presenter()
         self._presenter = MainPresenter(self, workspace_presenter, slice_presenter , powder_presenter, cut_presenter)
 
+        workspace_provider = self.wgtWorkspacemanager.get_workspace_provider()
+        self.wgtPowder.set_workspace_provider(workspace_provider)
+        self.wgtSlice.set_workspace_provider(workspace_provider)
+
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
         self.wgtWorkspacemanager.error_occurred.connect(self.show_error)

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -23,6 +23,7 @@ class MainWindow(QMainWindow, Ui_MainWindow, MainView):
         workspace_provider = workspace_presenter.get_workspace_provider()
         powder_presenter.set_workspace_provider(workspace_provider)
         slice_presenter.set_workspace_provider(workspace_provider)
+        cut_presenter.set_workspace_provider(workspace_provider)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -20,9 +20,9 @@ class MainWindow(QMainWindow, Ui_MainWindow, MainView):
         cut_presenter = self.wgtCut.get_presenter()
         self._presenter = MainPresenter(self, workspace_presenter, slice_presenter , powder_presenter, cut_presenter)
 
-        workspace_provider = self.wgtWorkspacemanager.get_workspace_provider()
-        self.wgtPowder.set_workspace_provider(workspace_provider)
-        self.wgtSlice.set_workspace_provider(workspace_provider)
+        workspace_provider = workspace_presenter.get_workspace_provider()
+        powder_presenter.set_workspace_provider(workspace_provider)
+        slice_presenter.set_workspace_provider(workspace_provider)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -20,3 +20,9 @@ class CutAlgorithm(object):
 
     def get_other_axis(self, workspace, axis):
         pass
+
+    def get_axis_range(self, workspace, dimension_name):
+        pass
+
+    def set_workspace_provider(self, workspace_provider):
+        pass

--- a/mslice/models/cut/cut_plotter.py
+++ b/mslice/models/cut/cut_plotter.py
@@ -1,5 +1,5 @@
 class CutPlotter(object):
-    def __init__(self, cut_algorithm):
+    def __init__(self, _cut_algorithm):
         raise Exception('This class is an interface')
 
     def plot_cut(self, selected_workspace, cut_axis, integration_start, integration_end, norm_to_one, intensity_start,

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -152,7 +152,8 @@ class MantidCutAlgorithm(CutAlgorithm):
 
     def _normalize_workspace(self, workspace):
         assert isinstance(workspace, IMDHistoWorkspace)
-        assert workspace.displayNormalization() == MDNormalization.NumEventsNormalization
+        if workspace.displayNormalization() != MDNormalization.NumEventsNormalization:
+            workspace.setDisplayNormalization(MDNormalization.NumEventsNormalization)
         num_events = workspace.getNumEventsArray()
         average_event_intensity = self._num_events_normalized_array(workspace)
         average_event_range = average_event_intensity.max() - average_event_intensity.min()

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -186,3 +186,9 @@ class MantidCutAlgorithm(CutAlgorithm):
 
         if axis.step is None:
             axis.step = (axis.end - axis.start)/100
+
+    def get_axis_range(self, workspace, dimension_name):
+        return tuple(self._workspace_provider.get_limits(workspace, dimension_name))
+
+    def set_workspace_provider(self, workspace_provider):
+        self._workspace_provider = workspace_provider

--- a/mslice/models/projection/powder/projection_calculator.py
+++ b/mslice/models/projection/powder/projection_calculator.py
@@ -12,3 +12,6 @@ class ProjectionCalculator(object):
     @abc.abstractmethod
     def calculate_projection(self, input_workspace, axis1, axis2, units):
         pass
+
+    def set_workspace_provider(self, workspace_provider):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -71,9 +71,7 @@ class MantidSliceAlgorithm(SliceAlgorithm):
             axis.step = (axis.end - axis.start)/100
 
     def get_axis_range(self, workspace, dimension_name):
-        workspace = self._workspace_provider.get_workspace_handle(workspace)
-        if not isinstance(workspace, IMDEventWorkspace):
-            return "", ""
-        dim = workspace.getDimensionIndexByName(dimension_name)
-        dim = workspace.getDimension(dim)
-        return dim.getMinimum(), dim.getMaximum()
+        return tuple(self._workspace_provider.get_limits(workspace, dimension_name))
+
+    def set_workspace_provider(self, workspace_provider):
+        self._workspace_provider = workspace_provider

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -27,3 +27,6 @@ class MatplotlibSlicePlotter(SlicePlotter):
 
     def get_axis_range(self, workspace, dimension_name):
         return self._slice_algorithm.get_axis_range(workspace, dimension_name)
+
+    def set_workspace_provider(self, workspace_provider):
+        self._slice_algorithm.set_workspace_provider(workspace_provider)

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -8,3 +8,6 @@ class SliceAlgorithm(object):
 
     def get_available_axis(self, workspace):
         pass
+
+    def set_workspace_provider(self, workspace_provider):
+        pass

--- a/mslice/models/slice/slice_plotter.py
+++ b/mslice/models/slice/slice_plotter.py
@@ -11,3 +11,6 @@ class SlicePlotter():
 
     def get_axis_range(self, workspace, dimension_name):
         pass
+
+    def set_workspace_provider(self, workspace_provider):
+        pass

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -59,7 +59,6 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         # Checks that loaded data is in energy transfer.
         enAxis = ws_h.getAxis(0)
         if 'DeltaE' not in enAxis.getUnit().unitID():
-            raise RuntimeWarning('Workspace has no energy transfer unit: %s' % (enAxis.getUnit().unitID()))
             self._limits[ws_name] = None
             return
         en = ws_h.getAxis(0).extractValues()
@@ -149,9 +148,9 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         else:
             ws_h = self.get_workspace_handle(workspace)
             dim = ws_h.getDimension(ws_h.getDimensionIndexByName(axis))
-            min = dim.getMinimum()
-            max = dim.getMaximum()
-            return min, max, (max-min)/100.
+            minimum = dim.getMinimum()
+            maximum = dim.getMaximum()
+            return minimum, maximum, (maximum - minimum)/100.
 
     def propagate_properties(self, old_workspace, new_workspace):
         """Propagates MSlice only properties of workspaces, e.g. limits"""

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -22,6 +22,7 @@ class CutPresenter(object):
         self._saved_parameters = dict()
         self._previous_cut = None
         self._previous_axis = None
+        self._minimumStep = dict()
 
     def register_master(self, main_presenter):
         self._main_presenter = main_presenter
@@ -194,6 +195,12 @@ class CutPresenter(object):
                     self._cut_view.populate_input_fields(self._saved_parameters[workspace][current_axis])
             self._previous_cut = workspace
             self._previous_axis = current_axis
+            for ax in axis:
+                try:
+                    self._minimumStep[ax] = self._cut_algorithm.get_axis_range(workspace, ax)[2]
+                except (KeyError, RuntimeError):
+                    self._minimumStep[ax] = None
+            self._cut_view.set_minimum_step(self._minimumStep[axis[0]])
 
         elif self._cut_algorithm.is_cut(workspace):
             self._cut_view.plotting_params_only()
@@ -205,6 +212,7 @@ class CutPresenter(object):
                 return map(lambda x: "%.5f" % x, args)
             self._cut_view.populate_cut_params(*format_(cut_axis.start, cut_axis.end, cut_axis.step))
             self._cut_view.populate_integration_params(*format_(*integration_limits))
+            self._minimumStep[cut_axis.units] = None
 
         else:
             self._cut_view.clear_input_fields()
@@ -222,8 +230,11 @@ class CutPresenter(object):
             self._previous_axis = self._cut_view.get_cut_axis()
             if self._previous_axis in self._saved_parameters[self._previous_cut].keys():
                 self._cut_view.populate_input_fields(self._saved_parameters[self._previous_cut][self._previous_axis])
-        else:
-            self._cut_view.clear_input_fields()
+        minStep = self._minimumStep[self._cut_view.get_cut_axis()]
+        self._cut_view.set_minimum_step(minStep)
 
     def _clear_displayed_error(self):
         self._cut_view.clear_displayed_error()
+
+    def set_workspace_provider(self, workspace_provider):
+        self._cut_algorithm.set_workspace_provider(workspace_provider)

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -164,6 +164,15 @@ class CutPresenter(object):
             return None
         return float(x)
 
+    def _set_minimum_step(self, workspace, axis):
+        """Gets axes limits from workspace_provider and then sets the minimumStep dictionary with those values"""
+        for ax in axis:
+            try:
+                self._minimumStep[ax] = self._cut_algorithm.get_axis_range(workspace, ax)[2]
+            except (KeyError, RuntimeError):
+                self._minimumStep[ax] = None
+        self._cut_view.set_minimum_step(self._minimumStep[axis[0]])
+
     def workspace_selection_changed(self):
         if self._previous_cut is not None and self._previous_axis is not None:
             if self._previous_cut not in self._saved_parameters.keys():
@@ -195,12 +204,7 @@ class CutPresenter(object):
                     self._cut_view.populate_input_fields(self._saved_parameters[workspace][current_axis])
             self._previous_cut = workspace
             self._previous_axis = current_axis
-            for ax in axis:
-                try:
-                    self._minimumStep[ax] = self._cut_algorithm.get_axis_range(workspace, ax)[2]
-                except (KeyError, RuntimeError):
-                    self._minimumStep[ax] = None
-            self._cut_view.set_minimum_step(self._minimumStep[axis[0]])
+            self._set_minimum_step(workspace, axis)
 
         elif self._cut_algorithm.is_cut(workspace):
             self._cut_view.plotting_params_only()

--- a/mslice/presenters/interfaces/main_presenter.py
+++ b/mslice/presenters/interfaces/main_presenter.py
@@ -1,5 +1,5 @@
 class MainPresenterInterface(object):
-    def __init__(self, main_view):
+    def __init__(self, _main_view):
         raise Exception("This class is an abstract interface and must no be instantiated")
 
     def get_selected_workspaces(self):

--- a/mslice/presenters/interfaces/powder_projection_presenter.py
+++ b/mslice/presenters/interfaces/powder_projection_presenter.py
@@ -9,3 +9,6 @@ class PowderProjectionPresenterInterface(object):
 
     def notify(self, command):
         raise NotImplementedError("This method must be overriden in implementation")
+
+    def set_workspace_provider(self, workspace_provider):
+        raise NotImplementedError("This method must be overriden in implementation")

--- a/mslice/presenters/interfaces/powder_projection_presenter.py
+++ b/mslice/presenters/interfaces/powder_projection_presenter.py
@@ -1,7 +1,7 @@
 
 class PowderProjectionPresenterInterface(object):
 
-    def __init__(self, powder_view, projection_calculator):
+    def __init__(self, _powder_view, _projection_calculator):
         raise Exception("This interface must not be instantiated")
 
     def register_master(self, main_view):

--- a/mslice/presenters/interfaces/slice_plotter_presenter.py
+++ b/mslice/presenters/interfaces/slice_plotter_presenter.py
@@ -1,5 +1,5 @@
 class SlicePlotterPresenterInterface(object):
-    def __init__(self, slice_view, slice_plotter):
+    def __init__(self, _slice_view, _slice_plotter):
         raise Exception("This interface class must not be instantiated")
 
     def register_master(self, main_view):

--- a/mslice/presenters/interfaces/slice_plotter_presenter.py
+++ b/mslice/presenters/interfaces/slice_plotter_presenter.py
@@ -10,3 +10,6 @@ class SlicePlotterPresenterInterface(object):
 
     def workspace_selection_changed(self):
         raise NotImplementedError("This method must be overriden in implementation")
+
+    def set_workspace_provider(self, workspace_provider):
+        raise NotImplementedError("This method must be overriden in implementation")

--- a/mslice/presenters/interfaces/workspace_manager_presenter.py
+++ b/mslice/presenters/interfaces/workspace_manager_presenter.py
@@ -1,5 +1,5 @@
 class WorkspaceManagerPresenterInterface(object):
-    def __init__(self, workspace_view, workspace_provider):
+    def __init__(self, _workspace_view, _workspace_provider):
         raise Exception("Interface Class must not be instantiated")
 
     def register_master(self, main_view):
@@ -14,7 +14,7 @@ class WorkspaceManagerPresenterInterface(object):
     def set_selected_workspaces(self, workspace_list):
         raise NotImplementedError("This method must be overriden in implementation")
 
-    def get_workspace_provider(self, workspace_provider):
+    def get_workspace_provider(self):
         raise NotImplementedError("This method must be overriden in implementation")
 
     def update_displayed_workspaces(self):

--- a/mslice/presenters/interfaces/workspace_manager_presenter.py
+++ b/mslice/presenters/interfaces/workspace_manager_presenter.py
@@ -14,5 +14,8 @@ class WorkspaceManagerPresenterInterface(object):
     def set_selected_workspaces(self, workspace_list):
         raise NotImplementedError("This method must be overriden in implementation")
 
+    def get_workspace_provider(self, workspace_provider):
+        raise NotImplementedError("This method must be overriden in implementation")
+
     def update_displayed_workspaces(self):
         raise NotImplementedError("This method must be overriden in implementation")

--- a/mslice/presenters/powder_projection_presenter.py
+++ b/mslice/presenters/powder_projection_presenter.py
@@ -76,3 +76,6 @@ class PowderProjectionPresenter(PowderProjectionPresenterInterface):
         # Assuming DeltaE is always the last axes option.
         if axes[curr_axis] != self._available_axes[-1] and axes[other_axis] != self._available_axes[-1]:
             axes_set[other_axis](self._available_axes[-1])
+
+    def set_workspace_provider(self, workspace_provider):
+        self._projection_calculator.set_workspace_provider(workspace_provider)

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -162,12 +162,10 @@ class SlicePlotterPresenter(SlicePlotterPresenterInterface):
         axis = self._slice_plotter.get_available_axis(workspace_selection)
         self._slice_view.populate_slice_x_options(axis)
         self._slice_view.populate_slice_y_options(axis[::-1])
-        x_min, x_max = self._slice_plotter.get_axis_range(workspace_selection,self._slice_view.get_slice_x_axis())
-        y_min, y_max = self._slice_plotter.get_axis_range(workspace_selection,self._slice_view.get_slice_y_axis())
         try:
-            x_step = (x_max - x_min)/100
-            y_step = (y_max - y_min)/100
-        except TypeError:
+            x_min, x_max, x_step = self._slice_plotter.get_axis_range(workspace_selection,self._slice_view.get_slice_x_axis())
+            y_min, y_max, y_step = self._slice_plotter.get_axis_range(workspace_selection,self._slice_view.get_slice_y_axis())
+        except (KeyError, RuntimeError):
             self._slice_view.clear_input_fields()
             return
         self._slice_view.populate_slice_x_params(*map(lambda x: "%.5f" % x, (x_min, x_max, x_step)))
@@ -175,3 +173,6 @@ class SlicePlotterPresenter(SlicePlotterPresenterInterface):
 
     def _clear_displayed_error(self):
         self._slice_view.clear_displayed_error()
+
+    def set_workspace_provider(self, workspace_provider):
+        self._slice_plotter.set_workspace_provider(workspace_provider)

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -147,6 +147,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 index_list.append(get_index(get_name(item)))
         self._workspace_manger_view.set_workspace_selected(index_list)
 
+    def get_workspace_provider(self):
+        return self._work_spaceprovider
+
     def update_displayed_workspaces(self):
         """Update the workspaces shown to user.
 

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -134,11 +134,11 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         """Get the currently selected workspaces from the user"""
         return self._workspace_manger_view.get_workspace_selected()
 
-    def set_selected_workspaces(self, list):
+    def set_selected_workspaces(self, workspace_list):
         get_index = self._workspace_manger_view.get_workspace_index
         get_name = self._work_spaceprovider.get_workspace_name
         index_list = []
-        for item in list:
+        for item in workspace_list:
             if isinstance(item, basestring):
                 index_list.append(get_index(item))
             elif isinstance(item, int):

--- a/mslice/tests/app_test.py
+++ b/mslice/tests/app_test.py
@@ -63,3 +63,4 @@ class AppTests(unittest.TestCase):
         MainWindow()
         self.projection_calculator.set_workspace_provider.assert_called_with(self.workspace_provider)
         self.slice_plotter.set_workspace_provider.assert_called_with(self.workspace_provider)
+        self.cut_algorithm.set_workspace_provider.assert_called_with(self.workspace_provider)

--- a/mslice/tests/app_test.py
+++ b/mslice/tests/app_test.py
@@ -1,0 +1,65 @@
+import mock
+import unittest
+from mock import patch
+import PyQt4
+
+from mslice.app.mainwindow import MainWindow
+from mslice.app.mainwindow_ui import Ui_MainWindow
+from mslice.presenters.powder_projection_presenter import PowderProjectionPresenter
+from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
+from mslice.presenters.slice_plotter_presenter import SlicePlotterPresenter
+from mslice.presenters.cut_presenter import CutPresenter
+from mslice.views.mainview import MainView
+from mslice.views.powder_projection_view import PowderView
+from mslice.views.slice_plotter_view import SlicePlotterView
+from mslice.views.cut_view import CutView
+from mslice.views.workspace_view import WorkspaceView
+from mslice.models.projection.powder.projection_calculator import ProjectionCalculator
+from mslice.models.slice.slice_plotter import SlicePlotter
+from mslice.models.workspacemanager.workspace_provider import WorkspaceProvider
+from mslice.models.cut.cut_algorithm import CutAlgorithm
+from mslice.models.cut.cut_plotter import CutPlotter
+
+mainview = mock.create_autospec(MainView)
+slice_view = mock.create_autospec(SlicePlotterView)
+powder_view = mock.create_autospec(PowderView)
+cut_view = mock.create_autospec(CutView)
+workspace_view = mock.create_autospec(WorkspaceView)
+
+class AppTests(unittest.TestCase):
+    def setUp(self):
+        self.workspace_provider = mock.create_autospec(WorkspaceProvider)
+        self.slice_plotter = mock.create_autospec(SlicePlotter)
+        self.projection_calculator = mock.create_autospec(ProjectionCalculator)
+        self.cut_algorithm = mock.create_autospec(CutAlgorithm)
+        self.cut_plotter = mock.create_autospec(CutPlotter)
+        # using globals is a bit ugly but I can't think of another way to access the required variables
+        # because they are only defined in the scope of MainWindow / setupUI
+        global workspace_view
+        global slice_view
+        global powder_view
+        global cut_view
+        self.slice_presenter = SlicePlotterPresenter(slice_view, self.slice_plotter)
+        self.workspace_presenter = WorkspaceManagerPresenter(workspace_view, self.workspace_provider)
+        self.powder_presenter = PowderProjectionPresenter(powder_view, self.projection_calculator)
+        self.cut_presenter = CutPresenter(cut_view, self.cut_algorithm, self.cut_plotter)
+        workspace_view.get_presenter = mock.Mock(return_value=self.workspace_presenter)
+        slice_view.get_presenter = mock.Mock(return_value=self.slice_presenter)
+        powder_view.get_presenter = mock.Mock(return_value=self.powder_presenter)
+        cut_view.get_presenter = mock.Mock(return_value=self.cut_presenter)
+
+    def mock_setupUi(self, mock_setup):
+        self.wgtWorkspacemanager = workspace_view
+        self.wgtSlice = slice_view
+        self.wgtPowder = powder_view
+        self.wgtCut = cut_view
+        global mainview
+        mainview = mock_setup
+
+    @patch.object(Ui_MainWindow, 'setupUi', mock_setupUi)
+    @patch.object(PyQt4.QtGui.QMainWindow, '__init__', lambda x: None)
+    def test_mainwindow(self):
+        """Test the MainWindow initialises correctly"""
+        MainWindow()
+        self.projection_calculator.set_workspace_provider.assert_called_with(self.workspace_provider)
+        self.slice_plotter.set_workspace_provider.assert_called_with(self.workspace_provider)

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -289,7 +289,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
         dims = ['dim1', 'dim2']
         self.slice_plotter.get_available_axis = mock.Mock(return_value=dims)
-        self.slice_plotter.get_axis_range = mock.Mock(return_value=(0,1))
+        self.slice_plotter.get_axis_range = mock.Mock(return_value=(0,1,0.1))
         slice_plotter_presenter.workspace_selection_changed()
         self.slice_view.populate_slice_x_options.assert_called()
         self.slice_view.populate_slice_y_options.assert_called()

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -271,6 +271,59 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_plotter.plot_slice.assert_not_called( )
         self.slice_view.error_invalid_intensity_params.assert_called_once_with()
 
+    def test_plot_slice_error_handling(self):
+        self.slice_plotter_presenter = SlicePlotterPresenter( self.slice_view, self.slice_plotter )
+        self.slice_plotter_presenter.register_master(self.main_presenter)
+        self.slice_plotter_presenter.register_master(self.main_presenter)
+        self.slice_plotter_presenter.register_master(self.main_presenter)
+        x = Axis('x', '0', '10' ,'1')
+        y = Axis('y', '2', '8', '3')
+        intensity_start = '7'
+        intensity_end = '8'
+        norm_to_one = False
+        smoothing = '10'
+        colourmap = 'colormap'
+        selected_workspace = 'workspace1'
+        self.slice_view.get_slice_x_axis.return_value = x.units
+        self.slice_view.get_slice_x_start.return_value = x.start
+        self.slice_view.get_slice_x_end.return_value = x.end
+        self.slice_view.get_slice_x_step.return_value = x.step
+        self.slice_view.get_slice_y_axis.return_value = y.units
+        self.slice_view.get_slice_y_start.return_value = y.start
+        self.slice_view.get_slice_y_end.return_value = y.end
+        self.slice_view.get_slice_y_step.return_value = y.step
+        self.slice_view.get_slice_intensity_start.return_value = intensity_start
+        self.slice_view.get_slice_intensity_end.return_value = intensity_end
+        self.slice_view.get_slice_is_norm_to_one.return_value = norm_to_one
+        self.slice_view.get_slice_smoothing.return_value = smoothing
+        self.slice_view.get_slice_colourmap.return_value = colourmap
+        plot_info = ("plot_data", "boundaries", "colormap", "norm")
+        self.slice_plotter.plot_slice = mock.Mock( return_value=plot_info )
+        # Test empty workspace, multiple workspaces
+        self.main_presenter.get_selected_workspaces.return_value = []
+        self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_view.error_select_one_workspace.assert_called()
+        self.main_presenter.get_selected_workspaces.return_value = [selected_workspace, selected_workspace]
+        self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_view.error_select_one_workspace.assert_called()
+        # Test invalid axes
+        self.main_presenter.get_selected_workspaces.return_value = [selected_workspace]
+        self.slice_view.get_slice_y_axis.return_value = x.units
+        self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_view.error_invalid_plot_parameters.assert_called()
+        # Test invalid smoothing parameters
+        self.slice_view.get_slice_y_axis.return_value = y.units
+        self.slice_view.get_slice_smoothing.return_value = 'a'
+        self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_view.error_invalid_smoothing_params.assert_called()
+        # Simulate matplotlib error
+        self.slice_view.get_slice_smoothing.return_value = smoothing
+        self.slice_plotter.plot_slice = mock.Mock(side_effect=ValueError('minvalue must be less than or equal to maxvalue'))
+        self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_view.error_invalid_intensity_params.assert_called()
+        self.slice_plotter.plot_slice = mock.Mock(side_effect=ValueError('something bad'))
+        self.assertRaises(ValueError, self.slice_plotter_presenter.notify, Command.DisplaySlice)
+
     def test_workspace_selection_changed_multiple_selected_empty_options_success(self):
         slice_plotter_presenter = SlicePlotterPresenter( self.slice_view, self.slice_plotter )
         slice_plotter_presenter.register_master(self.main_presenter)
@@ -295,6 +348,10 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.populate_slice_y_options.assert_called()
         self.slice_plotter.get_available_axis.assert_called()
         self.slice_plotter.get_axis_range.assert_called()
+        # Test error handling
+        self.slice_plotter.get_axis_range = mock.Mock(side_effect=KeyError)
+        slice_plotter_presenter.workspace_selection_changed()
+        self.slice_view.clear_input_fields.assert_called()
 
     def test_notify_presenter_clears_error(self):
         presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -1,6 +1,8 @@
 
 
 class CutView:
+    error_occurred = None
+
     def get_cut_axis(self):
         pass
 

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -42,6 +42,9 @@ class CutView:
     def set_cut_axis(self, axis_name):
         pass
 
+    def set_minimum_step(self, value):
+        pass
+
     def error_select_a_workspace(self):
         pass
 

--- a/mslice/views/powder_projection_view.py
+++ b/mslice/views/powder_projection_view.py
@@ -32,5 +32,8 @@ class PowderView(object):
     def set_powder_u2(self, name):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def set_workspace_provider(self, workspace_provider):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
     def clear_displayed_error(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/mslice/views/powder_projection_view.py
+++ b/mslice/views/powder_projection_view.py
@@ -2,6 +2,8 @@
 
 
 class PowderView(object):
+    error_occurred = None
+
     def __init__(self):
         raise Exception("This abstract class should not be instantiated")
 
@@ -32,8 +34,8 @@ class PowderView(object):
     def set_powder_u2(self, name):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def set_workspace_provider(self, workspace_provider):
+    def clear_displayed_error(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def clear_displayed_error(self):
+    def get_presenter(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/mslice/views/slice_plotter_view.py
+++ b/mslice/views/slice_plotter_view.py
@@ -1,6 +1,8 @@
 
 
 class SlicePlotterView:
+    error_occurred = None
+
     def __init__(self):
         raise Exception("This abstract class must not be instantiated")
 
@@ -41,9 +43,6 @@ class SlicePlotterView:
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_slice_colourmap(self):
-        raise NotImplementedError("This method must be implemented in a concrete view before being called")
-
-    def set_workspace_provider(self, workspace_provider):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def error_invalid_x_params(self):
@@ -89,4 +88,7 @@ class SlicePlotterView:
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def clear_displayed_error(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def get_presenter(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/mslice/views/slice_plotter_view.py
+++ b/mslice/views/slice_plotter_view.py
@@ -43,6 +43,9 @@ class SlicePlotterView:
     def get_slice_colourmap(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def set_workspace_provider(self, workspace_provider):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
     def error_invalid_x_params(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 

--- a/mslice/views/workspace_view.py
+++ b/mslice/views/workspace_view.py
@@ -40,6 +40,9 @@ class WorkspaceView(object):
     def get_presenter(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def get_workspace_provider(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
     def confirm_overwrite_workspace(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 

--- a/mslice/views/workspace_view.py
+++ b/mslice/views/workspace_view.py
@@ -18,7 +18,7 @@ class WorkspaceView(object):
     def get_workspace_new_name(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def get_workspace_efixed(self):
+    def get_workspace_efixed(self, workspace, hasMultipleWS=False):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_workspace_index(self, ws_name):

--- a/mslice/views/workspace_view.py
+++ b/mslice/views/workspace_view.py
@@ -1,6 +1,8 @@
 
 
 class WorkspaceView(object):
+    error_occurred = None
+
     def __init__(self):
         raise Exception("This abstact base class must not be instantiated")
 
@@ -38,9 +40,6 @@ class WorkspaceView(object):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def get_presenter(self):
-        raise NotImplementedError("This method must be implemented in a concrete view before being called")
-
-    def get_workspace_provider(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
     def confirm_overwrite_workspace(self):

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -44,7 +44,7 @@ class CutWidget(QWidget, CutView, Ui_Form):
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
 
-    def axis_changed(self, *args):
+    def axis_changed(self, _changed_index):
         self._presenter.notify(Command.AxisChanged)
 
     def get_presenter(self):

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -35,11 +35,28 @@ class CutWidget(QWidget, CutView, Ui_Form):
         cut_plotter = MatplotlibCutPlotter(cut_alogrithm)
         self._presenter = CutPresenter(self, cut_alogrithm, cut_plotter)
         self.cmbCutAxis.currentIndexChanged.connect(self.axis_changed)
+        self._minimumStep = None
+        self.lneCutStep.editingFinished.connect(self._step_edited)
 
     def _btn_clicked(self):
         sender = self.sender()
         command = self._command_lookup[sender]
         self._presenter.notify(command)
+
+    def _step_edited(self):
+        """Checks that user inputted step size is not too small."""
+        if self._minimumStep:
+            try:
+                value = float(self.lneCutStep.text())
+            except ValueError:
+                return
+            if value == 0:
+                self.lneCutStep.setText('%.5f' % (self._minimumStep))
+                self._display_error('Setting step size to default.')
+            elif value < (self._minimumStep / 10000.):
+                self._display_error('Step size too small!')
+                return False
+        return True
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
@@ -89,6 +106,9 @@ class CutWidget(QWidget, CutView, Ui_Form):
             self.cmbCutAxis.blockSignals(True)
             self.cmbCutAxis.setCurrentIndex(index[0])
             self.cmbCutAxis.blockSignals(False)
+
+    def set_minimum_step(self, value):
+        self._minimumStep = value
 
     def populate_cut_axis_options(self, options):
         self.cmbCutAxis.blockSignals(True)

--- a/mslice/widgets/projection/powder/powder.py
+++ b/mslice/widgets/projection/powder/powder.py
@@ -86,9 +86,6 @@ class PowderWidget(QWidget, Ui_Form, PowderView):
     def get_powder_units(self):
         return str(self.cmbPowderUnits.currentText())
 
-    def set_workspace_provider(self, workspace_provider):
-        self._presenter.set_workspace_provider(workspace_provider)
-
     def clear_displayed_error(self):
         self._display_error("")
 

--- a/mslice/widgets/projection/powder/powder.py
+++ b/mslice/widgets/projection/powder/powder.py
@@ -86,6 +86,9 @@ class PowderWidget(QWidget, Ui_Form, PowderView):
     def get_powder_units(self):
         return str(self.cmbPowderUnits.currentText())
 
+    def set_workspace_provider(self, workspace_provider):
+        self._presenter.set_workspace_provider(workspace_provider)
+
     def clear_displayed_error(self):
         self._display_error("")
 

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -80,6 +80,9 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
     def get_slice_intensity_end(self):
         return str(self.lneSliceIntensityEnd.text())
 
+    def set_workspace_provider(self, workspace_provider):
+        self._presenter.set_workspace_provider(workspace_provider)
+
     def populate_colormap_options(self, colormaps):
         self.cmbSliceColormap.clear()
         for colormap in colormaps:

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -31,12 +31,27 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
         self.display_errors_to_statusbar = True
         plotter = MatplotlibSlicePlotter(MantidSliceAlgorithm())
         self._presenter = SlicePlotterPresenter(self, plotter)
+        # Each time the fields are populated, set a minimum step size
+        self._minimumStep = {}
+        self.lneSliceXStep.textEdited.connect(lambda txt: self._step_edited('x', txt, self.lneSliceXStep))
+        self.lneSliceYStep.textEdited.connect(lambda txt: self._step_edited('y', txt, self.lneSliceYStep))
 
     def get_presenter(self):
         return self._presenter
 
     def _btn_clicked(self):
         self._presenter.notify(Command.DisplaySlice)
+
+    def _step_edited(self, idx, text, lineEdit):
+        """Checks that user inputted step size is not too small."""
+        if self._minimumStep:
+            try:
+                value = float(text)
+            except ValueError:
+                return
+            if value < (self._minimumStep[idx] / 100.):
+                lineEdit.setText(str(self._minimumStep[idx]))
+                self._display_error('Step size too small!')
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
@@ -79,9 +94,6 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
 
     def get_slice_intensity_end(self):
         return str(self.lneSliceIntensityEnd.text())
-
-    def set_workspace_provider(self, workspace_provider):
-        self._presenter.set_workspace_provider(workspace_provider)
 
     def populate_colormap_options(self, colormaps):
         self.cmbSliceColormap.clear()
@@ -129,11 +141,15 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
         self.lneSliceXStart.setText(x_start)
         self.lneSliceXEnd.setText(x_end)
         self.lneSliceXStep.setText(x_step)
+        if x_step:
+            self._minimumStep['x'] = float(x_step)
 
     def populate_slice_y_params(self, y_start, y_end, y_step):
         self.lneSliceYStart.setText(y_start)
         self.lneSliceYEnd.setText(y_end)
         self.lneSliceYStep.setText(y_step)
+        if y_step:
+            self._minimumStep['y'] = float(y_step)
 
     def clear_input_fields(self):
         self.populate_slice_x_options([])
@@ -144,6 +160,7 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
         self.lneSliceIntensityEnd.setText("")
         self.lneSliceSmoothing.setText("")
         self.rdoSliceNormToOne.setChecked(0)
+        self._minimumStep = {}
 
     def clear_displayed_error(self):
         self._display_error("")

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -145,6 +145,9 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
     def get_presenter(self):
         return self._presenter
 
+    def get_workspace_provider(self):
+        return self._presenter.get_workspace_provider()
+
     def list_item_changed(self, *args):
         self._presenter.notify(Command.SelectionChanged)
 

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -145,7 +145,7 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
     def get_presenter(self):
         return self._presenter
 
-    def list_item_changed(self, *args):
+    def list_item_changed(self):
         self._presenter.notify(Command.SelectionChanged)
 
     def error_unable_to_save(self):

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -145,9 +145,6 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
     def get_presenter(self):
         return self._presenter
 
-    def get_workspace_provider(self):
-        return self._presenter.get_workspace_provider()
-
     def list_item_changed(self, *args):
         self._presenter.notify(Command.SelectionChanged)
 


### PR DESCRIPTION
Implements using `SofQWNormalisedPolygons` (`SofQW3`) to rebin data (usually from MARI or with a "rings" mapping) where pixel sizes are large before conversion to MDWorkspace with the `CopyToMD` method. For large datasets (and for indirect geometry data), the direct conversion to `|Q|` using `ConvertToMD` is still used because the centre-point rebinning of `BinMD` is not a problem in those cases.

Also, implemented a calculation of the `|Q|` limits and steps from the detector angles in the datafile at loading, which is attached to the `WorkspaceProvider` as a property. This required changing the `MainWindow` code to ensure that all widgets and presenters run the same instance of `WorkspaceProvider`. 

**To test:**

Load data (single or multiple files). If the data is direct inelastic from MARI, check that when "calculate projection" is run that `SofQWNormalisedPolygons` is called. If the data is direct inelastic with "one2one" mapping from Merlin or LET, check that `SofQWNormalisedPolygons` is *not* called - and same for Iris or Osiris data.

When plotting a slice, put in a step size of `0` or a very small number (e.g. `1e-6`) and check that it resets it back to the `optimum` step size, and displays an error message in the status bar.

Fixes #118, #28, #48, #114
