### PR TITLE
Line Display Options

### DIFF
--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -198,22 +198,34 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.set_legends(self.get_legends())
         self.canvas.draw()
 
-    def set_line_color(self, line_index, color):
-        # sets color of both line and error bars - child[0] = line, child[1] = error bars
-        for child in self.canvas.figure.gca().containers[line_index].get_children():
-            child.set_color(color)
+    def get_line_data(self):
+        legends = self.get_legends()
+        all_line_options = []
+        for line_group in self.canvas.figure.gca().containers:
+            line_options = {}
+            line = line_group.get_children()[0]
+            line_options['color'] = line.get_color()
+            line_options['style'] = line.get_linestyle()
+            line_options['width'] = str(int(line.get_linewidth()))
+            line_options['marker'] = line.get_marker()
+            all_line_options.append(line_options)
+        return zip(legends, all_line_options)
 
-    def set_line_style(self, line_index, style):
-        line = self.canvas.figure.gca().containers[line_index].get_children()[0]
-        line.set_linestyle(style) #  may need error checking
-
-    def set_line_width(self, line_index, width):
-        for child in self.canvas.figure.gca().containers[line_index].get_children():
-            child.set_linewidth(width)
-
-    def set_line_marker(self, line_index, marker):
-        line = self.canvas.figure.gca().containers[line_index].get_children()[0]
-        line.set_marker(marker)  # may need error checking
+    def set_line_data(self, line_data):
+        legends = []
+        i = 0
+        for line in line_data:
+            legend, line_options = line
+            legends.append(legend)
+            line_model = self.canvas.figure.gca().containers[i]
+            for child in line_model.get_children():
+                child.set_color(str(line_options['color'])[0])
+                child.set_linewidth(line_options['width'])
+            main_line = line_model.get_children()[0]
+            main_line.set_linestyle(str(line_options['style']))
+            main_line.set_marker(str(line_options['marker']))
+            i += 1
+        self.set_legends(legends)
 
     def set_line_visible(self, line_index, visible):
         for child in self.canvas.figure.gca().containers[line_index].get_children():

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -19,6 +19,8 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
 
         self.legends_shown = True
         self.legends_visible = []
+        self.lines_visible = {}
+
         self.actionKeep.triggered.connect(self._report_as_kept_to_manager)
         self.actionMakeCurrent.triggered.connect(self._report_as_current_to_manager)
 
@@ -201,14 +203,17 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
     def get_line_data(self):
         legends = self.get_legends()
         all_line_options = []
+        i = 0
         for line_group in self.canvas.figure.gca().containers:
             line_options = {}
             line = line_group.get_children()[0]
+            line_options['show'] = self.get_line_visible(i)
             line_options['color'] = line.get_color()
             line_options['style'] = line.get_linestyle()
             line_options['width'] = str(int(line.get_linewidth()))
             line_options['marker'] = line.get_marker()
             all_line_options.append(line_options)
+            i += 1
         return zip(legends, all_line_options)
 
     def set_line_data(self, line_data):
@@ -218,6 +223,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             legend, line_options = line
             legends.append(legend)
             line_model = self.canvas.figure.gca().containers[i]
+            self.set_line_visible(i, line_options['show'])
             for child in line_model.get_children():
                 child.set_color(line_options['color'])
                 child.set_linewidth(line_options['width'])
@@ -228,8 +234,17 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.set_legends(legends)
 
     def set_line_visible(self, line_index, visible):
+        self.lines_visible[line_index] = visible
         for child in self.canvas.figure.gca().containers[line_index].get_children():
             child.set_alpha(visible)
+
+    def get_line_visible(self, line_index):
+        try:
+            ret = self.lines_visible[line_index]
+            return ret
+        except KeyError:
+            self.lines_visible[line_index] = True
+            return True
 
     @property
     def title(self):

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -149,13 +149,12 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             alpha = 1
         else:
             alpha = 0.
-        for container in current_axis.containers:
-            if isinstance(container, ErrorbarContainer):
-                elements = container.get_children()
-                for i in range(len(elements)):
-                    # The first component is the actual line so we will not touch it
-                    if i != 0:
-                        elements[i].set_alpha(alpha)
+        for i in range(len(current_axis.containers)):
+            if isinstance(current_axis.containers[i], ErrorbarContainer):
+                elements = current_axis.containers[i].get_children()
+                if self.get_line_visible(i):
+                    elements[1].set_alpha(alpha) #  elements[0] is the actual line, elements[1] is error bars
+
 
     def _toggle_errorbars(self):
         state = self._has_errorbars()

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -198,6 +198,27 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.set_legends(self.get_legends())
         self.canvas.draw()
 
+    def set_line_color(self, line_index, color):
+        # sets color of both line and error bars - child[0] = line, child[1] = error bars
+        for child in self.canvas.figure.gca().containers[line_index].get_children():
+            child.set_color(color)
+
+    def set_line_style(self, line_index, style):
+        line = self.canvas.figure.gca().containers[line_index].get_children()[0]
+        line.set_linestyle(style) #  may need error checking
+
+    def set_line_width(self, line_index, width):
+        for child in self.canvas.figure.gca().containers[line_index].get_children():
+            child.set_linewidth(width)
+
+    def set_line_marker(self, line_index, marker):
+        line = self.canvas.figure.gca().containers[line_index].get_children()[0]
+        line.set_marker(marker)  # may need error checking
+
+    def set_line_visible(self, line_index, visible):
+        for child in self.canvas.figure.gca().containers[line_index].get_children():
+            child.set_alpha(visible)
+
     @property
     def title(self):
         return self.canvas.figure.gca().get_title()

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -219,11 +219,11 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             legends.append(legend)
             line_model = self.canvas.figure.gca().containers[i]
             for child in line_model.get_children():
