### PR TITLE
Refactor PlotFigureManager using separate slice/cut classes

### DIFF
--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -23,6 +23,7 @@ class MatplotlibCutPlotter(CutPlotter):
         plt.ylabel(INTENSITY_LABEL)
         plt.autoscale()
         plt.ylim(intensity_start, intensity_end)
+        plt.gcf().canvas.manager.add_cut_plot(self)
         plt.draw_all()
 
     def _getDisplayName(self, axisUnits, comment=None):

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -28,7 +28,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
         self.overplot_lines[selected_ws] = {}
         self.show_scattering_function(selected_ws)
         plt.gcf().canvas.set_window_title(selected_ws)
-        plt.gcf().canvas.manager.add_slice_plotter(self)
+        plt.gcf().canvas.manager.add_slice_plot(self)
         plt.draw_all()
 
     def _cache_slice(self, plot_data, ws, boundaries, colourmap, norm, sample_temp, x_axis, y_axis):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -11,19 +11,19 @@ class CutPlot(object):
 
     def __init__(self, plot_figure, canvas, cut_plotter):
         self.plot_figure = plot_figure
-        self.canvas = canvas
-        self.cut_plotter = cut_plotter
-        self.lines_visible = {}
-        self.legends_shown = True
-        self.legends_visible = []
-        self.legend_dict = {}
+        self._canvas = canvas
+        self._cut_plotter = cut_plotter
+        self._lines_visible = {}
+        self._legends_shown = True
+        self._legends_visible = []
+        self._legend_dict = {}
         plot_figure.menuIntensity.setDisabled(True)
         plot_figure.menuInformation.setDisabled(True)
 
     def plot_options(self):
         new_config = CutPlotOptionsPresenter(CutPlotOptions(), self).get_new_config()
         if new_config:
-            self.canvas.draw()
+            self._canvas.draw()
 
     def object_clicked(self, target):
         pass  # not yet implemented
@@ -44,7 +44,7 @@ class CutPlot(object):
         return np.min(running_min) if running_min else absolute_minimum
 
     def change_axis_scale(self, xy_config):
-        current_axis = self.canvas.figure.gca()
+        current_axis = self._canvas.figure.gca()
         if xy_config['x_log']:
             xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
             xmin = self.get_min(xdata, absolute_minimum=0.)
@@ -67,7 +67,7 @@ class CutPlot(object):
     def _has_errorbars(self):
         """True current axes has visible errorbars,
          False if current axes has hidden errorbars"""
-        current_axis = self.canvas.figure.gca()
+        current_axis = self._canvas.figure.gca()
         # If all the error bars have alpha= 0 they are all transparent (hidden)
         containers = [x for x in current_axis.containers if isinstance(x, ErrorbarContainer)]
         line_components = [x.get_children() for x in containers]
@@ -85,7 +85,7 @@ class CutPlot(object):
 
     def _set_errorbars_shown_state(self, state):
         """Show errrorbar if state = 1, hide if state = 0"""
-        current_axis = self.canvas.figure.gca()
+        current_axis = self._canvas.figure.gca()
         if state:
             alpha = 1
         else:
@@ -103,23 +103,23 @@ class CutPlot(object):
         self._set_errorbars_shown_state(not state)
 
     def get_legends(self):
-        current_axis = self.canvas.figure.gca()
+        current_axis = self._canvas.figure.gca()
         legends = []
         labels = current_axis.get_legend_handles_labels()[1]
         for i in range(len(labels)):
             try:
-                v = self.legends_visible[i]
+                v = self._legends_visible[i]
             except IndexError:
                 v = True
-                self.legends_visible.append(True)
+                self._legends_visible.append(True)
             legends.append({'label': labels[i], 'visible': v})
         return legends
 
     def set_legends(self, legends):
-        current_axes = self.canvas.figure.gca()
+        current_axes = self._canvas.figure.gca()
         if current_axes.legend_:
             current_axes.legend_.remove()  # remove old legends
-        if legends is None or not self.legends_shown:
+        if legends is None or not self._legends_shown:
             return
         labels = []
         handles_to_show = []
@@ -130,20 +130,20 @@ class CutPlot(object):
             if legends[i]['visible']:
                 handles_to_show.append(handles[i])
                 labels.append(legends[i]['label'])
-            self.legends_visible[i] = legends[i]['visible']
+            self._legends_visible[i] = legends[i]['visible']
         x = current_axes.legend(handles_to_show, labels)  # add new legends
         x.draggable()
 
     def toggle_legend(self):
-        self.legends_shown = not self.legends_shown
+        self._legends_shown = not self._legends_shown
         self.set_legends(self.get_legends())
-        self.canvas.draw()
+        self._canvas.draw()
 
     def get_line_data(self):
         legends = self.get_legends()
         all_line_options = []
         i = 0
-        for line_group in self.canvas.figure.gca().containers:
+        for line_group in self._canvas.figure.gca().containers:
             line_options = {}
             line = line_group.get_children()[0]
             line_options['shown'] = self.get_line_visible(i)
@@ -161,7 +161,7 @@ class CutPlot(object):
         for line in line_data:
             legend, line_options = line
             legends.append(legend)
-            line_model = self.canvas.figure.gca().containers[i]
+            line_model = self._canvas.figure.gca().containers[i]
             self.set_line_visible(i, line_options['shown'])
             for child in line_model.get_children():
                 child.set_color(line_options['color'])
@@ -173,25 +173,25 @@ class CutPlot(object):
         self.set_legends(legends)
 
     def set_line_visible(self, line_index, visible):
-        self.lines_visible[line_index] = visible
-        for child in self.canvas.figure.gca().containers[line_index].get_children():
+        self._lines_visible[line_index] = visible
+        for child in self._canvas.figure.gca().containers[line_index].get_children():
             child.set_visible(visible)
 
     def get_line_visible(self, line_index):
         try:
-            ret = self.lines_visible[line_index]
+            ret = self._lines_visible[line_index]
             return ret
         except KeyError:
-            self.lines_visible[line_index] = True
+            self._lines_visible[line_index] = True
             return True
 
     @property
     def x_log(self):
-        return 'log' in self.canvas.figure.gca().get_xscale()
+        return 'log' in self._canvas.figure.gca().get_xscale()
 
     @property
     def y_log(self):
-        return 'log' in self.canvas.figure.gca().get_yscale()
+        return 'log' in self._canvas.figure.gca().get_yscale()
 
     @property
     def error_bars(self):
@@ -203,11 +203,11 @@ class CutPlot(object):
 
     @property
     def show_legends(self):
-        return self.legends_shown
+        return self._legends_shown
 
     @show_legends.setter
     def show_legends(self, value):
-        self.legends_shown = value
+        self._legends_shown = value
 
     @property
     def title(self):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -1,0 +1,255 @@
