### PR TITLE
Informational overplot - recoil lines

### DIFF
--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -120,10 +120,10 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         sample_temp = float(''.join(c for c in k_string if c.isdigit()))
         return sample_temp
 
-    def compute_recoil_line(self, x_axis, y_axis, relative_mass=1):
+    def compute_recoil_line(self, x_axis, relative_mass=1):
         momentum_transfer = np.arange(x_axis.start, x_axis.end, x_axis.step)
-        line = np.square(momentum_transfer * 1.e10 * constants.hbar ) / (2 * relative_mass * constants.neutron_mass) / \
-               (constants.elementary_charge / 1000)
+        line = np.square(momentum_transfer * 1.e10 * constants.hbar) / (2 * relative_mass * constants.neutron_mass) /\
+            (constants.elementary_charge / 1000)
         return momentum_transfer, line
 
     def _norm_to_one(self, data):

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -122,7 +122,8 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
 
     def compute_recoil_line(self, x_axis, y_axis, relative_mass=1):
         momentum_transfer = np.arange(x_axis.start, x_axis.end, x_axis.step)
-        line = np.square(momentum_transfer * HBAR_MEV) / (2 * relative_mass * constants.neutron_mass)
+        line = np.square(momentum_transfer * 1.e10 * constants.hbar ) / (2 * relative_mass * constants.neutron_mass) / \
+               (constants.elementary_charge / 1000)
         return momentum_transfer, line
 
     def _norm_to_one(self, data):

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -10,6 +10,7 @@ from mslice.models.alg_workspace_ops import AlgWorkspaceOps
 from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 KB_MEV = constants.value('Boltzmann constant in eV/K') * 1000
+HBAR_MEV = constants.value('Planck constant over 2 pi in eV s') * 1000
 
 
 class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
@@ -94,6 +95,11 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         k_string = string[pos_k - 3:pos_k]
         sample_temp = float(''.join(c for c in k_string if c.isdigit()))
         return sample_temp
+
+    def compute_recoil_line(self, x_axis, y_axis, relative_mass=1):
+        momentum_transfer = np.arange(x_axis.start, x_axis.end, x_axis.step)
+        line = np.square(momentum_transfer * HBAR_MEV) / (2 * relative_mass * constants.neutron_mass)
+        return momentum_transfer, line
 
     def _norm_to_one(self, data):
         data_range = data.max() - data.min()

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -108,8 +108,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
             line.set_label(label)  # add to legend
         else:
             x_axis = self.slice_cache[workspace]['x_axis']
-            y_axis = self.slice_cache[workspace]['y_axis']
-            x, y = self._slice_algorithm.compute_recoil_line(x_axis, y_axis, relative_mass)
+            x, y = self._slice_algorithm.compute_recoil_line(x_axis, relative_mass)
             color = recoil_colors[relative_mass] if relative_mass in recoil_colors else 'c'
             self.recoil_lines[workspace][relative_mass] = plt.gca().plot(x, y, color, label=label, alpha=.7)[0]
 

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -4,6 +4,9 @@ from .slice_plotter import SlicePlotter
 import mslice.plotting.pyplot as plt
 from mslice.app import MPL_COMPAT
 
+recoil_colors={1:'b', 2:'g', 4:'r'}
+recoil_labels={1:'Hydrogen', 2:'Deuterium', 4:'Helium'}
+
 
 class MatplotlibSlicePlotter(SlicePlotter):
     def __init__(self, slice_algorithm):
@@ -98,17 +101,23 @@ class MatplotlibSlicePlotter(SlicePlotter):
                         slice_cache['norm'], slice_cache['x_axis'], slice_cache['y_axis'])
 
     def add_recoil_line(self, workspace, relative_mass):
+        label = recoil_labels[relative_mass] if relative_mass in recoil_labels else 'Relative mass '+ str(relative_mass)
         if relative_mass in self.recoil_lines[workspace]:
-            self.recoil_lines[workspace][relative_mass].set_linestyle('-')  # make visible
+            line = self.recoil_lines[workspace][relative_mass]
+            line.set_linestyle('-')  # make visible
+            line.set_label(label)  # add to legend
         else:
             x_axis = self.slice_cache[workspace]['x_axis']
             y_axis = self.slice_cache[workspace]['y_axis']
             x, y = self._slice_algorithm.compute_recoil_line(x_axis, y_axis, relative_mass)
-            self.recoil_lines[workspace][relative_mass] = plt.gca().plot(x, y, 'g', alpha=.7)[0]
+            color = recoil_colors[relative_mass] if relative_mass in recoil_colors else 'c'
+            self.recoil_lines[workspace][relative_mass] = plt.gca().plot(x, y, color, label=label, alpha=.7)[0]
 
     def hide_recoil_line(self, workspace, relative_mass):
         if relative_mass in self.recoil_lines[workspace]:
-            self.recoil_lines[workspace][relative_mass].set_linestyle('')
+            line = self.recoil_lines[workspace][relative_mass]
+            line.set_linestyle('')
+            line.set_label('')
 
     def add_sample_temperature_field(self, field_name):
         self._sample_temp_fields.append(field_name)

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -1,11 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 from matplotlib.colors import Normalize
-import numpy as np
 from .slice_plotter import SlicePlotter
 import mslice.plotting.pyplot as plt
 from mslice.app import MPL_COMPAT
-
-from scipy import constants
 
 
 class MatplotlibSlicePlotter(SlicePlotter):
@@ -49,7 +46,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
 
     def _show_plot(self, workspace_name, plot_data, extent, colourmap, norm, x_axis, y_axis):
         plt.imshow(plot_data, extent=extent, cmap=colourmap, aspect='auto', norm=norm,
-                   interpolation='none')
+                   interpolation='none', hold=False)
         plt.title(workspace_name)
         comment = self._slice_algorithm.getComment(str(workspace_name))
         plt.xlabel(self._getDisplayName(x_axis.units, comment))

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -83,6 +83,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             self.slice_plotter.add_recoil_line(self.ws_title, relative_mass)
         else:
             self.slice_plotter.hide_recoil_line(self.ws_title, relative_mass)
+        self.update_recoil_legend()
         self.canvas.draw()
 
     def arbitrary_recoil_line(self):
@@ -91,6 +92,18 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             if not confirm:
                 return
         self.toggle_recoil_line(self.actionArbitrary_nuclei, self.arbitrary_nuclei)
+
+    def update_recoil_legend(self):
+        visible_lines = 0
+        axes = self.canvas.figure.gca()
+        for line in axes.get_lines():
+            if line.get_linestyle() == '-':
+                visible_lines += 1
+        if visible_lines >= 2:
+            legend = axes.legend(fontsize='small')
+            legend.draggable()
+        else:
+            axes.legend_ = None  # remove legend
 
     def intensity_selection(self, selected):
         '''Ticks selected and un-ticks other intensity options. Returns previous selection'''

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -54,11 +54,9 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
     def add_slice_plotter(self, slice_plotter):
         self.slice_plotter = slice_plotter
         self.menuIntensity.setDisabled(False)
-        self.actionToggleLegends.setDisabled(True)
         self.ws_title = self.title
         self.arbitrary_nuclei = None
 