-                child.set_color(str(line_options['color'])[0])
+                child.set_color(line_options['color'])
                 child.set_linewidth(line_options['width'])
             main_line = line_model.get_children()[0]
-            main_line.set_linestyle(str(line_options['style']))
-            main_line.set_marker(str(line_options['marker']))
+            main_line.set_linestyle(line_options['style'])
+            main_line.set_marker(line_options['marker'])
             i += 1
         self.set_legends(legends)
 

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -146,7 +146,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         if state:
             alpha = 1
         else:
-            alpha = 0
+            alpha = 0.
         for container in current_axis.containers:
             if isinstance(container, ErrorbarContainer):
                 elements = container.get_children()

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -16,12 +16,6 @@ class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
         super(PlotOptionsDialog, self).__init__()
         self.setupUi(self)
 
-        #  get reference to all child widgets
-        field = ['lneFigureTitle', 'lneXAxisLabel', 'lneYAxisLabel', 'lneXMin', 'lneXMax', 'chkXLog', 'lneYMax',
-                 'lneYMin', 'chkYLog']
-        for f in field:
-            setattr(self, f, self.axis_options.findChild((QtGui.QLineEdit, QtGui.QCheckBox), f))
-
         self.lneFigureTitle.editingFinished.connect(self.titleEdited)
         self.lneXAxisLabel.editingFinished.connect(self.xLabelEdited)
         self.lneYAxisLabel.editingFinished.connect(self.yLabelEdited)
@@ -103,8 +97,7 @@ class SlicePlotOptions(PlotOptionsDialog):
         self.chkXLog.hide()
         self.chkYLog.hide()
         self.cut_options.hide()
-        self.setMaximumWidth(300)
-        self.buttonBox.setMaximumWidth(275)
+        self.setMaximumWidth(350)
 
         self.lneCMin.editingFinished.connect(self.cRangeEdited)
         self.lneCMax.editingFinished.connect(self.cRangeEdited)
@@ -141,7 +134,6 @@ class CutPlotOptions(PlotOptionsDialog):
 
     xLogEdited = pyqtSignal()
     yLogEdited = pyqtSignal()
-    errorBarsEdited = pyqtSignal()
     showLegendsEdited = pyqtSignal()
 
     def __init__(self):
@@ -151,7 +143,6 @@ class CutPlotOptions(PlotOptionsDialog):
 
         self.chkXLog.stateChanged.connect(self.xLogEdited)
         self.chkYLog.stateChanged.connect(self.yLogEdited)
-        self.chkShowErrorBars.stateChanged.connect(self.errorBarsEdited)
         self.chkShowLegends.stateChanged.connect(self.showLegendsEdited)
 
     def set_line_data(self, line_data):
@@ -160,7 +151,7 @@ class CutPlotOptions(PlotOptionsDialog):
             line_widget = LegendAndLineOptionsSetter(self, legend['label'], legend['visible'], line_options)
             self.verticalLayout_legend.addWidget(line_widget)
             self._line_widgets.append(line_widget)
-        self.verticalLayout_legend.addStretch()
+            self.verticalLayout_legend.addStretch()
 
     def get_legends(self):
         legends = []
@@ -202,7 +193,7 @@ class CutPlotOptions(PlotOptionsDialog):
 
     @property
     def y_log(self):
-        return self.isChecked()
+        return self.chkYLog.isChecked()
 
     @y_log.setter
     def y_log(self, value):
@@ -289,6 +280,7 @@ class LegendAndLineOptionsSetter(QtGui.QWidget):
         self.show_legend_label.setText("Show legend: ")
         self.show_legend = QtGui.QCheckBox(self)
         self.show_legend.setChecked(show_legend)
+        self.show_line_changed(line_options['show'])
 
         layout = QtGui.QVBoxLayout(self)
         row1 = QtGui.QHBoxLayout()

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -204,6 +204,23 @@ class CutPlotOptions(PlotOptionsDialog):
 class LegendAndLineOptionsSetter(QtGui.QWidget):
     """This is a widget that has various legend and line controls for each line of a plot
     This widget has a concrete reference to the artist and modifies it"""
+
+    # dictionaries used to convert from matplotlib arguments to UI selection and vice versa
+    colors = {'B': 'Blue', 'G': 'Green', 'R': 'Red', 'C': 'Cyan', 'M': 'Magenta', 'Y': 'Yellow',
+                   'K': 'Black', 'W': 'White'}
+
+    styles = {'-': 'Solid', '--': 'Dashed', '-.': 'Dashdot', ':': 'Dotted'}
+
+    markers = {'o': 'Circle', ',': 'Pixel', '.': 'Point', 'v': 'Triangle down', '^': 'Triangle up',
+                    '<': 'Triangle_left', '>': 'Triangle right', '1': 'Arrow down', '2': 'Arrow up',
+                    '3': 'Arrow left', '4': 'Arrow right', '8': 'Octagon', 's': 'Square', 'p': 'Pentagon',
+                    '*': 'Star', 'h': 'Hexagon 1', 'H': 'Hexagon 2', '+': 'Plus', 'x': 'X', 'D': 'Diamond',
+                    'd': 'Diamond (thin)', '|': 'Vertical line', '_': 'Horizontal line', 'None': 'None'}
+
+    inverse_colors = {v: k for k, v in colors.iteritems()}
+    inverse_styles = {v: k for k, v in styles.iteritems()}
+    inverse_markers = {v: k for k, v in markers.iteritems()}
+
     def __init__(self, parent, text, is_enabled, line_options):
         super(LegendAndLineOptionsSetter, self).__init__(parent)
         self.isEnabled = QtGui.QCheckBox(self)