+from itertools import chain
+
+from matplotlib.container import ErrorbarContainer
+import numpy as np
+
+from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter
+from .plot_options import CutPlotOptions
+
+
+class CutPlot(object):
+
+    def __init__(self, plot_figure, canvas, cut_plotter):
+        self.plot_figure = plot_figure
+        self.canvas = canvas
+        self.cut_plotter = cut_plotter
+        self.lines_visible = {}
+        self.legends_shown = True
+        self.legends_visible = []
+        self.legend_dict = {}
+        plot_figure.menuIntensity.setDisabled(True)
+        plot_figure.menuInformation.setDisabled(True)
+
+    def plot_options(self):
+        new_config = CutPlotOptionsPresenter(CutPlotOptions(), self).get_new_config()
+        if new_config:
+            self.canvas.draw()
+
+    @staticmethod
+    def get_min(data, absolute_minimum=-np.inf):
+        """Determines the minimum of a set of numpy arrays"""
+        data = data if isinstance(data, list) else [data]
+        running_min = []
+        for values in data:
+            try:
+                running_min.append(np.min(values[np.isfinite(values) * (values > absolute_minimum)]))
+            except ValueError:  # If data is empty or not array of numbers
+                pass
+        return np.min(running_min) if running_min else absolute_minimum
+
+    def change_cut_plot(self, xy_config):
+        current_axis = self.canvas.figure.gca()
+        if xy_config['x_log']:
+            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            xmin = self.get_min(xdata, absolute_minimum=0.)
+            current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(xmin))))
+            if xmin > 0:
+                xy_config['x_range'] = (xmin, xy_config['x_range'][1])
+        else:
+            current_axis.set_xscale('linear')
+        if xy_config['y_log']:
+            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
+            ymin = self.get_min(ydata, absolute_minimum=0.)
+            current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(ymin))))
+            if ymin > 0:
+                xy_config['y_range'] = (ymin, xy_config['y_range'][1])
+        else:
+            current_axis.set_yscale('linear')
+        self.x_range = xy_config['x_range']
+        self.y_range = xy_config['y_range']
+
+    def _has_errorbars(self):
+        """True current axes has visible errorbars,
+         False if current axes has hidden errorbars"""
+        current_axis = self.canvas.figure.gca()
+        # If all the error bars have alpha= 0 they are all transparent (hidden)
+        containers = [x for x in current_axis.containers if isinstance(x, ErrorbarContainer)]
+        line_components = [x.get_children() for x in containers]
+        # drop the first element of each container because it is the the actual line
+        errorbars = [x[1:] for x in line_components]
+        errorbars = chain(*errorbars)
+        alpha = [x.get_alpha() for x in errorbars]
+        # replace None with 1(None indicates default which is 1)
+        alpha = [x if x is not None else 1 for x in alpha]
+        if sum(alpha) == 0:
+            has_errorbars = False
+        else:
+            has_errorbars = True
+        return has_errorbars
+
+    def _set_errorbars_shown_state(self, state):
+        """Show errrorbar if state = 1, hide if state = 0"""
+        current_axis = self.canvas.figure.gca()
+        if state:
+            alpha = 1
+        else:
+            alpha = 0.
+        for i in range(len(current_axis.containers)):
+            if isinstance(current_axis.containers[i], ErrorbarContainer):
+                elements = current_axis.containers[i].get_children()
+                if self.get_line_visible(i):
+                    elements[1].set_alpha(alpha)  # elements[0] is the actual line, elements[1] is error bars
+
+    def _toggle_errorbars(self):
+        state = self._has_errorbars()
+        if state is None:  # No errorbars in this plot
+            return
+        self._set_errorbars_shown_state(not state)
+
+    def get_legends(self):
+        current_axis = self.canvas.figure.gca()
+        legends = []
+        labels = current_axis.get_legend_handles_labels()[1]
+        for i in range(len(labels)):
+            try:
+                v = self.legends_visible[i]
+            except IndexError:
+                v = True
+                self.legends_visible.append(True)
+            legends.append({'label': labels[i], 'visible': v})
+        return legends
+
+    def set_legends(self, legends):
+        current_axes = self.canvas.figure.gca()
+        if current_axes.legend_:
+            current_axes.legend_.remove()  # remove old legends
+        if legends is None or not self.legends_shown:
+            return
+        labels = []
+        handles_to_show = []
+        handles = current_axes.get_legend_handles_labels()[0]
+        for i in range(len(legends)):
+            container = current_axes.containers[i]
+            container.set_label(legends[i]['label'])
+            if legends[i]['visible']:
+                handles_to_show.append(handles[i])
+                labels.append(legends[i]['label'])
+            self.legends_visible[i] = legends[i]['visible']
+        x = current_axes.legend(handles_to_show, labels)  # add new legends
+        x.draggable()
+
+    def toggle_legend(self):
+        self.legends_shown = not self.legends_shown
+        self.set_legends(self.get_legends())
+        self.canvas.draw()
+
+    def get_line_data(self):
+        legends = self.get_legends()
+        all_line_options = []
+        i = 0
+        for line_group in self.canvas.figure.gca().containers:
+            line_options = {}
+            line = line_group.get_children()[0]
+            line_options['shown'] = self.get_line_visible(i)
+            line_options['color'] = line.get_color()
+            line_options['style'] = line.get_linestyle()
+            line_options['width'] = str(int(line.get_linewidth()))
+            line_options['marker'] = line.get_marker()
+            all_line_options.append(line_options)
+            i += 1
+        return list(zip(legends, all_line_options))
+
+    def set_line_data(self, line_data):
+        legends = []
+        i = 0
+        for line in line_data:
+            legend, line_options = line
+            legends.append(legend)
+            line_model = self.canvas.figure.gca().containers[i]
+            self.set_line_visible(i, line_options['shown'])
+            for child in line_model.get_children():
+                child.set_color(line_options['color'])
+                child.set_linewidth(line_options['width'])
+            main_line = line_model.get_children()[0]
+            main_line.set_linestyle(line_options['style'])
+            main_line.set_marker(line_options['marker'])
+            i += 1
+        self.set_legends(legends)
+
+    def set_line_visible(self, line_index, visible):
+        self.lines_visible[line_index] = visible
+        for child in self.canvas.figure.gca().containers[line_index].get_children():
+            child.set_visible(visible)
+
+    def get_line_visible(self, line_index):
+        try:
+            ret = self.lines_visible[line_index]
+            return ret
+        except KeyError:
+            self.lines_visible[line_index] = True
+            return True
+
+    def __getattr__(self, name):
+        '''overridden to access shared properties of plot_figure. Called if property lookup fails'''
+        return getattr(self.plot_figure, name)
+
+    def __setattr__(self, name, value):
+        '''overridden to access shared properties of plot_figure. Always called when setting attribute'''
+        try:
+            object.__setattr__(self, name, value)
+        except KeyError:
+            setattr(self.plot_figure, name, value)
+
+    @property
+    def x_log(self):
+        return 'log' in self.canvas.figure.gca().get_xscale()
+
+    @property
+    def y_log(self):
+        return 'log' in self.canvas.figure.gca().get_yscale()
+
+    @property
+    def error_bars(self):
+        return self._has_errorbars()
+
+    @error_bars.setter
+    def error_bars(self, value):
+        self._set_errorbars_shown_state(value)
+
+    @property
+    def show_legends(self):
+        return self.legends_shown
+
+    @show_legends.setter
+    def show_legends(self, value):
+        self.legends_shown = value
+
+    @property
+    def title(self):
+        return self.plot_figure.title
+
+    @title.setter
+    def title(self, value):
+        self.plot_figure.title = value
+
+    @property
+    def x_label(self):
+        return self.plot_figure.x_label
+
+    @x_label.setter
+    def x_label(self, value):
+        self.plot_figure.x_label = value
+
+    @property
+    def y_label(self):
+        return self.plot_figure.y_label
+
+    @y_label.setter
+    def y_label(self, value):
+        self.plot_figure.y_label = value
+
+    @property
+    def x_range(self):
+        return self.plot_figure.x_range
+
+    @x_range.setter
+    def x_range(self, value):
+        self.plot_figure.x_range = value
+
+    @property
+    def y_range(self):
+        return self.plot_figure.y_range
+
+    @y_range.setter
+    def y_range(self, value):
+        self.plot_figure.y_range = value

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -37,7 +37,7 @@ class CutPlot(object):
                 pass
         return np.min(running_min) if running_min else absolute_minimum
 
-    def change_cut_plot(self, xy_config):
+    def change_axis_scale(self, xy_config):
         current_axis = self.canvas.figure.gca()
         if xy_config['x_log']:
             xdata = [ll.get_xdata() for ll in current_axis.get_lines()]

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -25,6 +25,12 @@ class CutPlot(object):
         if new_config:
             self.canvas.draw()
 
+    def object_clicked(self, target):
+        pass  # not yet implemented
+
+    def plot_clicked(self, x, y):
+        pass  # not yet implemented
+
     @staticmethod
     def get_min(data, absolute_minimum=-np.inf):
         """Determines the minimum of a set of numpy arrays"""

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -179,17 +179,6 @@ class CutPlot(object):
             self.lines_visible[line_index] = True
             return True
 
-    def __getattr__(self, name):
-        '''overridden to access shared properties of plot_figure. Called if property lookup fails'''
-        return getattr(self.plot_figure, name)
-
-    def __setattr__(self, name, value):
-        '''overridden to access shared properties of plot_figure. Always called when setting attribute'''
-        try:
-            object.__setattr__(self, name, value)
-        except KeyError:
-            setattr(self.plot_figure, name, value)
-
     @property
     def x_log(self):
         return 'log' in self.canvas.figure.gca().get_xscale()

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -8,7 +8,6 @@ import six
 
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.cut_plot import CutPlot
-from mslice.presenters.quick_options_presenter import quick_options
 
 from .plot_window_ui import Ui_MainWindow
 from .base_qt_plot_window import BaseQtPlotWindow
@@ -19,8 +18,6 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         super(PlotFigureManager, self).__init__(number, manager)
 
         self.plot_handler = None
-        self.quick_presenter = None
-        self.legend_dict = {}
 
         self.actionKeep.triggered.connect(self._report_as_kept_to_manager)
         self.actionMakeCurrent.triggered.connect(self._report_as_current_to_manager)
@@ -51,38 +48,11 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
 
     def plot_clicked(self, event):
         if event.dblclick:
-            x = event.x
-            y = event.y
-            bounds = self.calc_figure_boundaries()
-            if bounds['x_label'] < y < bounds['title']:
-                if bounds['y_label'] < x < bounds['colorbar_label']:
-                    if y < bounds['x_range']:
-                        self.quick_presenter = quick_options('x_range', self)
-                    elif x < bounds['y_range']:
-                        self.quick_presenter = quick_options('y_range', self)
-                    elif x > bounds['colorbar_range']:
-                        self.quick_presenter = quick_options('colorbar_range', self)
+            self.plot_handler.plot_clicked(event.x, event.y)
 
     def object_clicked(self, event):
         if event.mouseevent.dblclick:
