### PR TITLE
Logarithmic scale on cuts

### DIFF
--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -4,6 +4,7 @@ from matplotlib.backends.backend_qt4 import NavigationToolbar2QT
 from matplotlib.container import ErrorbarContainer
 import matplotlib.colors as colors
 from PyQt4.QtCore import Qt
+import numpy as np
 
 from .plot_window_ui import Ui_MainWindow
 from .base_qt_plot_window import BaseQtPlotWindow
@@ -53,14 +54,22 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         if new_config:
             self._apply_config(new_config)
 
+    def _get_min(self, data, absolute_minimum=-np.inf):
+        """Determines the minimum of a set of numpy arrays"""
+        data = data if isinstance(data, list) else [data]
+        running_min = []
+        for values in data:
+            try:
+                running_min.append(np.min(values[values > absolute_minimum]))
+            except ValueError:  # If data is empty or not array of numbers
+                pass
+        return np.min(running_min) if running_min else absolute_minimum
+
     def _apply_config(self, plot_config):
         current_axis = self.canvas.figure.gca()
         current_axis.set_title(plot_config.title)
         current_axis.set_xlabel(plot_config.xlabel)
         current_axis.set_ylabel(plot_config.ylabel)
-
-        current_axis.set_xlim(*plot_config.x_range)
-        current_axis.set_ylim(*plot_config.y_range)
 
         if current_axis.get_images():
             images = current_axis.get_images()
@@ -82,6 +91,22 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
                 norm = colors.Normalize(vmin, vmax)
                 mappable.set_norm(norm)
                 self.canvas.figure.colorbar(mappable)
+        else:
+            if plot_config.xlog:
+                current_axis.set_xscale('log', nonposx='mask')
+                xmin = self._get_min([ll.get_xdata() for ll in current_axis.get_lines()], absolute_minimum=0.)
+                plot_config.x_range = (xmin, plot_config.x_range[1])
+            else:
+                current_axis.set_xscale('linear')
+            if plot_config.ylog:
+                current_axis.set_yscale('log', nonposy='mask')
+                ymin = self._get_min([ll.get_ydata() for ll in current_axis.get_lines()], absolute_minimum=0.)
+                plot_config.y_range = (ymin, plot_config.y_range[1])
+            else:
+                current_axis.set_yscale('linear')
+
+        current_axis.set_xlim(*plot_config.x_range)
+        current_axis.set_ylim(*plot_config.y_range)
 
         legend_config = plot_config.legend
         for handle in legend_config.handles:
@@ -175,11 +200,15 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         if not current_axis.get_images():
             colorbar_range = None, None
             logarithmic = None
+            xlog = 'log' in current_axis.get_xscale()
+            ylog = 'log' in current_axis.get_yscale()
         else:
             mappable = current_axis.get_images()[0]
             colorbar_range = mappable.get_clim()
             norm = mappable.norm
             logarithmic = isinstance(norm, colors.LogNorm)
+            xlog = None
+            ylog = None
 
         # if a legend has been set to '' or has been hidden (by prefixing with '_)then it will be ignored by
         # axes.get_legend_handles_labels()
@@ -194,9 +223,9 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             visible = getattr(current_axis, 'legend_') is not None
             legend = LegendDescriptor(visible=visible, handles=handles)
         has_errorbars  = self._has_errorbars()