@@ -213,15 +230,18 @@ class LegendAndLineOptionsSetter(QtGui.QWidget):
 
         self.color_label = QtGui.QLabel(self)
         self.color_label.setText("Color:")
+
         self.line_color = QtGui.QComboBox(self)
-        self.line_color.addItems(['b', 'g', 'r', 'c', 'm', 'y', 'b', 'w'])
-        self.line_color.setCurrentIndex(self.line_color.findText(line_options['color']))
+        self.line_color.addItems(self.colors.values())
+        chosen_color_as_string = self.colors[line_options['color'].upper()]
+        self.line_color.setCurrentIndex(self.line_color.findText(chosen_color_as_string))
 
         self.style_label = QtGui.QLabel(self)
         self.style_label.setText("Style:")
         self.line_style = QtGui.QComboBox(self)
-        self.line_style.addItems(['-', '--', '-.', ':'])
-        self.line_style.setCurrentIndex(self.line_style.findText(line_options['style']))
+        self.line_style.addItems(self.styles.values())
+        chosen_style_as_string = self.styles[line_options['style']]
+        self.line_style.setCurrentIndex(self.line_style.findText(chosen_style_as_string))
 
         self.width_label = QtGui.QLabel(self)
         self.width_label.setText("Width:")
@@ -232,9 +252,11 @@ class LegendAndLineOptionsSetter(QtGui.QWidget):
         self.marker_label = QtGui.QLabel(self)
         self.marker_label.setText("Marker:")
         self.line_marker = QtGui.QComboBox(self)
-        self.line_marker.addItems(['o', ',', '.', 'v', '^', '<', '>', '1', '2', '3', '4', '8', 's', 'p' 'P',
-                                   '*', 'h', 'H', '+', 'x', 'X', 'D', 'd', '|', '_', 'None'])
-        self.line_marker.setCurrentIndex(self.line_marker.findText(line_options['marker']))
+        markers = self.markers.values()
+        markers.sort()
+        self.line_marker.addItems(markers)
+        chosen_marker_as_string = self.markers[line_options['marker']]
+        self.line_marker.setCurrentIndex(self.line_marker.findText(chosen_marker_as_string))
 
         layout = QtGui.QVBoxLayout(self)
         row1 = QtGui.QHBoxLayout()
@@ -263,11 +285,11 @@ class LegendAndLineOptionsSetter(QtGui.QWidget):
 
     @property
     def color(self):
-        return self.line_color.currentText()
+        return self.inverse_colors[str(self.line_color.currentText())]
 
     @property
     def style(self):
-        return self.line_style.currentText()
+        return self.inverse_styles[str(self.line_style.currentText())]
 
     @property
     def width(self):
@@ -275,4 +297,4 @@ class LegendAndLineOptionsSetter(QtGui.QWidget):
 
     @property
     def marker(self):
-        return self.line_marker.currentText()
+        return self.inverse_markers[str(self.line_marker.currentText())]

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -3,6 +3,7 @@ from PyQt4.QtCore import pyqtSignal
 
 from .plot_options_ui import Ui_Dialog
 
+
 class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
 
     titleEdited = pyqtSignal()
@@ -96,15 +97,9 @@ class SlicePlotOptions(PlotOptionsDialog):
         self.chkShowErrorBars.hide()
         self.groupBox.hide()
 
-        self.lneCMin.editingFinished.connect(self._c_range_edited)
-        self.lneCMax.editingFinished.connect(self._c_range_edited)
-        self.chkLogarithmic.stateChanged.connect(self._c_log_edited)
-
-    def _c_range_edited(self):
-        self.cRangeEdited.emit()
-
-    def _c_log_edited(self):
-        self.cLogEdited.emit()
+        self.lneCMin.editingFinished.connect(self.cRangeEdited)
+        self.lneCMax.editingFinished.connect(self.cRangeEdited)
+        self.chkLogarithmic.stateChanged.connect(self.cLogEdited)
 
     @property
     def colorbar_range(self):
@@ -138,15 +133,17 @@ class CutPlotOptions(PlotOptionsDialog):
     xLogEdited = pyqtSignal()
     yLogEdited = pyqtSignal()
     errorBarsEdited = pyqtSignal()
+    showLegendsEdited = pyqtSignal()
 
     def __init__(self):
         super(CutPlotOptions, self).__init__()
         self._legend_widgets = []
         self.groupBox_4.hide()
 
-        self.chkXLog.stateChanged.connect(self._x_log_edited)
-        self.chkYLog.stateChanged.connect(self._y_log_edited)
-        self.chkShowErrorBars.stateChanged.connect(self._error_bars_edited)
+        self.chkXLog.stateChanged.connect(self.xLogEdited)
+        self.chkYLog.stateChanged.connect(self.yLogEdited)
+        self.chkShowErrorBars.stateChanged.connect(self.errorBarsEdited)
+        self.chkShowLegends.stateChanged.connect(self.showLegendsEdited)
 
     def set_legends(self, legends):
         for legend in legends:
