### PR TITLE
General bug fixes

### DIFF
--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -17,6 +17,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
                    interpolation='none', hold=False)
         plt.xlabel(x_axis.units)
         plt.ylabel(y_axis.units)
+        plt.title(selected_workspace)
         plt.draw_all()
 
     def get_available_colormaps(self):

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -207,6 +207,7 @@ class CutPresenter(object):
             self._set_minimum_step(workspace, axis)
 
         elif self._cut_algorithm.is_cut(workspace):
+            self._cut_view.clear_input_fields()
             self._cut_view.plotting_params_only()
             cut_axis, integration_limits, is_normed = self._cut_algorithm.get_cut_params(workspace)
             if is_normed:
@@ -217,6 +218,8 @@ class CutPresenter(object):
             self._cut_view.populate_cut_params(*format_(cut_axis.start, cut_axis.end, cut_axis.step))
             self._cut_view.populate_integration_params(*format_(*integration_limits))
             self._minimumStep[cut_axis.units] = None
+            self._previous_cut = None
+            self._previous_axis = None
 
         else:
             self._cut_view.clear_input_fields()

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -156,9 +156,11 @@ class SlicePlotterPresenter(SlicePlotterPresenterInterface):
         workspace_selection = self._get_main_presenter().get_selected_workspaces()
         if len(workspace_selection) != 1:
             self._slice_view.clear_input_fields()
+            self._slice_view.disable()
             return
         workspace_selection = workspace_selection[0]
 
+        self._slice_view.enable()
         axis = self._slice_plotter.get_available_axis(workspace_selection)
         self._slice_view.populate_slice_x_options(axis)
         self._slice_view.populate_slice_y_options(axis[::-1])
@@ -167,6 +169,7 @@ class SlicePlotterPresenter(SlicePlotterPresenterInterface):
             y_min, y_max, y_step = self._slice_plotter.get_axis_range(workspace_selection,self._slice_view.get_slice_y_axis())
         except (KeyError, RuntimeError):
             self._slice_view.clear_input_fields()
+            self._slice_view.disable()
             return
         self._slice_view.populate_slice_x_params(*map(lambda x: "%.5f" % x, (x_min, x_max, x_step)))
         self._slice_view.populate_slice_y_params(*map(lambda x: "%.5f" % x, (y_min, y_max, y_step)))

--- a/mslice/views/slice_plotter_view.py
+++ b/mslice/views/slice_plotter_view.py
@@ -92,3 +92,9 @@ class SlicePlotterView:
 
     def get_presenter(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def disable(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def enable(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -167,5 +167,37 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
         self.rdoSliceNormToOne.setChecked(0)
         self._minimumStep = {}
 
+    def disable(self):
+        self.cmbSliceXAxis.setEnabled(False)
+        self.cmbSliceYAxis.setEnabled(False)
+        self.lneSliceXStart.setEnabled(False)
+        self.lneSliceXEnd.setEnabled(False)
+        self.lneSliceXStep.setEnabled(False)
+        self.lneSliceYStart.setEnabled(False)
+        self.lneSliceYEnd.setEnabled(False)
+        self.lneSliceYStep.setEnabled(False)
+        self.lneSliceIntensityStart.setEnabled(False)
+        self.lneSliceIntensityEnd.setEnabled(False)
+        self.lneSliceSmoothing.setEnabled(False)
+        self.rdoSliceNormToOne.setEnabled(False)
+        self.btnSliceDisplay.setEnabled(False)
+        self.cmbSliceColormap.setEnabled(False)
+
+    def enable(self):
+        self.cmbSliceXAxis.setEnabled(True)
+        self.cmbSliceYAxis.setEnabled(True)
+        self.lneSliceXStart.setEnabled(True)
+        self.lneSliceXEnd.setEnabled(True)
+        self.lneSliceXStep.setEnabled(True)
+        self.lneSliceYStart.setEnabled(True)
+        self.lneSliceYEnd.setEnabled(True)
+        self.lneSliceYStep.setEnabled(True)
+        self.lneSliceIntensityStart.setEnabled(True)
+        self.lneSliceIntensityEnd.setEnabled(True)
+        self.lneSliceSmoothing.setEnabled(True)
+        self.rdoSliceNormToOne.setEnabled(True)
+        self.btnSliceDisplay.setEnabled(True)
+        self.cmbSliceColormap.setEnabled(True)
+
     def clear_displayed_error(self):
         self._display_error("")


### PR DESCRIPTION
This PR addresses several issues:

  - #124 - Selecting a previously saved cut does not clear the `width` parameter but disables the edit box, so if this value was previously non-`None`, it can give a repeated set of the same cuts. Also fixed a bug in the code to remember previously set parameters - non-cutable saved cuts will overwrite the parameters of the previous cutable workspace.
  - #123 - Make the workspace name the slice title
  - #72 - The slice widgets are now disabled when a non-sliceable workspace is selected. (sorry wrong issue in the commit)

**To test:**

Load a dataset and calculate projection - check that selecting the projected workspace enables the slice widgets, and selecting the original dataset disables it. Check with other non-sliceable workspaces (e.g. saved cuts) and check that workspaces which should be sliceable *are*.

Plot the slice and check it has the correct title (name of the workspace).

Make a cut with a non-zero width and save the workspaces. Check that the saved workspaces are plotted correctly (e.g. without a width parameter, and not repeated in the plot), and that after clicking on them, when clicking back on the original (cutable) workspace that the cut parameters remained what you had set them.

Fixes #124, #123, #72