-        return PlotConfig(title=title, x_axis_label=xlabel, y_axis_label=ylabel, legends=legend,
-                          errorbars_enabled=has_errorbars,
-                          x_range=x_range,
-                          y_range=y_range,
+        return PlotConfig(title=title, xlabel=xlabel, ylabel=ylabel, legend=legend,
+                          errorbars=has_errorbars,
+                          x_range=x_range, xlog=xlog,
+                          y_range=y_range, ylog=ylog,
                           colorbar_range=colorbar_range,
                           logarithmic=logarithmic)

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -4,12 +4,15 @@ from .plot_options_ui import Ui_Dialog
 
 
 class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
-    def __init__(self, current_config):
+    def __init__(self, current_config): # noqa: C901
         super(PlotOptionsDialog, self).__init__()
         self.setupUi(self)
-        if current_config.title is not None: self.lneFigureTitle.setText(current_config.title)
-        if current_config.xlabel is not None: self.lneXAxisLabel.setText(current_config.xlabel)
-        if current_config.ylabel is not None: self.lneYAxisLabel.setText(current_config.ylabel)
+        if current_config.title is not None:
+            self.lneFigureTitle.setText(current_config.title)
+        if current_config.xlabel is not None:
+            self.lneXAxisLabel.setText(current_config.xlabel)
+        if current_config.ylabel is not None:
+            self.lneYAxisLabel.setText(current_config.ylabel)
         if None not in current_config.x_range:
             self.lneXMin.setText(str(current_config.x_range[0]))
             self.lneXMax.setText(str(current_config.x_range[1]))
@@ -23,9 +26,12 @@ class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
             self.chkYLog.hide()
         else:
             self.groupBox_4.hide()
-        if current_config.logarithmic is not None: self.chkLogarithmic.setChecked(current_config.logarithmic)
-        if current_config.xlog is not None: self.chkXLog.setChecked(current_config.xlog)
-        if current_config.ylog is not None: self.chkYLog.setChecked(current_config.ylog)
+        if current_config.logarithmic is not None:
+            self.chkLogarithmic.setChecked(current_config.logarithmic)
+        if current_config.xlog is not None:
+            self.chkXLog.setChecked(current_config.xlog)
+        if current_config.ylog is not None:
+            self.chkYLog.setChecked(current_config.ylog)
 
         self._legend_widgets = []
         self.chkShowLegends.setChecked(current_config.legend.visible)

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -7,12 +7,9 @@ class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
     def __init__(self, current_config):
         super(PlotOptionsDialog, self).__init__()
         self.setupUi(self)
-        if current_config.title is not None:
-            self.lneFigureTitle.setText(current_config.title)
-        if current_config.xlabel is not None:
-            self.lneXAxisLabel.setText(current_config.xlabel)
-        if current_config.ylabel is not None:
-            self.lneYAxisLabel.setText(current_config.ylabel)
+        if current_config.title is not None: self.lneFigureTitle.setText(current_config.title)
+        if current_config.xlabel is not None: self.lneXAxisLabel.setText(current_config.xlabel)
+        if current_config.ylabel is not None: self.lneYAxisLabel.setText(current_config.ylabel)
         if None not in current_config.x_range:
             self.lneXMin.setText(str(current_config.x_range[0]))
             self.lneXMax.setText(str(current_config.x_range[1]))
@@ -22,10 +19,13 @@ class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
         if None not in current_config.colorbar_range:
             self.lneCMin.setText(str(current_config.colorbar_range[0]))
             self.lneCMax.setText(str(current_config.colorbar_range[1]))
+            self.chkXLog.hide()
+            self.chkYLog.hide()
         else:
             self.groupBox_4.hide()
-        if current_config.logarithmic is not None:
-            self.chkLogarithmic.setChecked(current_config.logarithmic)
+        if current_config.logarithmic is not None: self.chkLogarithmic.setChecked(current_config.logarithmic)
+        if current_config.xlog is not None: self.chkXLog.setChecked(current_config.xlog)
+        if current_config.ylog is not None: self.chkYLog.setChecked(current_config.ylog)
 
         self._legend_widgets = []
         self.chkShowLegends.setChecked(current_config.legend.visible)
@@ -78,12 +78,12 @@ class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
                                     visible=legend_widget.is_visible())
 
         return PlotConfig(title=dialog.lneFigureTitle.text(),
-                          x_axis_label=dialog.lneXAxisLabel.text(),
-                          y_axis_label=dialog.lneYAxisLabel.text(),
-                          legends=legends,
-                          errorbars_enabled=dialog.chkShowErrorBars.isChecked(),
-                          x_range=x_range,
-                          y_range=y_range,
+                          xlabel=dialog.lneXAxisLabel.text(),
+                          ylabel=dialog.lneYAxisLabel.text(),
+                          legend=legends,
+                          errorbar=dialog.chkShowErrorBars.isChecked(),
+                          x_range=x_range, xlog=dialog.chkXLog.isChecked(),
+                          y_range=y_range, ylog=dialog.chkYLog.isChecked(),
                           colorbar_range=colorbar_range,
                           logarithmic=logarithmic)
 
@@ -151,20 +151,23 @@ class LegendDescriptor(object):
 
 
 class PlotConfig(object):
-    def __init__(self, title=None, x_axis_label=None, y_axis_label=None, legends=None, errorbars_enabled=None,
-                 x_range=(None, None), y_range=(None, None), colorbar_range=(None, None), logarithmic=None):
-        self.title = title
-        self.xlabel = x_axis_label
-        self.ylabel = y_axis_label
-        if legends is None:
-            self.legend = LegendDescriptor()
-        else:
-            self.legend = legends
-        self.errorbar = errorbars_enabled   # Has 3 values (True : shown, False: Not Shown, None: Not applicable)
-        self.x_range = x_range
-        self.y_range = y_range
-        self.colorbar_range = colorbar_range
-        self.logarithmic = logarithmic
+    def __init__(self, **kwargs):
+        # Define default values for all options
+        self.title = None
+        self.xlabel = None
+        self.ylabel = None
+        self.xlog = None
+        self.ylog = None
+        self.legend = LegendDescriptor()
+        self.errorbar = None
+        self.x_range = None
+        self.y_range = None
+        self.colorbar_range = None
+        self.logarithmic = None
+        # Populates fields from keyword arguments
+        for (argname, value) in kwargs.items():
+            if value is not None:
+                setattr(self, argname, value)
 
     @property
     def title(self):

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -103,6 +103,13 @@
       <item row="1" column="1">
        <widget class="QLineEdit" name="lneYMax"/>
       </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="chkYLog">
+        <property name="text">
+         <string>Logarithmic</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -131,6 +138,13 @@
       </item>
       <item row="1" column="1">
        <widget class="QLineEdit" name="lneXMax"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="chkXLog">
+        <property name="text">
+         <string>Logarithmic</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Implements the option to change the scale to log for the `x` and `y` axes of a cut.

**To test:**

Loads a dataset, calculate projection and make a cut. Go to plot options and select `Logarithmic`, and click ok. Check the result is in log-scale. The `symlog` option (symmetric-logarithmic) of Matplotlib is used so negative data can be handled with the region below the minimum data point strictly not zero in a linear scale. If the data has no negative values check that the scale is truncated below the minimum data value.

Fixes #125