@@ -159,15 +156,6 @@ class CutPlotOptions(PlotOptionsDialog):
         for legend_widget in self._legend_widgets:
             legends.append({'label': legend_widget.get_text(), 'visible': legend_widget.is_visible()})
         return legends
-
-    def _x_log_edited(self):
-        self.xLogEdited.emit()
-
-    def _y_log_edited(self):
-        self.yLogEdited.emit()
-
-    def _error_bars_edited(self):
-        self.errorBarsEdited.emit()
 
     @property
     def x_log(self):

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -151,7 +151,6 @@ class CutPlotOptions(PlotOptionsDialog):
             line_widget = LegendAndLineOptionsSetter(self, legend['label'], legend['visible'], line_options)
             self.verticalLayout_legend.addWidget(line_widget)
             self._line_widgets.append(line_widget)
-            self.verticalLayout_legend.addStretch()
 
     def get_legends(self):
         legends = []
@@ -308,7 +307,6 @@ class LegendAndLineOptionsSetter(QtGui.QWidget):
         row4.addWidget(self.show_legend_label)
         row4.addWidget(self.show_legend)
 
-        # noinspection PyUnresolvedReferences
         self.line_color.currentIndexChanged.connect(lambda selected: self.color_validator(selected))
         self.show_line.stateChanged.connect(lambda state: self.show_line_changed(state))
 

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -16,6 +16,12 @@ class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
         super(PlotOptionsDialog, self).__init__()
         self.setupUi(self)
 
+        #  get reference to all child widgets
+        field = ['lneFigureTitle', 'lneXAxisLabel', 'lneYAxisLabel', 'lneXMin', 'lneXMax', 'chkXLog', 'lneYMax',
+                 'lneYMin', 'chkYLog']
+        for f in field:
+            setattr(self, f, self.axis_options.findChild((QtGui.QLineEdit, QtGui.QCheckBox), f))
+
         self.lneFigureTitle.editingFinished.connect(self.titleEdited)
         self.lneXAxisLabel.editingFinished.connect(self.xLabelEdited)
         self.lneYAxisLabel.editingFinished.connect(self.yLabelEdited)
@@ -23,6 +29,8 @@ class PlotOptionsDialog(QtGui.QDialog, Ui_Dialog):
         self.lneXMax.editingFinished.connect(self.xRangeEdited)
         self.lneYMin.editingFinished.connect(self.yRangeEdited)
         self.lneYMax.editingFinished.connect(self.yRangeEdited)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
 
     @property
     def x_range(self):
@@ -94,8 +102,9 @@ class SlicePlotOptions(PlotOptionsDialog):
         super(SlicePlotOptions, self).__init__()
         self.chkXLog.hide()
         self.chkYLog.hide()
-        self.chkShowErrorBars.hide()
-        self.groupBox.hide()
+        self.cut_options.hide()
+        self.setMaximumWidth(300)
+        self.buttonBox.setMaximumWidth(275)
 
         self.lneCMin.editingFinished.connect(self.cRangeEdited)
         self.lneCMax.editingFinished.connect(self.cRangeEdited)
@@ -151,6 +160,7 @@ class CutPlotOptions(PlotOptionsDialog):
             line_widget = LegendAndLineOptionsSetter(self, legend['label'], legend['visible'], line_options)
             self.verticalLayout_legend.addWidget(line_widget)
             self._line_widgets.append(line_widget)
+        self.verticalLayout_legend.addStretch()
 
     def get_legends(self):
         legends = []
@@ -192,7 +202,7 @@ class CutPlotOptions(PlotOptionsDialog):
 
     @property
     def y_log(self):
-        return self.chkYLog.isChecked()
+        return self.isChecked()
 
     @y_log.setter
     def y_log(self, value):
@@ -281,6 +291,7 @@ class LegendAndLineOptionsSetter(QtGui.QWidget):
         layout.addLayout(row2)
         row3 = QtGui.QHBoxLayout()
         layout.addLayout(row3)
+        layout.addStretch()
 
         row1.addWidget(self.isEnabled)
         row1.addWidget(self.legendText)

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -38,7 +38,7 @@
       <item>
        <widget class="QGroupBox" name="groupBox">
         <property name="title">
-         <string>GroupBox</string>
+         <string>Figure Labels</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_5">
          <item row="1" column="1">
@@ -57,7 +57,7 @@
          <item row="1" column="0">
           <widget class="QLabel" name="label">
            <property name="text">
-            <string>Figure Title</string>
+            <string>Title</string>
            </property>
           </widget>
          </item>

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>318</width>
-    <height>620</height>
+    <width>628</width>
+    <height>456</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,259 +19,357 @@
   <property name="windowTitle">
    <string>Plot Options</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="4" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox_3">
