### PR TITLE
Add shim around IPython import to patch around a bug

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -4,8 +4,8 @@ and entry points.
 import os
 
 from PyQt4.QtGui import QApplication
-from IPython import start_ipython
 
+from mslice.external.ipython import start_ipython
 
 # Module-level reference to keep main window alive after show_gui has returned
 MAIN_WINDOW = None

--- a/mslice/external/ipython.py
+++ b/mslice/external/ipython.py
@@ -1,0 +1,35 @@
+"""This module contains patches to IPython to avoid bugs with various
+versions. Client code shold import from this module
+"""
+# std library
+from distutils.version import LooseVersion
+
+# third party
+import IPython
+# define same public api as IPython
+from IPython import * # noqa
+
+__all__ = dir(IPython)
+
+if LooseVersion(IPython.__version__) >= LooseVersion("1.0.0") and \
+   LooseVersion(IPython.__version__) < LooseVersion("3.0.0"):
+    # Monkey patch IPython.external.qt_loaders.commit_api to avoid
+    # a bugs on IPython various 1 < v < 3
+    # See https://github.com/ipython/ipython/pull/6730
+    import IPython.external.qt_loaders as _qt_loaders
+    def _commit_api_patched(api):
+        """Commit to a particular API, and trigger ImportErrors on subsequent
+           dangerous imports"""
+        ID =  _qt_loaders.ID
+        if api == _qt_loaders.QT_API_PYSIDE:
+            ID.forbid('PyQt4')
+            ID.forbid('PyQt5')
+        elif api == _qt_loaders.QT_API_PYQT5:
+            ID.forbid('PySide')
+            ID.forbid('PyQt4')
+        else:   # There are three other possibilities, all representing PyQt4
+            ID.forbid('PyQt5')
+            ID.forbid('PySide')
+    # enddef
+    # patch
+    _qt_loaders.commit_api = _commit_api_patched


### PR DESCRIPTION
**Description of work**

IPython 2 contained a bug when using PyQt4v1. A previous import of PyQt4
would always cause an error when loading IPython due to a logic error
in its interal import mechanism.

We now patch the faulty function with a fixed definition for those
versions affected.

This was mainly an issue on Ubuntu 16.04 that now comes with IPython 2.