-            target = event.artist
-            if target in self.legend_dict:
-                self.quick_presenter = quick_options(self.legend_dict[target], self)
-            else:
-                self.quick_presenter = quick_options(target, self)
-            self.plot_handler.post_click_event()
-
-    def calc_figure_boundaries(self):
-        fig_x, fig_y = self.canvas.figure.get_size_inches() * self.canvas.figure.dpi
-        bounds = {}
-        bounds['y_label'] = fig_x * 0.07
-        bounds['y_range'] = fig_x * 0.12
-        bounds['colorbar_range'] = fig_x * 0.75
-        bounds['colorbar_label'] = fig_x * 0.86
-        bounds['title'] = fig_y * 0.9
-        bounds['x_range'] = fig_y * 0.09
-        bounds['x_label'] = fig_y * 0.05
-        return bounds
+            self.plot_handler.object_clicked(event.artist)
 
     def toggle_data_cursor(self):
         if self.actionDataCursor.isChecked():

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -1,41 +1,26 @@
 from __future__ import (absolute_import, division, print_function)
-from functools import partial
-from itertools import chain
 
-from mantid.simpleapi import AnalysisDataService
 from matplotlib.backends.backend_qt4 import NavigationToolbar2QT
-from matplotlib.container import ErrorbarContainer
-import matplotlib.colors as colors
 
 from PyQt4.QtCore import Qt
-
 from PyQt4 import QtGui
-import numpy as np
-import os.path as path
 import six
 
-from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter, SlicePlotOptionsPresenter
+from mslice.plotting.plot_window.slice_plot import SlicePlot
+from mslice.plotting.plot_window.cut_plot import CutPlot
 from mslice.presenters.quick_options_presenter import quick_options
 
 from .plot_window_ui import Ui_MainWindow
 from .base_qt_plot_window import BaseQtPlotWindow
-from .plot_options import SlicePlotOptions, CutPlotOptions
 
 
 class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
     def __init__(self, number, manager):
         super(PlotFigureManager, self).__init__(number, manager)
 
-        self.legends_shown = True
-        self.legends_visible = []
-        self.lines_visible = {}
-        self.legend_dict = {}
-        self.slice_plotter = None
-        self.workspace_title = None
-        self.menuIntensity.setDisabled(True)
-        self.menuInformation.setDisabled(True)
-        self.cif_file = None
+        self.plot_handler = None
         self.quick_presenter = None
+        self.legend_dict = {}
 
         self.actionKeep.triggered.connect(self._report_as_kept_to_manager)
         self.actionMakeCurrent.triggered.connect(self._report_as_current_to_manager)
@@ -50,6 +35,8 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.action_Print_Plot.triggered.connect(self.print_plot)
         self.actionPlotOptions.triggered.connect(self._plot_options)
         self.actionToggleLegends.triggered.connect(self._toggle_legend)
+        self.canvas.mpl_connect('button_press_event', self.plot_clicked)
+        self.canvas.mpl_connect('pick_event', self.object_clicked)
 
         self.show()  # is not a good idea in non interactive mode
 
@@ -59,42 +46,14 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
     def is_cut_figure(self):
         return not bool(self.canvas.figure.gca().get_images())
 
-    def add_slice_plotter(self, slice_plotter):
-        self.slice_plotter = slice_plotter
-        self.menuIntensity.setDisabled(False)
-        self.menuInformation.setDisabled(False)
-        self.ws_title = self.title
-        self.arbitrary_nuclei = None
+    def add_slice_plot(self, slice_plotter):
+        self.plot_handler = SlicePlot(self, self.canvas, slice_plotter)
 
-        self.actionS_Q_E.triggered.connect(partial(self.show_intensity_plot, self.actionS_Q_E,
-                                                   self.slice_plotter.show_scattering_function, False))
-        self.actionChi_Q_E.triggered.connect(partial(self.show_intensity_plot, self.actionChi_Q_E,
-                                                     self.slice_plotter.show_dynamical_susceptibility, True))
-        self.actionChi_Q_E_magnetic.triggered.connect(partial(self.show_intensity_plot, self.actionChi_Q_E_magnetic,
-                                                              self.slice_plotter.show_dynamical_susceptibility_magnetic,
-                                                              True))
-        self.actionD2sigma_dOmega_dE.triggered.connect(partial(self.show_intensity_plot, self.actionD2sigma_dOmega_dE,
-                                                               self.slice_plotter.show_d2sigma, False))
-        self.actionSymmetrised_S_Q_E.triggered.connect(partial(self.show_intensity_plot, self.actionSymmetrised_S_Q_E,
-                                                               self.slice_plotter.show_symmetrised, True))
-        self.actionGDOS.triggered.connect(partial(self.show_intensity_plot, self.actionGDOS,
-                                                  self.slice_plotter.show_gdos, True))
+    def add_cut_plot(self, cut_plotter):
+        self.plot_handler = CutPlot(self, self.canvas, cut_plotter)
 
-        self.actionHydrogen.triggered.connect(partial(self.toggle_overplot_line, self.actionHydrogen, 1, True))
-        self.actionDeuterium.triggered.connect(partial(self.toggle_overplot_line, self.actionDeuterium, 2, True))
-        self.actionHelium.triggered.connect(partial(self.toggle_overplot_line, self.actionHelium, 4, True))
-        self.actionArbitrary_nuclei.triggered.connect(self.arbitrary_recoil_line)
-        self.actionAluminium.triggered.connect(partial(self.toggle_overplot_line, self.actionAluminium,
-                                                       'Aluminium', False))
-        self.actionCopper.triggered.connect(partial(self.toggle_overplot_line, self.actionCopper,
-                                                    'Copper', False))
-        self.actionNiobium.triggered.connect(partial(self.toggle_overplot_line, self.actionNiobium,
-                                                     'Niobium', False))
-        self.actionTantalum.triggered.connect(partial(self.toggle_overplot_line, self.actionTantalum,
-                                                      'Tantalum', False))
-        self.actionCIF_file.triggered.connect(partial(self.cif_file_powder_line))
-        self.canvas.mpl_connect('button_press_event', self.plot_clicked)
-        self.canvas.mpl_connect('pick_event', self.object_clicked)
+    def _toggle_legend(self):
+        self.plot_handler.toggle_legend()
 
     def plot_clicked(self, event):
         x = event.x
@@ -111,68 +70,12 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
 
     def object_clicked(self, event):
         target = event.artist
+        print(self.legend_dict)
         if target in self.legend_dict:
             self.quick_presenter = quick_options(self.legend_dict[target], self)
         else:
             self.quick_presenter = quick_options(target, self)
-
-    def reset_info_checkboxes(self):
-        for key, line in six.iteritems(self.slice_plotter.overplot_lines[self.ws_title]):
-            if str(line.get_linestyle()) == 'None':
-                if isinstance(key, int):
-                    key = self.slice_plotter.get_recoil_label(key)
-                action_checked = getattr(self, 'action' + key)
-                action_checked.setChecked(False)
-
-    def toggle_overplot_line(self, action, key, recoil, checked, cif_file=None):
-        if checked:
-            self.slice_plotter.add_overplot_line(self.ws_title, key, recoil, cif_file)
-        else:
-            self.slice_plotter.hide_overplot_line(self.ws_title, key)
-        self.update_slice_legend()
-        self.canvas.draw()
-
-    def arbitrary_recoil_line(self):
-        if self.actionArbitrary_nuclei.isChecked():
-            self.arbitrary_nuclei, confirm = QtGui.QInputDialog.getInt(self, 'Arbitrary Nuclei', 'Enter relative mass:')
-            if not confirm:
-                return
-        self.toggle_overplot_line(self.actionArbitrary_nuclei, self.arbitrary_nuclei, True)
-
-    def cif_file_powder_line(self, checked):
-        if checked:
-            cif_path = str(QtGui.QFileDialog().getOpenFileName(self, 'Open CIF file', '/home', 'Files (*.cif)'))
-            key = path.basename(cif_path).rsplit('.')[0]
-            self.cif_file = key
-        else:
-            key = self.cif_file
-            cif_path = None
-        self.toggle_overplot_line(self.actionCIF_file, key, False, self.actionCIF_file.isChecked(), cif_file=cif_path)
-
-    def update_slice_legend(self):
-        lines = []
-        axes = self.canvas.figure.gca()
-        for line in axes.get_lines():
-            if str(line.get_linestyle()) != 'None' and line.get_label() != '':
-                lines.append(line)
-        if len(lines) > 0:
-            legend = axes.legend(fontsize='small')
-            legend.draggable()
-            for legline, line in zip(legend.get_lines(), lines):
-                legline.set_picker(5)
-                self.legend_dict[legline] = line
-            for label, line in zip(legend.get_texts(), lines):
-                label.set_picker(5)
-                self.legend_dict[label] = line
-        else:
-            axes.legend_ = None  # remove legend
-
-    def _toggle_slice_legend(self):
-        axes = self.canvas.figure.gca()
-        if axes.legend_ is None:
-            self.update_slice_legend()
-        else:
-            axes.legend_ = None
+        self.plot_handler.post_click_event()
 
     def calc_figure_boundaries(self):
         fig_x, fig_y = self.canvas.figure.get_size_inches() * self.canvas.figure.dpi
@@ -185,64 +88,6 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         bounds['x_range'] = fig_y * 0.09
         bounds['x_label'] = fig_y * 0.05
         return bounds