-     <property name="title">
-      <string>Y axis</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Min</string>
+  <widget class="QWidget" name="axis_options" native="true">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>9</y>
+     <width>291</width>
+     <height>401</height>
+    </rect>
+   </property>
+   <widget class="QLabel" name="label_2">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>54</y>
+      <width>53</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Y axis</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>2</y>
+      <width>53</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Figure Title</string>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="lneFigureTitle">
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>2</y>
+      <width>200</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="layoutDirection">
+     <enum>Qt::LeftToRight</enum>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="lneYAxisLabel">
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>54</y>
+      <width>200</width>
+      <height>20</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QGroupBox" name="groupBox_2">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>80</y>
+      <width>281</width>
+      <height>102</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>X axis</string>
+    </property>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="lneXMin">
+       <property name="maximumSize">
+        <size>
+         <width>181</width>
+         <height>16777215</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lneXMax">
+       <property name="maximumSize">
+        <size>
+         <width>181</width>
+         <height>16777215</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="chkXLog">
+       <property name="text">
+        <string>Logarithmic</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QGroupBox" name="groupBox_4">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>296</y>
+      <width>281</width>
+      <height>102</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Colorbar</string>
+    </property>
+    <layout class="QGridLayout" name="gridLayout_4">
+     <item row="0" column="0">
+      <widget class="QLabel" name="lblCMin">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="lneCMin"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblCMax">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lneCMax"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="chkLogarithmic">
+       <property name="text">
+        <string>Logarithmic</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QGroupBox" name="groupBox_3">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>188</y>
+      <width>281</width>
+      <height>102</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Y axis</string>
+    </property>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Min</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="lneYMin">
+       <property name="maximumSize">
+        <size>
+         <width>181</width>
+         <height>16777215</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Max</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lneYMax">
+       <property name="maximumSize">
+        <size>
+         <width>181</width>
+         <height>16777215</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="chkYLog">
+       <property name="text">
+        <string>Logarithmic</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QLineEdit" name="lneXAxisLabel">
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>28</y>
+      <width>200</width>
+      <height>20</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_3">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>28</y>
+      <width>53</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>X axis </string>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QWidget" name="cut_options" native="true">
+   <property name="geometry">
+    <rect>
+     <x>300</x>
+     <y>9</y>
+     <width>322</width>
+     <height>401</height>
+    </rect>
+   </property>
+   <widget class="QCheckBox" name="chkShowErrorBars">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>380</y>
+      <width>295</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Show Error Bars</string>
+    </property>
+   </widget>
+   <widget class="QGroupBox" name="groupBox">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>0</y>
+      <width>306</width>
+      <height>371</height>
+     </rect>
+    </property>
+    <property name="title">
+     <string>Legend and Line Options</string>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QCheckBox" name="chkShowLegends">
+       <property name="text">
+        <string>Show Legends</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QScrollArea" name="scrollArea">
+       <property name="minimumSize">
+        <size>
+         <width>275</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="lineWidth">
+        <number>0</number>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents_5">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>284</width>
+          <height>313</height>
+         </rect>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="lneYMin"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Max</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="lneYMax"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="chkYLog">
-        <property name="text">
-         <string>Logarithmic</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>X axis</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Min</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="lneXMin"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Max</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="lneXMax"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="chkXLog">
-        <property name="text">
-         <string>Logarithmic</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="QCheckBox" name="chkShowErrorBars">
-     <property name="text">
-      <string>Show Error Bars</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>X axis </string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Figure Title</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Y axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="lneYAxisLabel"/>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="lneFigureTitle"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="lneXAxisLabel"/>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox_4">
-     <property name="title">
-      <string>Colorbar</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="lblCMin">
-        <property name="text">
-         <string>Min</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="lneCMin"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="lblCMax">
-        <property name="text">
-         <string>Max</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="lneCMax"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="chkLogarithmic">
-        <property name="text">
-         <string>Logarithmic</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Legend and Line Options</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="chkShowLegends">
-        <property name="text">
-         <string>Show Legends</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QScrollArea" name="scrollArea">
-        <property name="minimumSize">
-         <size>
-          <width>275</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="lineWidth">
-         <number>0</number>
-        </property>
-        <property name="horizontalScrollBarPolicy">
-         <enum>Qt::ScrollBarAlwaysOff</enum>
-        </property>
-        <property name="widgetResizable">
-         <bool>true</bool>
-        </property>
-        <widget class="QWidget" name="scrollAreaWidgetContents_5">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>278</width>
-           <height>90</height>
-          </rect>
+        <layout class="QVBoxLayout" name="verticalLayout_legend">
+         <property name="spacing">
+          <number>4</number>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_legend">
-          <property name="spacing">
-           <number>4</number>
-          </property>
-          <property name="sizeConstraint">
-           <enum>QLayout::SetDefaultConstraint</enum>
-          </property>
-          <property name="leftMargin">
-           <number>5</number>
-          </property>
-          <property name="topMargin">
-           <number>5</number>
-          </property>
-          <property name="bottomMargin">
-           <number>5</number>
-          </property>
-         </layout>
-        </widget>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <property name="leftMargin">
+          <number>5</number>
+         </property>
+         <property name="topMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+        </layout>
        </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-  </layout>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>420</y>
+     <width>601</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="layoutDirection">
+    <enum>Qt::LeftToRight</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <zorder>axis_options</zorder>
+  <zorder>cut_options</zorder>
+  <zorder>buttonBox</zorder>
+  <zorder>buttonBox</zorder>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>Dialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>Dialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>628</width>
-    <height>456</height>
+    <width>710</width>
+    <height>501</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,356 +19,344 @@
   <property name="windowTitle">
    <string>Plot Options</string>
   </property>
