### PR TITLE
Refactored cut parameter cache code

### DIFF
--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -26,3 +26,12 @@ class CutAlgorithm(object):
 
     def set_workspace_provider(self, workspace_provider):
         pass
+
+    def set_saved_cut_parameters(self, workspace, axis, parameters):
+        pass
+
+    def get_saved_cut_parameters(self, workspace, axis=None):
+        pass
+
+    def is_axis_saved(self, workspace, axis):
+        pass

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -124,6 +124,15 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         cut_axis.step = (cut_axis.end - cut_axis.start)/float(cut_binning[-1])
         return cut_axis, integration_range, is_norm
 
+    def set_saved_cut_parameters(self, workspace, axis, parameters):
+        self._workspace_provider.setCutParameters(workspace, axis, parameters)
+
+    def get_saved_cut_parameters(self, workspace, axis=None):
+        return self._workspace_provider.getCutParameters(workspace, axis)
+
+    def is_axis_saved(self, workspace, axis):
+        return self._workspace_provider.isAxisSaved(workspace, axis)
+
     def _num_events_normalized_array(self, workspace):
         assert isinstance(workspace, IMDHistoWorkspace)
         with np.errstate(invalid='ignore'):

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -24,6 +24,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         # Stores various parameters of workspaces not stored by Mantid
         self._EfDefined = {}
         self._limits = {}
+        self._cutParameters = {}
 
     def get_workspace_names(self):
         return AnalysisDataService.getObjectNames()
@@ -236,3 +237,26 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             return workspace.getComment()
         ws_handle = self.get_workspace_handle(workspace)
         return ws_handle.getComment()
+
+    def setCutParameters(self, workspace, axis, parameters):
+        if workspace not in self._cutParameters:
+            self._cutParameters[workspace] = dict()
+        self._cutParameters[workspace][axis] = parameters
+        self._cutParameters[workspace]['previous_axis'] = axis
+
+    def getCutParameters(self, workspace, axis=None):
+        if workspace in self._cutParameters:
+            if axis is not None:
+                if axis in self._cutParameters[workspace]:
+                    return self._cutParameters[workspace][axis], axis
+                else:
+                    return None, None
+            else:
+                prev_axis = self._cutParameters[workspace]['previous_axis']
+                return self._cutParameters[workspace][prev_axis], prev_axis
+        return None, None
+
+    def isAxisSaved(self, workspace, axis):
+        if workspace in self._cutParameters:
+            return True if axis in self._cutParameters[workspace] else False
+        return False

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -131,6 +131,8 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             self._limits[new_name] = self._limits.pop(selected_workspace)
         if selected_workspace in self._EfDefined:
             self._EfDefined[new_name] = self._EfDefined.pop(selected_workspace)
+        if selected_workspace in self._cutParameters:
+            self._cutParameters[new_name] = self._cutParameters.pop(selected_workspace)
         return ws
 
     def combine_workspace(self, selected_workspaces, new_name):

--- a/mslice/models/workspacemanager/workspace_provider.py
+++ b/mslice/models/workspacemanager/workspace_provider.py
@@ -51,3 +51,12 @@ class WorkspaceProvider(object):
 
     def getComment(self, workspace):
         pass
+
+    def setCutParameters(self, workspace, axis, parameters):
+        pass
+
+    def getCutParameters(self, workspace, axis=None):
+        pass
+
+    def isAxisSaved(self, workspace, axis):
+        pass

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -211,6 +211,7 @@ class CutPresenter(PresenterUtility):
                 current_axis = axis[0]
                 saved_parameters = None
 
+            self._cut_view.clear_input_fields()
             self._cut_view.populate_cut_axis_options(axis)
             self._cut_view.enable()
             self._cut_view.set_cut_axis(current_axis)

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -76,6 +76,7 @@ class CutPresenterTest(unittest.TestCase):
         fields = dict()
         fields['axes'] = available_dimensions
         self.view.get_input_fields = mock.Mock(return_value=fields)
+        self.view.is_fields_cleared = mock.Mock(return_value=False)
         cut_presenter.workspace_selection_changed()
         self.view.get_cut_axis.assert_called_with()
         # Change back to check that it repopulates the fields
@@ -405,6 +406,7 @@ class CutPresenterTest(unittest.TestCase):
         fields1['normtounity'] = False
         self.view.get_input_fields = mock.Mock(return_value=fields1)
         self.view.get_cut_axis = mock.Mock(return_value='dim2')
+        self.view.is_fields_cleared = mock.Mock(return_value=False)
         cut_presenter.notify(Command.AxisChanged)
         self.view.clear_input_fields.assert_called_with(keep_axes=True)
         self.view.populate_input_fields.assert_not_called()

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -377,6 +377,7 @@ class CutPresenterTest(unittest.TestCase):
         integrated_axis = 'integrated axis'
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, selected_workspaces, integrated_axis)
+        self.cut_algorithm.get_saved_cut_parameters = mock.Mock(return_value=(None, None))
         cut_presenter.notify(Command.Plot)
         call_list = [
             call(selected_workspace=selected_workspaces[0], cut_axis=processed_axis,

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -94,5 +94,8 @@ class CutView:
     def clear_input_fields(self, **kwargs):
         pass
 
+    def is_fields_cleared(self):
+        pass
+
     def clear_displayed_error(self):
         pass

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -143,6 +143,18 @@ class CutWidget(QWidget, CutView, Ui_Form):
         self.lneCutSmoothing.setText("")
         self.rdoCutNormToOne.setChecked(0)
 
+    def is_fields_cleared(self):
+        current_fields = self.get_input_fields()
+        cleared_fields = {'cut_parameters': ['', '', ''],
+                          'integration_range': ['', ''],
+                          'integration_width': '',
+                          'smoothing': '',
+                          'normtounity': False}
+        for k in cleared_fields:
+            if current_fields[k] != cleared_fields[k]:
+                return False
+        return True
+
     def populate_input_fields(self, saved_input):
         self.populate_cut_params(*saved_input['cut_parameters'])
         self.populate_integration_params(*saved_input['integration_range'])


### PR DESCRIPTION
The code to store cut parameters previously defined by the user in the `Cut` tab has now been moved into the `MantidWorkspaceProvider` class from the `CutPresenter` class. This means that workspace operations (especially `RenameWorkspace`) will not break the caching system (because the parameters are stored as `dict` entries keyed by the workspace name).

**To test:**

Load several input files and calculate projections for them (making sure they are the same type, e.g. all Q-E or 2theta-E). Select one of the projected workspace and go to the cut axis and put some numbers into the fields there. Now click on another projected workspace and check the numbers in the fields remain unchanged. Click on a non-projected workspace and check the numbers are cleared and fields are disabled. Click again on a previously selected projected workspace and check the numbers are the same as what you previously inputed.

Now change the axis type (e.g. from `MomentumTransfer` to `DeltaE`) and put in some other numbers. Now click on another projected workspace and check that the numbers are copied over (remain unchanged). Click on a non-projected workspace and check the numbers are cleared and fields are disabled. Click on any of the previously selected workspaces and check that the cut parameters (including the axis type you last left it on) are correct.

Rename one of the projected workspaces and check that the cut parameters are still ok.

Fixes #172