-
-    def intensity_selection(self, selected):
-        '''Ticks selected and un-ticks other intensity options. Returns previous selection'''
-        options = self.menuIntensity.actions()
-        previous = None
-        for op in options:
-            if op.isChecked() and op is not selected:
-                previous = op
-            op.setChecked(False)
-        selected.setChecked(True)
-        return previous
-
-    def show_intensity_plot(self, action, slice_plotter_method, temp_dependent):
-        if action.isChecked():
-            previous = self.intensity_selection(action)
-            cbar_log = self.colorbar_log
-            x_range = self.x_range
-            y_range = self.y_range
-            title = self.title
-            if temp_dependent:
-                if not self._run_temp_dependent(slice_plotter_method, previous):
-                    return
-            else:
-                slice_plotter_method(self.ws_title)
-            self.change_slice_plot(self.colorbar_range, cbar_log)
-            self.x_range = x_range
-            self.y_range = y_range
-            self.title = title
-            self.canvas.draw()
-        else:
-            action.setChecked(True)
-
-    def _run_temp_dependent(self, slice_plotter_method, previous):
-        try:
-            slice_plotter_method(self.ws_title)
-        except ValueError:  # sample temperature not yet set
-            try:
-                field = self.ask_sample_temperature_field(str(self.ws_title))
-            except RuntimeError:  # if cancel is clicked, go back to previous selection
-                self.intensity_selection(previous)
-                return False
-            self.slice_plotter.add_sample_temperature_field(field)
-            self.slice_plotter.update_sample_temperature(self.ws_title)
-            slice_plotter_method(self.ws_title)
-        return True
-
-    def ask_sample_temperature_field(self, ws_name):
-        if ws_name[-3:] == '_QE':
-            ws_name = ws_name[:-3]
-        ws = AnalysisDataService[ws_name]
-        temp_field, confirm = QtGui.QInputDialog.getItem(self, 'Sample Temperature',
-                                                         'Sample Temperature not found. ' +
-                                                         'Select the sample temperature field:',
-                                                         ws.run().keys(), False)
-        if not confirm:
-            raise RuntimeError("sample_temperature_dialog cancelled")
-        else:
-            return str(temp_field)
 
     def toggle_data_cursor(self):
         if self.actionDataCursor.isChecked():
@@ -261,13 +106,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             self.actionKeep.setChecked(False)
 
     def _plot_options(self):
-        if self.is_slice_figure():
-            view_class, presenter_class = SlicePlotOptions, SlicePlotOptionsPresenter
-        else:
-            view_class, presenter_class = CutPlotOptions, CutPlotOptionsPresenter
-        new_config = presenter_class(view_class(), self).get_new_config()
-        if new_config:
-            self.canvas.draw()
+        self.plot_handler.plot_options()
 
     def print_plot(self):
         printer = QtGui.QPrinter()
@@ -281,184 +120,6 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             painter = QtGui.QPainter(printer)
             painter.drawPixmap(0,0,pixmap_image)
             painter.end()
-
-    @staticmethod
-    def get_min(data, absolute_minimum=-np.inf):
-        """Determines the minimum of a set of numpy arrays"""
-        data = data if isinstance(data, list) else [data]
-        running_min = []
-        for values in data:
-            try:
-                running_min.append(np.min(values[np.isfinite(values) * (values > absolute_minimum)]))
-            except ValueError:  # If data is empty or not array of numbers
-                pass
-        return np.min(running_min) if running_min else absolute_minimum
-
-    def change_cut_plot(self, xy_config):
-        current_axis = self.canvas.figure.gca()
-        if xy_config['x_log']:
-            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
-            xmin = self.get_min(xdata, absolute_minimum=0.)
-            current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(xmin))))
-            if xmin > 0:
-                xy_config['x_range'] = (xmin, xy_config['x_range'][1])
-        else:
-            current_axis.set_xscale('linear')
-        if xy_config['y_log']:
-            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
-            ymin = self.get_min(ydata, absolute_minimum=0.)
-            current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(ymin))))
-            if ymin > 0:
-                xy_config['y_range'] = (ymin, xy_config['y_range'][1])
-        else:
-            current_axis.set_yscale('linear')
-        self.x_range = xy_config['x_range']
-        self.y_range = xy_config['y_range']
-
-    def change_slice_plot(self, colorbar_range, logarithmic):
-        current_axis = self.canvas.figure.gca()
-        images = current_axis.get_images()
-        if len(images) != 1:
-            raise RuntimeError("Expected single image on axes, found " + str(len(images)))
-        mappable = images[0]
-        vmin, vmax = colorbar_range
-        if logarithmic and type(mappable.norm) != colors.LogNorm:
-            mappable.colorbar.remove()
-            if vmin == float(0):
-                vmin = 0.001
-            norm = colors.LogNorm(vmin, vmax)
-            mappable.set_norm(norm)
-            self.canvas.figure.colorbar(mappable)
-        elif not logarithmic and type(mappable.norm) != colors.Normalize:
-            mappable.colorbar.remove()
-            norm = colors.Normalize(vmin, vmax)
-            mappable.set_norm(norm)
-            self.canvas.figure.colorbar(mappable)
-        mappable.set_clim((vmin, vmax))
-
-    def _has_errorbars(self):
-        """True current axes has visible errorbars,
-         False if current axes has hidden errorbars"""
-        current_axis = self.canvas.figure.gca()
-        # If all the error bars have alpha= 0 they are all transparent (hidden)
-        containers = [x for x in current_axis.containers if isinstance(x, ErrorbarContainer)]
-        line_components = [x.get_children() for x in containers]
-        # drop the first element of each container because it is the the actual line
-        errorbars = [x[1:] for x in line_components]
-        errorbars = chain(*errorbars)
-        alpha = [x.get_alpha() for x in errorbars]
-        # replace None with 1(None indicates default which is 1)
-        alpha = [x if x is not None else 1 for x in alpha]
-        if sum(alpha) == 0:
-            has_errorbars = False
-        else:
-            has_errorbars = True
-        return has_errorbars
-
-    def _set_errorbars_shown_state(self, state):
-        """Show errrorbar if state = 1, hide if state = 0"""
-        current_axis = self.canvas.figure.gca()
-        if state:
-            alpha = 1
-        else:
-            alpha = 0.
-        for i in range(len(current_axis.containers)):
-            if isinstance(current_axis.containers[i], ErrorbarContainer):
-                elements = current_axis.containers[i].get_children()
-                if self.get_line_visible(i):
-                    elements[1].set_alpha(alpha) #  elements[0] is the actual line, elements[1] is error bars
-
-    def _toggle_errorbars(self):
-        state = self._has_errorbars()
-        if state is None:  # No errorbars in this plot
-            return
-        self._set_errorbars_shown_state(not state)
-
-    def get_legends(self):
-        current_axis = self.canvas.figure.gca()
-        legends = []
-        labels = current_axis.get_legend_handles_labels()[1]
-        for i in range(len(labels)):
-            try:
-                v = self.legends_visible[i]
-            except IndexError:
-                v = True
-                self.legends_visible.append(True)
-            legends.append({'label': labels[i], 'visible': v})
-        return legends
-
-    def set_legends(self, legends):
-        current_axes = self.canvas.figure.gca()
-        if current_axes.legend_:
-            current_axes.legend_.remove()  # remove old legends
-        if legends is None or not self.legends_shown:
-            return
-        labels = []
-        handles_to_show = []
-        handles = current_axes.get_legend_handles_labels()[0]
-        for i in range(len(legends)):
-            container = current_axes.containers[i]
-            container.set_label(legends[i]['label'])
-            if legends[i]['visible']:
-                handles_to_show.append(handles[i])
-                labels.append(legends[i]['label'])
-            self.legends_visible[i] = legends[i]['visible']
-        x = current_axes.legend(handles_to_show, labels)  # add new legends
-        x.draggable()
-
-    def _toggle_legend(self):
-        if self.is_slice_figure():
-            self._toggle_slice_legend()
-        else:
-            self.legends_shown = not self.legends_shown
-            self.set_legends(self.get_legends())
-        self.canvas.draw()
-
-    def get_line_data(self):
-        legends = self.get_legends()
-        all_line_options = []
-        i = 0
-        for line_group in self.canvas.figure.gca().containers:
-            line_options = {}
-            line = line_group.get_children()[0]
-            line_options['shown'] = self.get_line_visible(i)
-            line_options['color'] = line.get_color()
-            line_options['style'] = line.get_linestyle()
-            line_options['width'] = str(int(line.get_linewidth()))
-            line_options['marker'] = line.get_marker()
-            all_line_options.append(line_options)
-            i += 1
-        return list(zip(legends, all_line_options))
-
-    def set_line_data(self, line_data):
-        legends = []
-        i = 0
-        for line in line_data:
-            legend, line_options = line
-            legends.append(legend)
-            line_model = self.canvas.figure.gca().containers[i]
-            self.set_line_visible(i, line_options['shown'])
-            for child in line_model.get_children():
-                child.set_color(line_options['color'])
-                child.set_linewidth(line_options['width'])
-            main_line = line_model.get_children()[0]
-            main_line.set_linestyle(line_options['style'])
-            main_line.set_marker(line_options['marker'])
-            i += 1
-        self.set_legends(legends)
-
-    def set_line_visible(self, line_index, visible):
-        self.lines_visible[line_index] = visible
-        for child in self.canvas.figure.gca().containers[line_index].get_children():
-            child.set_visible(visible)
-
-    def get_line_visible(self, line_index):
-        try:
-            ret = self.lines_visible[line_index]
-            return ret
-        except KeyError:
-            self.lines_visible[line_index] = True
-            return True
 
     def get_window_title(self):
         return six.text_type(self.windowTitle())