-  <widget class="QWidget" name="axis_options" native="true">
-   <property name="geometry">
-    <rect>
-     <x>9</x>
-     <y>9</y>
-     <width>291</width>
-     <height>401</height>
-    </rect>
-   </property>
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>54</y>
-      <width>53</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Y axis</string>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>2</y>
-      <width>53</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Figure Title</string>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="lneFigureTitle">
-    <property name="geometry">
-     <rect>
-      <x>80</x>
-      <y>2</y>
-      <width>200</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="layoutDirection">
-     <enum>Qt::LeftToRight</enum>
-    </property>
-   </widget>
-   <widget class="QLineEdit" name="lneYAxisLabel">
-    <property name="geometry">
-     <rect>
-      <x>80</x>
-      <y>54</y>
-      <width>200</width>
-      <height>20</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QGroupBox" name="groupBox_2">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>80</y>
-      <width>281</width>
-      <height>102</height>
-     </rect>
-    </property>
-    <property name="title">
-     <string>X axis</string>
-    </property>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Min</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="lneXMin">
-       <property name="maximumSize">
-        <size>
-         <width>181</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Max</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="lneXMax">
-       <property name="maximumSize">
-        <size>
-         <width>181</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="chkXLog">
-       <property name="text">
-        <string>Logarithmic</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QGroupBox" name="groupBox_4">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>296</y>
-      <width>281</width>
-      <height>102</height>
-     </rect>
-    </property>
-    <property name="title">
-     <string>Colorbar</string>
-    </property>
-    <layout class="QGridLayout" name="gridLayout_4">
-     <item row="0" column="0">
-      <widget class="QLabel" name="lblCMin">
-       <property name="text">
-        <string>Min</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="lneCMin"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="lblCMax">
-       <property name="text">
-        <string>Max</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="lneCMax"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="chkLogarithmic">
-       <property name="text">
-        <string>Logarithmic</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QGroupBox" name="groupBox_3">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>188</y>
-      <width>281</width>
-      <height>102</height>
-     </rect>
-    </property>
-    <property name="title">
-     <string>Y axis</string>
-    </property>
-    <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Min</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="lneYMin">
-       <property name="maximumSize">
-        <size>
-         <width>181</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Max</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="lneYMax">
-       <property name="maximumSize">
-        <size>
-         <width>181</width>
-         <height>16777215</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="chkYLog">
-       <property name="text">
-        <string>Logarithmic</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QLineEdit" name="lneXAxisLabel">
-    <property name="geometry">
-     <rect>
-      <x>80</x>
-      <y>28</y>
-      <width>200</width>
-      <height>20</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QLabel" name="label_3">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>28</y>
-      <width>53</width>
-      <height>20</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>X axis </string>
-    </property>
-   </widget>
-  </widget>
-  <widget class="QWidget" name="cut_options" native="true">
-   <property name="geometry">
-    <rect>
-     <x>300</x>
-     <y>9</y>
-     <width>322</width>
-     <height>401</height>
-    </rect>
-   </property>
-   <widget class="QCheckBox" name="chkShowErrorBars">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>380</y>
-      <width>295</width>
-      <height>17</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Show Error Bars</string>
-    </property>
-   </widget>
-   <widget class="QGroupBox" name="groupBox">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>0</y>
-      <width>306</width>
-      <height>371</height>
-     </rect>
-    </property>
-    <property name="title">
-     <string>Legend and Line Options</string>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QCheckBox" name="chkShowLegends">
-       <property name="text">
-        <string>Show Legends</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QScrollArea" name="scrollArea">
-       <property name="minimumSize">
-        <size>
-         <width>275</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="lineWidth">
-        <number>0</number>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="widgetResizable">
-        <bool>true</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-       <widget class="QWidget" name="scrollAreaWidgetContents_5">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>284</width>
-          <height>313</height>
-         </rect>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <widget class="QWidget" name="axis_options" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>4</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string>GroupBox</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_legend">
-         <property name="spacing">
-          <number>4</number>
-         </property>
-         <property name="sizeConstraint">
-          <enum>QLayout::SetDefaultConstraint</enum>
-         </property>
-         <property name="leftMargin">
-          <number>5</number>
-         </property>
-         <property name="topMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>5</number>
-         </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="lneFigureTitle">
+           <property name="layoutDirection">
+            <enum>Qt::LeftToRight</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="lneXAxisLabel"/>
+         </item>
+         <item row="5" column="1">
+          <widget class="QLineEdit" name="lneYAxisLabel"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Figure Title</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>X axis </string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Y axis</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-  </widget>
-  <widget class="QDialogButtonBox" name="buttonBox">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>420</y>
-     <width>601</width>
-     <height>23</height>
-    </rect>
-   </property>
-   <property name="layoutDirection">
-    <enum>Qt::LeftToRight</enum>
-   </property>
-   <property name="standardButtons">
-    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-   </property>
-  </widget>
-  <zorder>axis_options</zorder>
-  <zorder>cut_options</zorder>
-  <zorder>buttonBox</zorder>
-  <zorder>buttonBox</zorder>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="title">
+         <string>X axis</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Min</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="lneXMin">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Max</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="lneXMax">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="chkXLog">
+           <property name="text">
+            <string>Logarithmic</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_3">
+        <property name="title">
+         <string>Y axis</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Min</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="lneYMin">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Max</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="lneYMax">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LeftToRight</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="chkYLog">
+           <property name="text">
+            <string>Logarithmic</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_4">
+        <property name="title">
+         <string>Colorbar</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="0" column="0">
+          <widget class="QLabel" name="lblCMin">
+           <property name="text">
+            <string>Min</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="lneCMin"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="lblCMax">
+           <property name="text">
+            <string>Max</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="lneCMax"/>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="chkLogarithmic">
+           <property name="text">
+            <string>Logarithmic</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QWidget" name="cut_options" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>5</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QGroupBox" name="groupBox_legend">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>Legend and Line Options</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetNoConstraint</enum>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="chkShowLegends">
+           <property name="text">
+            <string>Show Legends</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QScrollArea" name="scrollArea">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="lineWidth">
+            <number>0</number>
+           </property>
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAlwaysOff</enum>
+           </property>
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
+           <widget class="QWidget" name="scrollAreaWidgetContents">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>341</width>
+              <height>355</height>
+             </rect>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_legend">
+             <property name="spacing">
+              <number>4</number>
+             </property>
+             <property name="sizeConstraint">
+              <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
+             <property name="leftMargin">
+              <number>5</number>
+             </property>
+             <property name="topMargin">
+              <number>5</number>
+             </property>
+             <property name="bottomMargin">
+              <number>5</number>
+             </property>
+            </layout>
+           </widget>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="chkShowErrorBars">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Show Error Bars</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -6,77 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>297</width>
-    <height>522</height>
+    <width>318</width>
+    <height>620</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Plot Options</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Figure Title</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="lneFigureTitle"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>X axis </string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="lneXAxisLabel"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Y axis</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="lneYAxisLabel"/>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="chkShowErrorBars">
-     <property name="text">
-      <string>Show Error Bars</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Legend and Line Options</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="chkShowLegends">
-        <property name="text">
-         <string>Show Legends</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="4" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
@@ -149,6 +92,53 @@
      </layout>
     </widget>
    </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="QCheckBox" name="chkShowErrorBars">
