### PR TITLE
Save multiple selected workspaces

### DIFF
--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -93,14 +93,15 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         if not selected_workspaces:
             self._workspace_manger_view.error_select_one_workspace()
             return
-        dir = self._workspace_manger_view.get_directory_to_save_workspaces()
-        if not dir:
+        save_directory = self._workspace_manger_view.get_directory_to_save_workspaces()
+        if not save_directory:
             self._workspace_manger_view.error_invalid_save_path()
+            return
         for workspace in selected_workspaces:
             filename = workspace
             if not filename.endswith('.nxs'):
                 filename += '.nxs'
-            path = os.path.join(str(dir), filename)
+            path = os.path.join(str(save_directory), filename)
             try:
                 self._work_spaceprovider.save_nexus(workspace, path)
             except RuntimeError:

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -93,20 +93,18 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         if not selected_workspaces:
             self._workspace_manger_view.error_select_one_workspace()
             return
-        if len(selected_workspaces) > 1:
-            self._workspace_manger_view.error_select_only_one_workspace()
-            return
-        selected_workspace = selected_workspaces[0]
-        path = self._workspace_manger_view.get_workspace_to_save_filepath()
-        if not path:
+        dir = self._workspace_manger_view.get_directory_to_save_workspaces()
+        if not dir:
             self._workspace_manger_view.error_invalid_save_path()
-            return
-        if not path.endswith('.nxs'):
-            path += '.nxs'
-        try:
-            self._work_spaceprovider.save_nexus(selected_workspace, path)
-        except RuntimeError:
-            self._workspace_manger_view.error_unable_to_save()
+        for workspace in selected_workspaces:
+            filename = workspace
+            if not filename.endswith('.nxs'):
+                filename += '.nxs'
+            path = os.path.join(str(dir), filename)
+            try:
+                self._work_spaceprovider.save_nexus(workspace, path)
+            except RuntimeError:
+                self._workspace_manger_view.error_unable_to_save()
 
     def _remove_selected_workspaces(self):
         selected_workspaces = self._workspace_manger_view.get_workspace_selected()

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -160,27 +160,28 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
-        path_to_save_to = r'A:\file\path\save.nxs'
+        path_to_save_to = r'A:\file\path'
         workspace_to_save = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_save])
-        self.view.get_workspace_to_save_filepath = mock.Mock(return_value=path_to_save_to)
+        self.view.get_directory_to_save_workspaces = mock.Mock(return_value=path_to_save_to)
 
         self.presenter.notify(Command.SaveSelectedWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_workspace_selected.assert_called_once_with()
-        self.view.get_workspace_to_save_filepath.assert_called_once_with()
-        self.workspace_provider.save_nexus.assert_called_once_with(workspace_to_save, path_to_save_to)
+        self.view.get_directory_to_save_workspaces.assert_called_once_with()
+        self.workspace_provider.save_nexus.assert_called_once_with(workspace_to_save, r'A:\file\path\file1.nxs')
 
-    def test_save_workspace_multiple_selected_prompt_user(self):
+    def test_save_workspace_multiple_selected(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         #Create a view that reports multiple workspaces are selected on calls to get_workspace_selected
+        path_to_save_to = r'A:\file\path'
         self.view.get_workspace_selected = mock.Mock(return_value=['file1','file2'])
-
+        self.view.get_directory_to_save_workspaces = mock.Mock(return_value=path_to_save_to)
         self.presenter.notify(Command.SaveSelectedWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
-        self.view.error_select_only_one_workspace.assert_called_once_with()
-        self.view.get_workspace_to_save_filepath.assert_not_called()
-        self.workspace_provider.save_nexus.assert_not_called()
+        self.view.get_directory_to_save_workspaces.assert_called_once_with()
+        calls = [call('file1', r'A:\file\path\file1.nxs'), call('file2', r'A:\file\path\file2.nxs')]
+        self.workspace_provider.save_nexus.assert_has_calls(calls)
 
     def test_save_workspace_non_selected_prompt_user(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
@@ -200,12 +201,12 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         path_to_save_to = "" # view returns empty string to indicate operation cancelled
         workspace_to_save = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_save])
-        self.view.get_workspace_to_save_filepath = mock.Mock(return_value=path_to_save_to)
+        self.view.get_directory_to_save_workspaces = mock.Mock(return_value=path_to_save_to)
 
         self.presenter.notify(Command.SaveSelectedWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_workspace_selected.assert_called_once_with()
-        self.view.get_workspace_to_save_filepath.assert_called_once_with()
+        self.view.get_directory_to_save_workspaces.assert_called_once_with()
         self.view.error_invalid_save_path.assert_called_once()
         self.workspace_provider.save_nexus.assert_not_called()
 

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -162,6 +162,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path'
         workspace_to_save = 'file1'
+        result_path = join(path_to_save_to, workspace_to_save + '.nxs')
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_save])
         self.view.get_directory_to_save_workspaces = mock.Mock(return_value=path_to_save_to)
 
@@ -169,18 +170,20 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_directory_to_save_workspaces.assert_called_once_with()
-        self.workspace_provider.save_nexus.assert_called_once_with(workspace_to_save, r'A:\file\path\file1.nxs')
+        self.workspace_provider.save_nexus.assert_called_once_with(workspace_to_save, result_path)
 
     def test_save_workspace_multiple_selected(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
         #Create a view that reports multiple workspaces are selected on calls to get_workspace_selected
         path_to_save_to = r'A:\file\path'
         self.view.get_workspace_selected = mock.Mock(return_value=['file1','file2'])
+        result_paths = [join(path_to_save_to, 'file1.nxs'), join(path_to_save_to, 'file2.nxs')]
         self.view.get_directory_to_save_workspaces = mock.Mock(return_value=path_to_save_to)
+
         self.presenter.notify(Command.SaveSelectedWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_directory_to_save_workspaces.assert_called_once_with()
-        calls = [call('file1', r'A:\file\path\file1.nxs'), call('file2', r'A:\file\path\file2.nxs')]
+        calls = [call('file1', result_paths[0]), call('file2', result_paths[1])]
         self.workspace_provider.save_nexus.assert_has_calls(calls)
 
     def test_save_workspace_non_selected_prompt_user(self):

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -93,11 +93,6 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         paths = QFileDialog.getOpenFileNames()
         return [str(filename) for filename in paths]
 
-    def get_workspace_to_save_filepath(self):
-        extension = 'Nexus file (*.nxs)'
-        path = QFileDialog.getSaveFileName(filter=extension)
-        return str(path)
-
     def get_directory_to_save_workspaces(self):
         return QFileDialog.getExistingDirectory()
 

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -98,6 +98,9 @@ class WorkspaceManagerWidget(QWidget,Ui_Form,WorkspaceView):
         path = QFileDialog.getSaveFileName(filter=extension)
         return str(path)
 
+    def get_directory_to_save_workspaces(self):
+        return QFileDialog.getExistingDirectory()
+
     def get_workspace_new_name(self):
         name, success = QInputDialog.getText(self,"Workspace New Name","Enter the new name for the workspace :      ")
         # The message above was padded with spaces to allow the whole title to show up


### PR DESCRIPTION
Can now save multiple selected workspaces at once.

**To test:**
- Load/generate workspaces in the workspace manager
- Select multiple workspaces with ctrl or shift
- Click Save

This produces a dialog that asks which directory to save the files.

Fixes #141