@@ -512,52 +173,3 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
     def y_range(self, value):
         self.canvas.figure.gca().set_ylim(value)
 
-    @property
-    def x_log(self):
-        return 'log' in self.canvas.figure.gca().get_xscale()
-
-    @property
-    def y_log(self):
-        return 'log' in self.canvas.figure.gca().get_yscale()
-
-    @property
-    def colorbar_label(self):
-        return self.canvas.figure.get_axes()[1].get_ylabel()
-
-    @colorbar_label.setter
-    def colorbar_label(self, value):
-        self.canvas.figure.get_axes()[1].set_ylabel(value, labelpad=20, rotation=270, picker=5)
-
-    @property
-    def colorbar_range(self):
-        return self.canvas.figure.gca().get_images()[0].get_clim()
-
-    @colorbar_range.setter
-    def colorbar_range(self, value):
-        self.change_slice_plot(value, self.colorbar_log)
-
-    @property
-    def colorbar_log(self):
-        mappable = self.canvas.figure.gca().get_images()[0]
-        norm = mappable.norm
-        return isinstance(norm, colors.LogNorm)
-
-    @colorbar_log.setter
-    def colorbar_log(self, value):
-        self.change_slice_plot(self.colorbar_range, value)
-
-    @property
-    def error_bars(self):
-        return self._has_errorbars()
-
-    @error_bars.setter
-    def error_bars(self, value):
-        self._set_errorbars_shown_state(value)
-
-    @property
-    def show_legends(self):
-        return self.legends_shown
-
-    @show_legends.setter
-    def show_legends(self, value):
-        self.legends_shown = value

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -163,4 +163,3 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
     @y_range.setter
     def y_range(self, value):
         self.canvas.figure.gca().set_ylim(value)
-

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -88,6 +88,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         if self.actionDataCursor.isChecked():
             self.stock_toolbar.message.connect(self.statusbar.showMessage)
             self.canvas.setCursor(Qt.CrossCursor)
+
         else:
             self.stock_toolbar.message.disconnect()
             self.canvas.setCursor(Qt.ArrowCursor)

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -17,7 +17,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
     def __init__(self, number, manager):
         super(PlotFigureManager, self).__init__(number, manager)
 
-        self.plot_handler = None
+        self._plot_handler = None
 
         self.actionKeep.triggered.connect(self._report_as_kept_to_manager)
         self.actionMakeCurrent.triggered.connect(self._report_as_current_to_manager)
@@ -38,21 +38,21 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
         self.show()  # is not a good idea in non interactive mode
 
     def add_slice_plot(self, slice_plotter):
-        self.plot_handler = SlicePlot(self, self.canvas, slice_plotter)
+        self._plot_handler = SlicePlot(self, self.canvas, slice_plotter)
 
     def add_cut_plot(self, cut_plotter):
-        self.plot_handler = CutPlot(self, self.canvas, cut_plotter)
+        self._plot_handler = CutPlot(self, self.canvas, cut_plotter)
 
     def _toggle_legend(self):
-        self.plot_handler.toggle_legend()
+        self._plot_handler.toggle_legend()
 
     def plot_clicked(self, event):
         if event.dblclick:
-            self.plot_handler.plot_clicked(event.x, event.y)
+            self._plot_handler.plot_clicked(event.x, event.y)
 
     def object_clicked(self, event):
         if event.mouseevent.dblclick:
-            self.plot_handler.object_clicked(event.artist)
+            self._plot_handler.object_clicked(event.artist)
 
     def toggle_data_cursor(self):
         if self.actionDataCursor.isChecked():
@@ -72,7 +72,7 @@ class PlotFigureManager(BaseQtPlotWindow, Ui_MainWindow):
             self.actionKeep.setChecked(False)
 
     def _plot_options(self):
-        self.plot_handler.plot_options()
+        self._plot_handler.plot_options()
 
     def print_plot(self):
         printer = QtGui.QPrinter()

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -120,7 +120,6 @@ class SlicePlot(object):
                 lines.append(line)
         if len(lines) > 0:
             legend = axes.legend(fontsize='small')