-        self.actionToggleLegends.triggered.connect(self._toggle_legend)
         self.actionS_Q_E.triggered.connect(partial(self.show_intensity_plot, self.actionS_Q_E,
                                                    self.slice_plotter.show_scattering_function, False))
         self.actionChi_Q_E.triggered.connect(partial(self.show_intensity_plot, self.actionChi_Q_E,
@@ -83,7 +81,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             self.slice_plotter.add_recoil_line(self.ws_title, relative_mass)
         else:
             self.slice_plotter.hide_recoil_line(self.ws_title, relative_mass)
-        self.update_recoil_legend()
+        self.update_slice_legend()
         self.canvas.draw()
 
     def arbitrary_recoil_line(self):
@@ -93,7 +91,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
                 return
         self.toggle_recoil_line(self.actionArbitrary_nuclei, self.arbitrary_nuclei)
 
-    def update_recoil_legend(self):
+    def update_slice_legend(self):
         visible_lines = 0
         axes = self.canvas.figure.gca()
         for line in axes.get_lines():
@@ -104,6 +102,14 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             legend.draggable()
         else:
             axes.legend_ = None  # remove legend
+
+    def _toggle_slice_legend(self):
+        axes = self.canvas.figure.gca()
+        if axes.legend_ is None:
+            legend = axes.legend(fontsize='small')
+            legend.draggable()
+        else:
+            axes.legend_ = None
 
     def intensity_selection(self, selected):
         '''Ticks selected and un-ticks other intensity options. Returns previous selection'''
@@ -310,6 +316,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         current_axes = self.canvas.figure.gca()
         if current_axes.legend_:
             current_axes.legend_.remove()  # remove old legends
+            return
         if legends is None or not self.legends_shown:
             return
         labels = []
@@ -326,8 +333,11 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         x.draggable()
 
     def _toggle_legend(self):
-        self.legends_shown = not self.legends_shown
-        self.set_legends(self.get_legends())
+        if self.is_slice_figure():
+            self._toggle_slice_legend()
+        else:
+            self.legends_shown = not self.legends_shown
+            self.set_legends(self.get_legends())
         self.canvas.draw()
 
     def get_line_data(self):

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -56,6 +56,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.slice_plotter = slice_plotter
         self.menuIntensity.setDisabled(False)
         self.ws_title = self.title
+        self.arbitrary_nuclei = None
         self.actionS_Q_E.triggered.connect(partial(self.show_intensity_plot, self.actionS_Q_E,
                                                    self.slice_plotter.show_scattering_function, False))
         self.actionChi_Q_E.triggered.connect(partial(self.show_intensity_plot, self.actionChi_Q_E,
@@ -63,6 +64,24 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.actionChi_Q_E_magnetic.triggered.connect(partial(self.show_intensity_plot, self.actionChi_Q_E_magnetic,
                                                               self.slice_plotter.show_dynamical_susceptibility_magnetic,
                                                               True))
+        self.actionHydrogen.triggered.connect(partial(self.toggle_recoil_line, self.actionHydrogen, 1))
+        self.actionDeuterium.triggered.connect(partial(self.toggle_recoil_line, self.actionDeuterium, 2))
+        self.actionHelium.triggered.connect(partial(self.toggle_recoil_line, self.actionHelium, 4))
+        self.actionArbitrary_nuclei.triggered.connect(self.arbitrary_recoil_line)
+    #
+    def toggle_recoil_line(self, action, relative_mass):
+        if action.isChecked():
+            self.slice_plotter.add_recoil_line(self.ws_title, relative_mass)
+        else:
+            self.slice_plotter.hide_recoil_line(self.ws_title, relative_mass)
+        self.canvas.draw()
+
+    def arbitrary_recoil_line(self):
+        if self.actionArbitrary_nuclei.isChecked():
+            self.arbitrary_nuclei, confirm = QInputDialog.getInt(self, 'Arbitrary Nuclei', 'Enter relative mass:')
+            if not confirm:
+                return
+        self.toggle_recoil_line(self.actionArbitrary_nuclei, self.arbitrary_nuclei)
 
     def intensity_selection(self, selected):
         '''Ticks selected and un-ticks other intensity options. Returns previous selection'''

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -316,7 +316,6 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         current_axes = self.canvas.figure.gca()
         if current_axes.legend_:
             current_axes.legend_.remove()  # remove old legends
-            return
         if legends is None or not self.legends_shown:
             return
         labels = []

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -97,7 +97,8 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         for line in axes.get_lines():
             if line.get_linestyle() == '-':
                 visible_lines += 1
-        if visible_lines >= 2:
+                break
+        if visible_lines >= 1:
             legend = axes.legend(fontsize='small')
             legend.draggable()
         else:

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -68,7 +68,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.actionDeuterium.triggered.connect(partial(self.toggle_recoil_line, self.actionDeuterium, 2))
         self.actionHelium.triggered.connect(partial(self.toggle_recoil_line, self.actionHelium, 4))
         self.actionArbitrary_nuclei.triggered.connect(self.arbitrary_recoil_line)
-    #
+
     def toggle_recoil_line(self, action, relative_mass):
         if action.isChecked():
             self.slice_plotter.add_recoil_line(self.ws_title, relative_mass)

--- a/mslice/plotting/plot_window/plot_window.ui
+++ b/mslice/plotting/plot_window/plot_window.ui
@@ -32,6 +32,16 @@
     <property name="title">
      <string>Information</string>
     </property>
+    <widget class="QMenu" name="menuRecoil_lines">
+     <property name="title">
+      <string>Recoil lines</string>
+     </property>
+     <addaction name="actionHydrogen"/>
+     <addaction name="actionDeuterium"/>
+     <addaction name="actionHelium"/>
+     <addaction name="actionArbitrary_nuclei"/>
+    </widget>
+    <addaction name="menuRecoil_lines"/>
    </widget>
    <widget class="QMenu" name="menuIntensity">
     <property name="enabled">
@@ -190,6 +200,38 @@
    </property>
    <property name="text">
     <string>Chi''(Q,E) magnetic</string>
+   </property>
+  </action>
+  <action name="actionHydrogen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Hydrogen</string>
+   </property>
+  </action>
+  <action name="actionDeuterium">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Deuterium</string>
+   </property>
+  </action>
+  <action name="actionHelium">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Helium</string>
+   </property>
+  </action>
+  <action name="actionArbitrary_nuclei">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Arbitrary nuclei</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Plot recoil lines over slices (from issue #163).

Added options to the Information -> Recoil lines menu on slices to toggle Hydrogen, Deuterium or Helium recoil lines. There is also an option to plot any other atom by entering the relative mass.
