### PR TITLE
Multiple cuts (finite `widths`) of multiple workspaces

### DIFF
--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -196,6 +196,10 @@ class CutPresenter(PresenterUtility):
             axis = self._cut_algorithm.get_available_axis(workspace)
             current_axis = axis[0]
             if self._previous_cut is not None and self._previous_axis is not None:
+                if self._previous_cut not in self._saved_parameters:
+                    self._saved_parameters[self._previous_cut] = dict()
+                if self._previous_axis not in self._saved_parameters[self._previous_cut]:
+                    self._saved_parameters[self._previous_cut][self._previous_axis] = self._cut_view.get_input_fields()
                 if axis == self._saved_parameters[self._previous_cut][self._previous_axis]['axes']:
                     current_axis = self._cut_view.get_cut_axis()
             self._cut_view.populate_cut_axis_options(axis)

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -107,10 +107,6 @@ class CutPresenter(PresenterUtility):
         self._cut_algorithm.compute_cut(*cut_params)
         self._main_presenter.update_displayed_workspaces()
 
-    def _workspaces_selected(self):
-        selected_workspaces = self._main_presenter.get_selected_workspaces()
-        return len(selected_workspaces)
-
     def _parse_input(self, workspace_index=0):
         # The messages of the raised exceptions are discarded. They are there for the sake of clarity/debugging
         selected_workspaces = self._main_presenter.get_selected_workspaces()

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -16,6 +16,11 @@ from mslice.presenters.slice_plotter_presenter import Axis
 from mslice.widgets.cut.command import Command
 from mslice.views.cut_view import CutView
 
+def isstr(s):
+    try:
+        return isinstance(s, basestring)
+    except NameError:
+        return isinstance(s, str)
 
 class CutPresenterTest(unittest.TestCase):
     def setUp(self):
@@ -122,7 +127,7 @@ class CutPresenterTest(unittest.TestCase):
         integration_start, integration_end, width = tuple(args[2:5])
         intensity_start, intensity_end, is_norm = tuple(args[5:8])
         workspace, integrated_axis = tuple(args[8:10])
-        if isinstance(workspace, basestring):
+        if isstr(workspace):
             workspace = [workspace]
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=workspace)
         self.view.get_cut_axis = mock.Mock(return_value=axis.units)

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -122,7 +122,7 @@ class CutPresenterTest(unittest.TestCase):
         integration_start, integration_end, width = tuple(args[2:5])
         intensity_start, intensity_end, is_norm = tuple(args[5:8])
         workspace, integrated_axis = tuple(args[8:10])
-        if not hasattr(workspace, '__iter__'):
+        if isinstance(workspace, basestring):
             workspace = [workspace]
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=workspace)
         self.view.get_cut_axis = mock.Mock(return_value=axis.units)
@@ -136,6 +136,7 @@ class CutPresenterTest(unittest.TestCase):
         self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
         self.view.get_integration_width = mock.Mock(return_value=width)
         self.cut_algorithm.get_other_axis = mock.Mock(return_value=integrated_axis)
+        self.cut_algorithm.get_available_axis = mock.Mock(return_value=[axis.units,integrated_axis])
 
     def test_cut_parse_input_errors(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
@@ -365,8 +366,6 @@ class CutPresenterTest(unittest.TestCase):
         integrated_axis = 'integrated axis'
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, selected_workspaces, integrated_axis)
-        available_dimensions = ["dim1", "dim2"]
-        self.cut_algorithm.get_available_axis = mock.Mock(return_value=available_dimensions)
         cut_presenter.notify(Command.Plot)
         call_list = [
             call(selected_workspace=selected_workspaces[0], cut_axis=processed_axis,

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -122,7 +122,9 @@ class CutPresenterTest(unittest.TestCase):
         integration_start, integration_end, width = tuple(args[2:5])
         intensity_start, intensity_end, is_norm = tuple(args[5:8])
         workspace, integrated_axis = tuple(args[8:10])
-        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
+        if not hasattr(workspace, '__iter__'):
+            workspace = [workspace]
+        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=workspace)
         self.view.get_cut_axis = mock.Mock(return_value=axis.units)
         self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
         self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
@@ -344,6 +346,37 @@ class CutPresenterTest(unittest.TestCase):
             call(selected_workspace=workspace, cut_axis=processed_axis,integration_start=7,
                  integration_end=8,norm_to_one=is_norm,intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=True)
+        ]
+        self.cut_algorithm.compute_cut.assert_not_called()
+        self.cut_plotter.plot_cut.assert_has_calls(call_list)
+
+    def test_plot_multiple_workspaces_cut(self):
+        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
+        cut_presenter.register_master(self.main_presenter)
+        axis = Axis("units", "0", "100", "1")
+        processed_axis = Axis("units", 0, 100, 1)
+        integration_start = 3
+        integration_end = 8
+        width = ""
+        intensity_start = 11
+        intensity_end = 30
+        is_norm = True
+        selected_workspaces = ["ws1", "ws2"]
+        integrated_axis = 'integrated axis'
+        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, selected_workspaces, integrated_axis)
+        available_dimensions = ["dim1", "dim2"]
+        self.cut_algorithm.get_available_axis = mock.Mock(return_value=available_dimensions)
+        cut_presenter.notify(Command.Plot)
+        call_list = [
+            call(selected_workspace=selected_workspaces[0], cut_axis=processed_axis,
+                 integration_start=integration_start, integration_end=integration_end,
+                 norm_to_one=is_norm, intensity_start=intensity_start,
+                 intensity_end=intensity_end, plot_over=False),
+            call(selected_workspace=selected_workspaces[1], cut_axis=processed_axis,
+                 integration_start=integration_start, integration_end=integration_end,
+                 norm_to_one=is_norm, intensity_start=intensity_start,
+                 intensity_end=intensity_end, plot_over=True),
         ]
         self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_has_calls(call_list)


### PR DESCRIPTION
Fixes a bug where if the `width` parameter was set, and multiple workspaces were selected, only the first workspace would be plotted. This was due to a bug in the parameter caching mechanism which meant that parameters for non-first workspaces were not set.

**To test:**

Load and calculation projection for multiple (>1) workspaces. Select multiple projected workspaces. In the cut tab, set finite values for all parameters, including `width`, and `Plot`. Check that all selected workspaces were plotted.

Fixes #162 