-            legend.draggable()
             for legline, line in zip(legend.get_lines(), lines):
                 legline.set_picker(5)
                 self.plot_figure.legend_dict[legline] = line

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -1,0 +1,262 @@
+from functools import partial
+import six
+from PyQt4 import QtGui
+import os.path as path
+import matplotlib.colors as colors
+
+from mantid.simpleapi import AnalysisDataService
+
+from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
+from .plot_options import SlicePlotOptions
+
+
+class SlicePlot(object):
+    
+    def __init__(self, plot_figure, canvas, slice_plotter):
+        self.plot_figure = plot_figure
+        self.canvas = canvas
+        self.slice_plotter = slice_plotter
+        self.ws_title = plot_figure.title
+        self.arbitrary_nuclei = None
+        self.cif_file = None
+    
+        plot_figure.actionS_Q_E.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionS_Q_E,
+                                                   self.slice_plotter.show_scattering_function, False))
+        plot_figure.actionChi_Q_E.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionChi_Q_E,
+                                                     self.slice_plotter.show_dynamical_susceptibility, True))
+        plot_figure.actionChi_Q_E_magnetic.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionChi_Q_E_magnetic,
+                                                              self.slice_plotter.show_dynamical_susceptibility_magnetic,
+                                                              True))
+        plot_figure.actionD2sigma_dOmega_dE.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionD2sigma_dOmega_dE,
+                                                               self.slice_plotter.show_d2sigma, False))
+        plot_figure.actionSymmetrised_S_Q_E.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionSymmetrised_S_Q_E,
+                                                               self.slice_plotter.show_symmetrised, True))
+        plot_figure.actionGDOS.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionGDOS,
+                                                  self.slice_plotter.show_gdos, True))
+    
+        plot_figure.actionHydrogen.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionHydrogen, 1, True))
+        plot_figure.actionDeuterium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionDeuterium, 2, True))
+        plot_figure.actionHelium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionHelium, 4, True))
+        plot_figure.actionArbitrary_nuclei.triggered.connect(self.arbitrary_recoil_line)
+        plot_figure.actionAluminium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionAluminium,
+                                                       'Aluminium', False))
+        plot_figure.actionCopper.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionCopper,
+                                                    'Copper', False))
+        plot_figure.actionNiobium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionNiobium,
+                                                     'Niobium', False))
+        plot_figure.actionTantalum.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionTantalum,
+                                                      'Tantalum', False))
+        plot_figure.actionCIF_file.triggered.connect(partial(self.cif_file_powder_line))
+
+    def plot_options(self):
+        new_config = SlicePlotOptionsPresenter(SlicePlotOptions(), self).get_new_config()
+        if new_config:
+            self.canvas.draw()
+
+    def post_click_event(self):
+        self.reset_info_checkboxes()
+        self.update_legend()
+
+    def change_slice_plot(self, colorbar_range, logarithmic):
+        current_axis = self.canvas.figure.gca()
+        images = current_axis.get_images()
+        if len(images) != 1:
+            raise RuntimeError("Expected single image on axes, found " + str(len(images)))
+        mappable = images[0]
+        vmin, vmax = colorbar_range
+        if logarithmic and type(mappable.norm) != colors.LogNorm:
+            mappable.colorbar.remove()
+            if vmin == float(0):
+                vmin = 0.001
+            norm = colors.LogNorm(vmin, vmax)
+            mappable.set_norm(norm)
+            self.canvas.figure.colorbar(mappable)
+        elif not logarithmic and type(mappable.norm) != colors.Normalize:
+            mappable.colorbar.remove()
+            norm = colors.Normalize(vmin, vmax)
+            mappable.set_norm(norm)
+            self.canvas.figure.colorbar(mappable)
+        mappable.set_clim((vmin, vmax))
+
+    def reset_info_checkboxes(self):
+        for key, line in six.iteritems(self.slice_plotter.overplot_lines[self.ws_title]):
+            if str(line.get_linestyle()) == 'None':
+                if isinstance(key, int):
+                    key = self.slice_plotter.get_recoil_label(key)
+                action_checked = getattr(self, 'action' + key)
+                action_checked.setChecked(False)
+
+    def toggle_overplot_line(self, action, key, recoil, checked, cif_file=None):
+        if checked:
+            self.slice_plotter.add_overplot_line(self.ws_title, key, recoil, cif_file)
+        else:
+            self.slice_plotter.hide_overplot_line(self.ws_title, key)
+        self.update_legend()
+        self.canvas.draw()
+
+    def arbitrary_recoil_line(self):
+        if self.plot_figure.actionArbitrary_nuclei.isChecked():
+            self.arbitrary_nuclei, confirm = QtGui.QInputDialog.getInt(self, 'Arbitrary Nuclei', 'Enter relative mass:')
+            if not confirm:
+                return
+        self.toggle_overplot_line(self.plot_figure.actionArbitrary_nuclei, self.arbitrary_nuclei, True)
+
+    def cif_file_powder_line(self, checked):
+        if checked:
+            cif_path = str(QtGui.QFileDialog().getOpenFileName(self, 'Open CIF file', '/home', 'Files (*.cif)'))
+            key = path.basename(cif_path).rsplit('.')[0]
+            self.cif_file = key
+        else:
+            key = self.cif_file
+            cif_path = None
+        self.toggle_overplot_line(self.plot_figure.actionCIF_file, key, False,
+                                  self.plot_figure.actionCIF_file.isChecked(), cif_file=cif_path)
+
+    def update_legend(self):
+        lines = []
+        axes = self.canvas.figure.gca()
+        for line in axes.get_lines():
+            if str(line.get_linestyle()) != 'None' and line.get_label() != '':
+                lines.append(line)
+        if len(lines) > 0:
+            legend = axes.legend(fontsize='small')
+            legend.draggable()
+            for legline, line in zip(legend.get_lines(), lines):
+                legline.set_picker(5)
+                self.plot_figure.legend_dict[legline] = line
+            for label, line in zip(legend.get_texts(), lines):
+                label.set_picker(5)
+                self.plot_figure.legend_dict[label] = line
+        else:
+            axes.legend_ = None  # remove legend
+
+    def toggle_legend(self):
+        axes = self.canvas.figure.gca()
+        if axes.legend_ is None:
+            self.update_legend()
+        else:
+            axes.legend_ = None
+
+    def intensity_selection(self, selected):
+        '''Ticks selected and un-ticks other intensity options. Returns previous selection'''
+        options = self.plot_figure.menuIntensity.actions()
+        previous = None
+        for op in options:
+            if op.isChecked() and op is not selected:
+                previous = op
+            op.setChecked(False)
+        selected.setChecked(True)
+        return previous
+
+    def show_intensity_plot(self, action, slice_plotter_method, temp_dependent):
+        if action.isChecked():
+            previous = self.intensity_selection(action)
+            cbar_log = self.colorbar_log
+            x_range = self.x_range
+            y_range = self.y_range
+            title = self.title
+            if temp_dependent:
+                if not self._run_temp_dependent(slice_plotter_method, previous):
+                    return
+            else:
+                slice_plotter_method(self.ws_title)
+            self.change_slice_plot(self.colorbar_range, cbar_log)
+            self.x_range = x_range
+            self.y_range = y_range
+            self.title = title
+            self.canvas.draw()
+        else:
+            action.setChecked(True)
+
+    def _run_temp_dependent(self, slice_plotter_method, previous):
+        try:
+            slice_plotter_method(self.ws_title)
+        except ValueError:  # sample temperature not yet set
+            try:
+                field = self.ask_sample_temperature_field(str(self.ws_title))
+            except RuntimeError:  # if cancel is clicked, go back to previous selection
+                self.intensity_selection(previous)
+                return False
+            self.slice_plotter.add_sample_temperature_field(field)
+            self.slice_plotter.update_sample_temperature(self.ws_title)
+            slice_plotter_method(self.ws_title)
+        return True
+
+    def ask_sample_temperature_field(self, ws_name):
+        if ws_name[-3:] == '_QE':
+            ws_name = ws_name[:-3]
+        ws = AnalysisDataService[ws_name]
+        temp_field, confirm = QtGui.QInputDialog.getItem(self.plot_figure, 'Sample Temperature',
+                                                         'Sample Temperature not found. ' +
+                                                         'Select the sample temperature field:',
+                                                         ws.run().keys(), False)
+        if not confirm:
+            raise RuntimeError("sample_temperature_dialog cancelled")
+        else:
+            return str(temp_field)
+
+    @property
+    def colorbar_label(self):
+        return self.canvas.figure.get_axes()[1].get_ylabel()
+
+    @colorbar_label.setter
+    def colorbar_label(self, value):
+        self.canvas.figure.get_axes()[1].set_ylabel(value, labelpad=20, rotation=270, picker=5)
+
+    @property
+    def colorbar_range(self):
+        return self.canvas.figure.gca().get_images()[0].get_clim()
+
+    @colorbar_range.setter
+    def colorbar_range(self, value):
+        self.change_slice_plot(value, self.colorbar_log)
+
+    @property
+    def colorbar_log(self):
+        mappable = self.canvas.figure.gca().get_images()[0]
+        norm = mappable.norm
+        return isinstance(norm, colors.LogNorm)
+
+    @colorbar_log.setter
+    def colorbar_log(self, value):
+        self.change_slice_plot(self.colorbar_range, value)
+
+    @property
+    def title(self):
+        return self.plot_figure.title
+
+    @title.setter
+    def title(self, value):
+        self.plot_figure.title = value
+
+    @property
+    def x_label(self):
+        return self.plot_figure.x_label
+
+    @x_label.setter
+    def x_label(self, value):
+        self.plot_figure.x_label = value
+
+    @property
+    def y_label(self):
+        return self.plot_figure.y_label
+
+    @y_label.setter
+    def y_label(self, value):
+        self.plot_figure.y_label = value
+
+    @property
+    def x_range(self):
+        return self.plot_figure.x_range
+
+    @x_range.setter
+    def x_range(self, value):
+        self.plot_figure.x_range = value
+
+    @property
+    def y_range(self):
+        return self.plot_figure.y_range
+
+    @y_range.setter
+    def y_range(self, value):
+        self.plot_figure.y_range = value

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -11,7 +11,7 @@ from .plot_options import SlicePlotOptions
 
 
 class SlicePlot(object):
-    
+
     def __init__(self, plot_figure, canvas, slice_plotter):
         self.plot_figure = plot_figure
         self.canvas = canvas
@@ -19,33 +19,42 @@ class SlicePlot(object):
         self.ws_title = plot_figure.title
         self.arbitrary_nuclei = None
         self.cif_file = None
-    
+
         plot_figure.actionS_Q_E.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionS_Q_E,
-                                                   self.slice_plotter.show_scattering_function, False))
+                                                          self.slice_plotter.show_scattering_function, False))
         plot_figure.actionChi_Q_E.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionChi_Q_E,
-                                                     self.slice_plotter.show_dynamical_susceptibility, True))
-        plot_figure.actionChi_Q_E_magnetic.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionChi_Q_E_magnetic,
-                                                              self.slice_plotter.show_dynamical_susceptibility_magnetic,
-                                                              True))
-        plot_figure.actionD2sigma_dOmega_dE.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionD2sigma_dOmega_dE,
-                                                               self.slice_plotter.show_d2sigma, False))
-        plot_figure.actionSymmetrised_S_Q_E.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionSymmetrised_S_Q_E,
-                                                               self.slice_plotter.show_symmetrised, True))
+                                                            self.slice_plotter.show_dynamical_susceptibility, True))
+
+        plot_figure.actionChi_Q_E_magnetic.triggered.connect(
+            partial(self.show_intensity_plot, plot_figure.actionChi_Q_E_magnetic,
+                    self.slice_plotter.show_dynamical_susceptibility_magnetic, True))
+
+        plot_figure.actionD2sigma_dOmega_dE.triggered.connect(
+            partial(self.show_intensity_plot, plot_figure.actionD2sigma_dOmega_dE,
+                    self.slice_plotter.show_d2sigma, False))
+
+        plot_figure.actionSymmetrised_S_Q_E.triggered.connect(
+            partial(self.show_intensity_plot, plot_figure.actionSymmetrised_S_Q_E,
+                    self.slice_plotter.show_symmetrised, True))
+
         plot_figure.actionGDOS.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionGDOS,
-                                                  self.slice_plotter.show_gdos, True))
+                                                         self.slice_plotter.show_gdos, True))
     
-        plot_figure.actionHydrogen.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionHydrogen, 1, True))
-        plot_figure.actionDeuterium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionDeuterium, 2, True))
-        plot_figure.actionHelium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionHelium, 4, True))
+        plot_figure.actionHydrogen.triggered.connect(
+            partial(self.toggle_overplot_line, plot_figure.actionHydrogen, 1, True))
+        plot_figure.actionDeuterium.triggered.connect(
+            partial(self.toggle_overplot_line, plot_figure.actionDeuterium, 2, True))
+        plot_figure.actionHelium.triggered.connect(
+            partial(self.toggle_overplot_line, plot_figure.actionHelium, 4, True))
         plot_figure.actionArbitrary_nuclei.triggered.connect(self.arbitrary_recoil_line)
-        plot_figure.actionAluminium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionAluminium,
-                                                       'Aluminium', False))
-        plot_figure.actionCopper.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionCopper,
-                                                    'Copper', False))
-        plot_figure.actionNiobium.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionNiobium,
-                                                     'Niobium', False))
-        plot_figure.actionTantalum.triggered.connect(partial(self.toggle_overplot_line, plot_figure.actionTantalum,
-                                                      'Tantalum', False))
+        plot_figure.actionAluminium.triggered.connect(
+            partial(self.toggle_overplot_line, plot_figure.actionAluminium, 'Aluminium', False))
+        plot_figure.actionCopper.triggered.connect(
+            partial(self.toggle_overplot_line, plot_figure.actionCopper, 'Copper', False))
+        plot_figure.actionNiobium.triggered.connect(
+            partial(self.toggle_overplot_line, plot_figure.actionNiobium, 'Niobium', False))
+        plot_figure.actionTantalum.triggered.connect(
+            partial(self.toggle_overplot_line, plot_figure.actionTantalum, 'Tantalum', False))
         plot_figure.actionCIF_file.triggered.connect(partial(self.cif_file_powder_line))
 
     def plot_options(self):