+     <property name="text">
+      <string>Show Error Bars</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>X axis </string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Figure Title</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Y axis</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="lneYAxisLabel"/>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="lneFigureTitle"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="lneXAxisLabel"/>
+   </item>
    <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
@@ -180,6 +170,68 @@
         <property name="text">
          <string>Logarithmic</string>
         </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Legend and Line Options</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="chkShowLegends">
+        <property name="text">
+         <string>Show Legends</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="minimumSize">
+         <size>
+          <width>275</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <property name="horizontalScrollBarPolicy">
+         <enum>Qt::ScrollBarAlwaysOff</enum>
+        </property>
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents_5">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>278</width>
+           <height>90</height>
+          </rect>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_legend">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <property name="leftMargin">
+           <number>5</number>
+          </property>
+          <property name="topMargin">
+           <number>5</number>
+          </property>
+          <property name="bottomMargin">
+           <number>5</number>
+          </property>
+         </layout>
+        </widget>
        </widget>
       </item>
      </layout>

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>297</width>
-    <height>476</height>
+    <height>522</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -64,7 +64,7 @@
    <item row="6" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Legends</string>
+      <string>Legend and Line Options</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -71,7 +71,6 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         super(CutPlotOptionsPresenter, self).__init__(plot_options_dialog, plot_figure_manager)
         self._xy_config.update({'x_log': self._model.x_log, 'y_log': self._model.y_log})
 
-        self._view.errorBarsEdited.connect(partial(self._value_modified, 'error_bars'))
         self._view.showLegendsEdited.connect(partial(self._value_modified, 'show_legends'))
         self._view.xLogEdited.connect(partial(self._xy_config_modified, 'x_log'))
         self._view.yLogEdited.connect(partial(self._xy_config_modified, 'y_log'))
@@ -95,4 +94,5 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
             setattr(self._model, key, value)
         line_data = self._view.get_line_data()
         self._model.set_line_data(line_data)
+        self._model.error_bars = self._view.error_bars
         return True

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -76,8 +76,8 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         self._view.xLogEdited.connect(partial(self._xy_config_modified, 'x_log'))
         self._view.yLogEdited.connect(partial(self._xy_config_modified, 'y_log'))
 
-        legends = self._model.get_legends()
-        self._view.set_legends(legends)
+        line_data = self._model.get_line_data()
+        self._view.set_line_data(line_data)
 
     def set_properties(self):
         properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'x_log', 'y_log', 'error_bars',
@@ -93,6 +93,6 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
             self._model.change_cut_plot(self._xy_config)
         for key, value in self._modified_values.items():
             setattr(self._model, key, value)
-        legends = self._view.get_legends()
-        self._model.set_legends(legends)
+        line_data = self._view.get_line_data()
+        self._model.set_line_data(line_data)
         return True

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -40,8 +40,7 @@ class SlicePlotOptionsPresenter(PlotOptionsPresenter):
         self._view.cRangeEdited.connect(self._set_c_range)
 
     def set_properties(self):
-        properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'colorbar_range', 'colorbar_log',
-                      'show_legends']
+        properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'colorbar_range', 'colorbar_log']
         for p in properties:
             setattr(self._view, p, getattr(self._model, p))
 
@@ -73,6 +72,7 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         self._xy_config.update({'x_log': self._model.x_log, 'y_log': self._model.y_log})
 
         self._view.errorBarsEdited.connect(partial(self._value_modified, 'error_bars'))
+        self._view.showLegendsEdited.connect(partial(self._value_modified, 'show_legends'))
         self._view.xLogEdited.connect(partial(self._xy_config_modified, 'x_log'))
         self._view.yLogEdited.connect(partial(self._xy_config_modified, 'y_log'))
 
@@ -80,7 +80,8 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         self._view.set_legends(legends)
 
     def set_properties(self):
-        properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'x_log', 'y_log', 'error_bars']
+        properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'x_log', 'y_log', 'error_bars',
+                      'show_legends']
         for p in properties:
             setattr(self._view, p, getattr(self._model, p))
 

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -40,7 +40,8 @@ class SlicePlotOptionsPresenter(PlotOptionsPresenter):
         self._view.cRangeEdited.connect(self._set_c_range)
 
     def set_properties(self):
