### PR TITLE
Minimum step in automatic bin size estimate

### DIFF
--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -9,6 +9,7 @@ from .validation_decorators import require_main_presenter
 from PyQt4.QtGui import QFileDialog
 from os.path import splitext
 import numpy as np
+import warnings
 
 
 class CutPresenter(PresenterUtility):
@@ -50,6 +51,7 @@ class CutPresenter(PresenterUtility):
         integration_start to integration_end """
         selected_workspaces = self._main_presenter.get_selected_workspaces()
         try:
+            self._parse_step()
             params = self._parse_input(workspace_index)
         except ValueError:
             return
@@ -106,6 +108,19 @@ class CutPresenter(PresenterUtility):
         cut_params = params[:5]
         self._cut_algorithm.compute_cut(*cut_params)
         self._main_presenter.update_displayed_workspaces()
+
+    def _parse_step(self):
+        step = self._cut_view.get_cut_axis_step()
+        try:
+            step = float(step)
+        except ValueError:
+            step = self._cut_view.get_minimum_step()
+            if step is not None:
+                self._cut_view.populate_cut_params(self._cut_view.get_cut_axis_start(),
+                                                   self._cut_view.get_cut_axis_end(),
+                                                   "%0.5f" % step)
+                self._cut_view.error_invalid_cut_step_parameter()
+                warnings.warn("Invalid cut step, using default value")
 
     def _parse_input(self, workspace_index=0):
         # The messages of the raised exceptions are discarded. They are there for the sake of clarity/debugging

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -503,6 +503,7 @@ class CutPresenterTest(unittest.TestCase):
         integrated_axis = 'integrated axis'
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        self.view.get_cut_axis_step = mock.Mock(return_value="")
         self.view.get_minimum_step = mock.Mock(return_value=1)
 
         with warnings.catch_warnings():

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -73,5 +73,5 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         limits = self.ws_provider._limits['test_ws_2d']
         np.testing.assert_array_equal(limits['DeltaE'], [-10, 10, 1])
         np.testing.assert_array_equal(limits['|Q|'], limits['MomentumTransfer'])
-        np.testing.assert_almost_equal(limits['|Q|'], [0.0699211, 3.454529, 0.0020998970], 5)
-        np.testing.assert_almost_equal(limits['Degrees'], [3.43, 134.14, 0.09999263], 5)
+        np.testing.assert_almost_equal(limits['|Q|'], [0.05998867,  3.46446147,  0.01203236], 5)
+        np.testing.assert_almost_equal(limits['Degrees'], [3.43, 134.14, 0.5729578], 5)

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -46,6 +46,9 @@ class CutView:
     def set_minimum_step(self, value):
         pass
 
+    def get_minimum_step(self):
+        pass
+
     def error_select_a_workspace(self):
         pass
 

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -64,6 +64,9 @@ class CutView:
     def error_current_selection_invalid(self):
         pass
 
+    def error_invalid_cut_step_parameter(self):
+        pass
+
     def populate_cut_axis_options(self,options):
         pass
 

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -52,7 +52,8 @@ class CutWidget(QWidget, CutView, Ui_Form):
             try:
                 value = float(self.lneCutStep.text())
             except ValueError:
-                return
+                value = 0
+                self.error_invalid_cut_step_parameter()
             if value == 0:
                 self.lneCutStep.setText('%.5f' % (self._minimumStep))
                 self._display_error('Setting step size to default.')
@@ -241,6 +242,9 @@ class CutWidget(QWidget, CutView, Ui_Form):
 
     def error_invalid_cut_axis_parameters(self):
         self._display_error("Invalid cut axis parameters")
+
+    def error_invalid_cut_step_parameter(self):
+        self._display_error("Invalid cut step parameter. Using default.")
 
     def error_invalid_integration_parameters(self):
         self._display_error("Invalid parameters for integration")

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -114,6 +114,9 @@ class CutWidget(QWidget, CutView, Ui_Form):
     def set_minimum_step(self, value):
         self._minimumStep = value
 
+    def get_minimum_step(self):
+        return self._minimumStep
+
     def populate_cut_axis_options(self, options):
         self.cmbCutAxis.blockSignals(True)
         self.cmbCutAxis.clear()

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -51,7 +51,8 @@ class SliceWidget(QWidget, Ui_Form, SlicePlotterView):
             try:
                 value = float(lineEdit.text())
             except ValueError:
-                return
+                value = 0
+                self._display_error('Invalid step parameter. Using default value.')
             if value == 0:
                 lineEdit.setText(str(self._minimumStep[idx]))
                 self._display_error('Setting step size to default.')


### PR DESCRIPTION
Users reported that the default Q-step sizes is sometimes too small, leading to `NaN` in the plots (white pixels or gaps in line plots). This is because the current algorithm uses the smallest difference between detector angles which may only apply to a small part of the detector area. 

This PR changes the minimum value to be around 0.6 degrees, in order to avoid the `NaN` problem. 

Also, it changes the behaviour of when the default step sizes are used - previously the user had to put a zero `0` in the edit box to trigger the default value to be used. Now, if the value is empty or is otherwise invalid, the default value is used.

**To test:**

Load a MERLIN reduced dataset (e.g.: `MER30936_Ei10.00meV_Rings.nxspe` 
[MER30936_Ei10.00meV_Rings.zip](https://github.com/mantidproject/mslice/files/1611097/MER30936_Ei10.00meV_Rings.zip)) and check that the default step size does not give white pixels in the middle of the dataset (except for a white parabolic line about 2/3 of the way across which is a gap in the detectors). 

Check that the default step size is used if the step input box is empty (only for cuts, for slices [and cuts] once the user clicks on the box and it then loses focus, a callback is invoked checking if the value is valid and if not, automatically overwrites it with the default value).

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #191