@@ -57,7 +66,7 @@ class SlicePlot(object):
         self.reset_info_checkboxes()
         self.update_legend()
 
-    def change_slice_plot(self, colorbar_range, logarithmic):
+    def change_axis_scale(self, colorbar_range, logarithmic):
         current_axis = self.canvas.figure.gca()
         images = current_axis.get_images()
         if len(images) != 1:
@@ -159,7 +168,7 @@ class SlicePlot(object):
                     return
             else:
                 slice_plotter_method(self.ws_title)
-            self.change_slice_plot(self.colorbar_range, cbar_log)
+            self.change_axis_scale(self.colorbar_range, cbar_log)
             self.x_range = x_range
             self.y_range = y_range
             self.title = title
@@ -208,7 +217,7 @@ class SlicePlot(object):
 
     @colorbar_range.setter
     def colorbar_range(self, value):
-        self.change_slice_plot(value, self.colorbar_log)
+        self.change_axis_scale(value, self.colorbar_log)
 
     @property
     def colorbar_log(self):
@@ -218,7 +227,7 @@ class SlicePlot(object):
 
     @colorbar_log.setter
     def colorbar_log(self, value):
-        self.change_slice_plot(self.colorbar_range, value)
+        self.change_axis_scale(self.colorbar_range, value)
 
     @property
     def title(self):

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -45,7 +45,7 @@ class SlicePlotOptionsPresenter(PlotOptionsPresenter):
         if not dialog_accepted:
             return None
         if self._color_config['modified']:
-            self._model.change_slice_plot(self._color_config['c_range'], self._color_config['log'])
+            self._model.change_axis_scale(self._color_config['c_range'], self._color_config['log'])
         for key, value in list(self._modified_values.items()):
             setattr(self._model, key, value)
         self._model.x_range = self._xy_config['x_range']
@@ -85,7 +85,7 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         if not dialog_accepted:
             return None
         if self._xy_config['modified']:
-            self._model.change_cut_plot(self._xy_config)
+            self._model.change_axis_scale(self._xy_config)
         for key, value in list(self._modified_values.items()):
             setattr(self._model, key, value)
         line_data = self._view.get_line_data()

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -3,8 +3,8 @@ from functools import partial
 
 
 class PlotOptionsPresenter(object):
-    def __init__(self, plot_options_dialog, plot_figure_manager):
-        self._model = plot_figure_manager
+    def __init__(self, plot_options_dialog, plot_handler):
+        self._model = plot_handler
         self._view = plot_options_dialog
         self._modified_values = {}
         self._xy_config = {'x_range': self._model.x_range, 'y_range': self._model.y_range, 'modified': False}
@@ -17,11 +17,6 @@ class PlotOptionsPresenter(object):
         self._view.xRangeEdited.connect(partial(self._xy_config_modified, 'x_range'))
         self._view.yRangeEdited.connect(partial(self._xy_config_modified, 'y_range'))
 
-    def set_properties(self):
-        properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range']
-        for p in properties:
-            setattr(self._view, p, getattr(self._model, p))
-
     def _value_modified(self, value_name):
         self._modified_values[value_name] = getattr(self._view, value_name)
 
@@ -32,8 +27,8 @@ class PlotOptionsPresenter(object):
 
 class SlicePlotOptionsPresenter(PlotOptionsPresenter):
 
-    def __init__(self, plot_options_dialog, plot_figure_manager):
-        super(SlicePlotOptionsPresenter, self).__init__(plot_options_dialog, plot_figure_manager)
+    def __init__(self, plot_options_dialog, slice_handler):
+        super(SlicePlotOptionsPresenter, self).__init__(plot_options_dialog, slice_handler)
 
         self._color_config = {'c_range': self._model.colorbar_range, 'log': self._model.colorbar_log, 'modified': False}
 
@@ -68,8 +63,8 @@ class SlicePlotOptionsPresenter(PlotOptionsPresenter):
 
 class CutPlotOptionsPresenter(PlotOptionsPresenter):
 
-    def __init__(self, plot_options_dialog, plot_figure_manager):
-        super(CutPlotOptionsPresenter, self).__init__(plot_options_dialog, plot_figure_manager)
+    def __init__(self, plot_options_dialog, cut_handler):
+        super(CutPlotOptionsPresenter, self).__init__(plot_options_dialog, cut_handler)
         self._xy_config.update({'x_log': self._model.x_log, 'y_log': self._model.y_log})
 
         self._view.showLegendsEdited.connect(partial(self._value_modified, 'show_legends'))

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -74,8 +74,6 @@ class QuickLinePresenter(object):
             line.set_linestyle('')
         if not self.view.legend:
             line.set_label('')
-        self.model.reset_info_checkboxes()
-        self.model.update_slice_legend()
         self.model.canvas.draw()
         self.close()
 

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -29,7 +29,7 @@ class QuickAxisPresenter(object):
         setattr(self.model, target, range)
         if target == 'colorbar_range':
             self.model.colorbar_log = self.view.log_scale.isChecked()
-        self.model.canvas.draw()
+
 
 
 class QuickLabelPresenter(object):
@@ -44,7 +44,6 @@ class QuickLabelPresenter(object):
 
     def set_label(self):
         self.target.set_text(self.view.label)
-        self.model.canvas.draw()
 
 
 class QuickLinePresenter(object):
@@ -67,4 +66,3 @@ class QuickLinePresenter(object):
             line.set_linestyle('')
         if not self.view.legend:
             line.set_label('')
-        self.model.canvas.draw()

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -1,5 +1,7 @@
-from mock import MagicMock, PropertyMock
+from mock import MagicMock
+import numpy as np
 import unittest
+
 
 from mslice.plotting.plot_window.cut_plot import CutPlot
 
@@ -8,3 +10,40 @@ class CutPlotTest(unittest.TestCase):
 
     def setUp(self):
         self.plot_figure = MagicMock()
+        self.canvas = MagicMock()
+        self.cut_plotter = MagicMock()
+        self.axes = MagicMock()
+        self.canvas.figure.gca = MagicMock(return_value=self.axes)
+        self.cut_plot = CutPlot(self.plot_figure, self.canvas, self.cut_plotter)
+
+    def test_get_min(self):
+        data = [np.array([3, 6, 10]), np.array([3, 2, 7])]
+        self.assertEqual(self.cut_plot.get_min(data), 2)
+        self.assertEqual(self.cut_plot.get_min(data, 4), 6)
+
+    def test_change_scale_linear(self):
+        self.axes.set_xscale = MagicMock()
+        self.axes.set_yscale = MagicMock()
+        xy_config = {'x_log': False, 'y_log': False, 'x_range': (0, 10), 'y_range': (1, 7)}
+
+        self.cut_plot.change_axis_scale(xy_config)
+        self.axes.set_xscale.assert_called_once_with('linear')
+        self.axes.set_yscale.assert_called_once_with('linear')
+        self.assertEqual(self.cut_plot.x_range, (0,10))
+        self.assertEqual(self.cut_plot.y_range, (1,7))
+
+    def test_change_scale_log(self):
+        self.axes.set_xscale = MagicMock()
+        self.axes.set_yscale = MagicMock()
+        line = MagicMock()
+        line.get_ydata = MagicMock(return_value=np.array([1, 5, 10]))
+        line.get_xdata = MagicMock(return_value=np.array([20, 60, 12]))
+        self.axes.get_lines = MagicMock(return_value = [line])
+        self.canvas.figure.gca = MagicMock(return_value = self.axes)
+        xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
+
+        self.cut_plot.change_axis_scale(xy_config)
+        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
+        self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
+        self.assertEqual(self.cut_plot.x_range, (12,20))
+        self.assertEqual(self.cut_plot.y_range, (1,7))

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -1,0 +1,10 @@
+from mock import MagicMock, PropertyMock
+import unittest
+
+from mslice.plotting.plot_window.cut_plot import CutPlot
+
+
+class CutPlotTest(unittest.TestCase):
+
+    def setUp(self):
+        self.plot_figure = MagicMock()

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -94,7 +94,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.presenter2 = CutPlotOptionsPresenter(self.view, self.model)
         self.presenter2._xy_config_modified('x_range')
         self.presenter2.get_new_config()
-        self.model.change_cut_plot.assert_called_once()
+        self.model.change_axis_scale.assert_called_once()
 
     def test_change_colorbar_config(self):
         view_colorbar_range_mock = PropertyMock()
@@ -121,7 +121,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.presenter._set_c_range()
         self.presenter._set_colorbar_log()
         self.presenter.get_new_config()
-        self.model.change_slice_plot.assert_called_once_with((2, 10), True)
+        self.model.change_axis_scale.assert_called_once_with((2, 10), True)
 
     def test_change_xy_log(self):
         view_x_log_mock = PropertyMock()