-        properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'colorbar_range', 'colorbar_log']
+        properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'colorbar_range', 'colorbar_log',
+                      'show_legends']
         for p in properties:
             setattr(self._view, p, getattr(self._model, p))
 
@@ -94,44 +95,3 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         legends = self._view.get_legends()
         self._model.set_legends(legends)
         return True
-
-
-class LegendDescriptor(object):
-    """This is a class that describes the legends on a plot"""
-    def __init__(self, visible=False, applicable=True, handles=None):
-        self.visible = visible
-        self.applicable = applicable
-        if handles:
-            self.handles = list(handles)
-        else:
-            self.handles = []
-        self._labels = {}
-
-    def all_legends(self):
-        """An iterator which yields a dictionary description of legends containing the handle,
-        text and if visible or not"""
-        for handle in self.handles:
-            yield self.get_legend_descriptor(handle)
-
-    def set_legend_text(self, handle, text, visible=True):
-        if handle not in self.handles:
-            self.handles.append(handle)
-        if not visible:
-            text = '_' + text
-        self._labels[handle] = text
-
-    def get_legend_descriptor(self, handle):
-        if handle in self._labels.keys():
-            label = self._labels[handle]  # If a new value has been set for a handle return that
-        else:
-            label = handle.get_label()   # Else get the value from the plot
-        if label.startswith('_'):
-            x = {'text': label[1:], 'visible': False, 'handle': handle}
-        else:
-            x = {'text': label, 'visible': True, 'handle': handle}
-        return x
-
-    def get_legend_text(self, handle):
-        if handle in self._labels.keys():
-            return self._labels[handle]
-        return handle.get_label()

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -1,8 +1,6 @@
 from mock import MagicMock, PropertyMock, Mock
 import unittest
-from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter, SlicePlotOptionsPresenter, \
-    LegendDescriptor
-
+from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter, SlicePlotOptionsPresenter
 
 
 class PlotOptionsPresenterTest(unittest.TestCase):
@@ -171,6 +169,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
 
         model_error_bars_mock.assert_called_once_with(False)
 
+    '''TODO: add/update tests 
     def test_legends(self):
         #  model -> view
         legends = LegendDescriptor(handles=['legend0', 'legend1'])
@@ -186,4 +185,4 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.presenter.get_new_config()
 
         self.view.get_legends.assert_called_once_with()
-        self.model.set_legends.assert_called_once_with(legends2)
+        self.model.set_legends.assert_called_once_with(legends2)'''

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, PropertyMock, Mock
+from mock import MagicMock, PropertyMock
 import unittest
 from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter, SlicePlotOptionsPresenter
 
@@ -169,7 +169,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
 
         model_error_bars_mock.assert_called_once_with(False)
 
-    '''TODO: add/update tests 
+    '''TODO: add/update tests
     def test_legends(self):
         #  model -> view
         legends = LegendDescriptor(handles=['legend0', 'legend1'])

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -164,7 +164,6 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         # view -> model
         model_error_bars_mock.reset_mock()
         view_error_bars_mock.return_value = False
-        self.presenter._value_modified('error_bars')
         self.presenter.get_new_config()
 
         model_error_bars_mock.assert_called_once_with(False)

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, PropertyMock
+from mock import MagicMock, PropertyMock, Mock
 import unittest
 from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter, SlicePlotOptionsPresenter
 
@@ -169,20 +169,24 @@ class PlotOptionsPresenterTest(unittest.TestCase):
 
         model_error_bars_mock.assert_called_once_with(False)
 
-    '''TODO: add/update tests
-    def test_legends(self):
+    def test_line_options(self):
         #  model -> view
-        legends = LegendDescriptor(handles=['legend0', 'legend1'])
-        self.model.get_legends = Mock(return_value=legends)
+        line_options = [{'color': 'k', 'style': '-', 'width': '10', 'marker': '*'}]
+        legends = {'label': 'legend1', 'visible': True}
+        line_data = zip(legends, line_options)
+        self.model.get_line_data = Mock(return_value=line_data)
         self.presenter = CutPlotOptionsPresenter(self.view, self.model)
 
-        self.model.get_legends.assert_called_once_with()
-        self.view.set_legends.assert_called_once_with(legends)
+        self.model.get_line_data.assert_called_once_with()
+        self.view.set_line_data.assert_called_once_with(line_data)
 
         #  view -> model
-        legends2 = LegendDescriptor(visible=False, handles=['legend2'])
-        self.view.get_legends = Mock(return_value=legends2)
+        line_options2 = [{'color': 'b', 'style': '-', 'width': '10', 'marker': 'o'}]
+        legends2 = {'label': 'legend1', 'visible': False}
+        line_data2 = zip(legends2, line_options2)
+
+        self.view.get_line_data = Mock(return_value=line_data2)
         self.presenter.get_new_config()
 
-        self.view.get_legends.assert_called_once_with()
-        self.model.set_legends.assert_called_once_with(legends2)'''
+        self.view.get_line_data.assert_called_once_with()
+        self.model.set_line_data.assert_called_once_with(line_data2)


### PR DESCRIPTION
Added various options to change the appearance of lines in cut plots.
- Refactored legends code to be more extendable and removed redundant data
- Added controls to UI for line appearance ( line colour, style, width, marker type and show/hide)
- Add unit test to presenter for new line controls

**To test:**
- Open any cut plot
- Click plot options
- Change values for line colour / style / width / marker and click OK

Fixes #104 
Fixes #109