### PR TITLE
Remove unneeded `show` call.

### DIFF
--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -24,8 +24,6 @@ class MatplotlibSlicePlotter(SlicePlotter):
         plt.ylabel(self._getDisplayName(y_axis.units, comment))
         plt.title(selected_workspace)
         plt.gcf().canvas.set_window_title(selected_workspace)
-        plt.show()
-
         plt.draw_all()
 
     def _getDisplayName(self, axisUnits, comment=None):


### PR DESCRIPTION
Description of work.

Removes call to `show` when plotting a slice.

**To test:**

See issue for testing instructions.

Fixes #160.