@@ -148,7 +148,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.presenter._xy_config_modified('x_log')
         self.presenter._xy_config_modified('y_log')
         self.presenter.get_new_config()
-        self.model.change_cut_plot.assert_called_once_with({'x_range': (1, 2), 'y_range': (3, 4), 'modified': True,
+        self.model.change_axis_scale.assert_called_once_with({'x_range': (1, 2), 'y_range': (3, 4), 'modified': True,
                                                             'x_log': False,    'y_log': True})
 
     def test_show_error_bars(self):

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -149,7 +149,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.presenter._xy_config_modified('y_log')
         self.presenter.get_new_config()
         self.model.change_axis_scale.assert_called_once_with({'x_range': (1, 2), 'y_range': (3, 4), 'modified': True,
-                                                            'x_log': False,    'y_log': True})
+                                                              'x_log': False,    'y_log': True})
 
     def test_show_error_bars(self):
         view_error_bars_mock = PropertyMock()

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -15,7 +15,7 @@ class QuickAxisTest(unittest.TestCase):
         range_max = PropertyMock(return_value=10)
         type(self.view).range_max = range_max
 
-    def test__accept(self):
+    def test_accept(self):
         self.view.exec_ = MagicMock(return_value=True)
         QuickAxisPresenter(self.view, 'x_range', self.model)
         self.model.canvas.draw.assert_called_once()

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -18,14 +18,13 @@ class QuickAxisTest(unittest.TestCase):
     def test_accept(self):
         self.view.exec_ = MagicMock(return_value=True)
         QuickAxisPresenter(self.view, 'x_range', self.model)
-        self.model.canvas.draw.assert_called_once()
+        self.assertEquals(self.model.x_range, (5,10))
 
     def test_reject(self):
         self.view.exec_ = MagicMock(return_value=False)
         self.view.set_range = Mock()
         QuickAxisPresenter(self.view, 'x_range', self.model)
         self.view.set_range.assert_not_called()
-        self.model.canvas.draw.assert_not_called()
 
     def test_colorbar(self):
         self.view.exec_ = MagicMock(return_value=True)
@@ -33,7 +32,6 @@ class QuickAxisTest(unittest.TestCase):
         type(self.model).colorbar_log = colorbar_log
         self.view.log_scale.isChecked = Mock()
         QuickAxisPresenter(self.view, 'colorbar_range', self.model)
-        self.model.canvas.draw.assert_called_once()
         self.view.log_scale.isChecked.assert_called_once()
         colorbar_log.assert_called_once()
 
@@ -47,19 +45,16 @@ class QuickLabelTest(unittest.TestCase):
         label = PropertyMock(return_value="label")
         type(self.view).label = label
         self.target.set_text = MagicMock()
-        self.model.canvas.draw = MagicMock()
 
     def test_accept(self):
         self.view.exec_ = MagicMock(return_value=True)
         QuickLabelPresenter(self.view, self.target, self.model)
         self.target.set_text.assert_called_once_with("label")
-        self.model.canvas.draw.assert_called_once()
 
     def test_reject(self):
         self.view.exec_ = MagicMock(return_value=False)
         QuickLabelPresenter(self.view, self.target, self.model)
         self.target.set_text.assert_not_called()
-        self.model.canvas.draw.assert_not_called()
 
 
 class QuickLineTest(unittest.TestCase):
@@ -97,7 +92,6 @@ class QuickLineTest(unittest.TestCase):
         self.target.set_linewidth.assert_called_once_with(3)
         self.target.set_marker.assert_called_once_with(4)
         self.target.set_label.assert_called_once_with(5)
-        self.model.canvas.draw.assert_called_once()
 
     def test_accept_legend_shown(self):
         shown = PropertyMock(return_value=False)
@@ -111,7 +105,6 @@ class QuickLineTest(unittest.TestCase):
         self.target.set_linewidth.assert_called_once_with(3)
         self.target.set_marker.assert_called_once_with(4)
         self.target.set_label.assert_called_with('')
-        self.model.canvas.draw.assert_called_once()
 
     def test_reject(self):
         self.view.exec_ = MagicMock(return_value=False)
@@ -121,4 +114,3 @@ class QuickLineTest(unittest.TestCase):
         self.target.set_linewidth.assert_not_called()
         self.target.set_marker.assert_not_called()
         self.target.set_label.assert_not_called()
-        self.model.canvas.draw.assert_not_called()

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -20,7 +20,7 @@ class SlicePlotTest(unittest.TestCase):
         norm = PropertyMock(return_value = colors.Normalize)
         type(image).norm = norm
         self.axes.get_images = MagicMock(return_value=[image])
-        self.slice_plot.change_slice_plot((0,10), True)
+        self.slice_plot.change_axis_scale((0, 10), True)
         image.set_norm.assert_called_once()
         norm_set = image.set_norm.call_args_list[0][0][0]
         self.assertEqual(norm_set.vmin, 0.001)
@@ -33,10 +33,27 @@ class SlicePlotTest(unittest.TestCase):
         norm = PropertyMock(return_value=colors.LogNorm)
         type(image).norm = norm
         self.axes.get_images = MagicMock(return_value=[image])
-        self.slice_plot.change_slice_plot((0, 15), False)
+        self.slice_plot.change_axis_scale((0, 15), False)
         image.set_norm.assert_called_once()
         norm_set = image.set_norm.call_args_list[0][0][0]
         self.assertEqual(norm_set.vmin, 0)
         self.assertEqual(norm_set.vmax, 15)
         self.assertEqual(type(norm_set), colors.Normalize)
         image.set_clim.assert_called_once_with((0, 15))
+
+    def test_reset_checkboxes(self):
+        self.slice_plot.ws_title = 'title'
+        line1 = MagicMock()
+        line2 = MagicMock()
+        line1.get_linestyle = MagicMock(return_value='None')
+        line2.get_linestyle = MagicMock(return_value = '-')
+        self.slice_plotter.overplot_lines.__getitem__ = MagicMock(return_value={0: line1, 1: line2})
+        self.slice_plotter.get_recoil_label = MagicMock()
+        self.slice_plotter.get_recoil_label.side_effect = ['0', '1']
+        action0 = PropertyMock()
+        type(self.slice_plot).action0 = action0
+        action1 = PropertyMock()
+        type(self.slice_plot).action1 = action1
+        self.slice_plot.reset_info_checkboxes()
+        self.slice_plot.action0.setChecked.assert_called_once_with(False)
+        self.slice_plot.action1.setChecked.assert_not_called()

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -1,0 +1,42 @@
+from mock import MagicMock, PropertyMock
+import unittest
+
+import matplotlib.colors as colors
+from mslice.plotting.plot_window.slice_plot import SlicePlot
+
+
+class SlicePlotTest(unittest.TestCase):
+
+    def setUp(self):
+        self.plot_figure = MagicMock()
+        self.canvas = MagicMock()
+        self.slice_plotter = MagicMock()
+        self.axes = MagicMock()
+        self.canvas.figure.gca = MagicMock(return_value=self.axes)
+        self.slice_plot = SlicePlot(self.plot_figure, self.canvas, self.slice_plotter)
+
+    def test_change_logarithmic(self):
+        image = MagicMock()
+        norm = PropertyMock(return_value = colors.Normalize)
+        type(image).norm = norm
+        self.axes.get_images = MagicMock(return_value=[image])
+        self.slice_plot.change_slice_plot((0,10), True)
+        image.set_norm.assert_called_once()
+        norm_set = image.set_norm.call_args_list[0][0][0]
+        self.assertEqual(norm_set.vmin, 0.001)
+        self.assertEqual(norm_set.vmax, 10)
+        self.assertEqual(type(norm_set), colors.LogNorm)
+        image.set_clim.assert_called_once_with((0.001, 10))
+
+    def test_change_linear(self):
+        image = MagicMock()
+        norm = PropertyMock(return_value=colors.LogNorm)
+        type(image).norm = norm
+        self.axes.get_images = MagicMock(return_value=[image])
+        self.slice_plot.change_slice_plot((0, 15), False)
+        image.set_norm.assert_called_once()
+        norm_set = image.set_norm.call_args_list[0][0][0]
+        self.assertEqual(norm_set.vmin, 0)
+        self.assertEqual(norm_set.vmax, 15)
+        self.assertEqual(type(norm_set), colors.Normalize)
+        image.set_clim.assert_called_once_with((0, 15))

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -42,7 +42,7 @@ class SlicePlotTest(unittest.TestCase):
         image.set_clim.assert_called_once_with((0, 15))
 
     def test_reset_checkboxes(self):
-        self.slice_plot.ws_title = 'title'
+        self.slice_plot._ws_title = 'title'
         line1 = MagicMock()
         line2 = MagicMock()
         line1.get_linestyle = MagicMock(return_value='None')


### PR DESCRIPTION
This changes PlotFigureManager class to only include code that is common to both slices and cuts, and puts the specific methods into new classes, `SlicePlot` and `CutPlot`. This simplifies the classes and makes it much easier to test important methods.

**To test**
run `SlicePlotTest` and `CutPlotTest`

Fixes #186 
