### PR TITLE
Another pyqt shim

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -3,7 +3,7 @@ and entry points.
 """
 import os
 
-from qtpy.QtWidgets import QApplication
+from mslice.util.qt.QtWidgets import QApplication
 
 from mslice.external.ipython import start_ipython
 

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy.QtWidgets import QApplication, QMainWindow, QLabel
+from mslice.util.qt.QtWidgets import QApplication, QMainWindow, QLabel
 
 from mslice.presenters.main_presenter import MainPresenter
 from mslice.util.qt import load_ui

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -4,9 +4,9 @@ import importlib
 
 from matplotlib.figure import Figure
 import six
-from qtpy import QT_VERSION
-from qtpy.QtCore import Qt
-from qtpy import QtWidgets
+from mslice.util.qt import QT_VERSION
+from mslice.util.qt.QtCore import Qt
+from mslice.util.qt import QtWidgets
 
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.cut_plot import CutPlot

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-import qtpy.QtWidgets as QtWidgets
-from qtpy.QtCore import Signal
+import mslice.util.qt.QtWidgets as QtWidgets
+from mslice.util.qt.QtCore import Signal
 from six import iteritems
 
 from mslice.util.qt import load_ui

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -1,8 +1,8 @@
 
 from mslice.plotting.plot_window.plot_options import LegendAndLineOptionsSetter
 
-from qtpy import QtWidgets
-from qtpy.QtCore import Signal
+from mslice.util.qt import QtWidgets
+from mslice.util.qt.QtCore import Signal
 
 
 class QuickOptions(QtWidgets.QDialog):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -1,7 +1,7 @@
 from functools import partial
 import six
 
-from qtpy import QtWidgets
+from mslice.util.qt import QtWidgets
 
 import os.path as path
 import matplotlib.colors as colors

--- a/mslice/plotting/pyplot.py
+++ b/mslice/plotting/pyplot.py
@@ -3241,7 +3241,7 @@ def autoscale(enable=True, axis='both', tight=None):
 _setup_pyplot_info_docstrings()
 
 if __name__ == '__main__':
-    from qtpy.QtWidgets import QApplication
+    from mslice.util.qt.QtWidgets import QApplication
     qapp = QApplication([])
     imshow([[1,2],[3,4]])
     plot([1,2,3,4])

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -6,7 +6,7 @@ from mslice.presenters.slice_plotter_presenter import Axis
 from mslice.views.cut_view import CutView
 from mslice.widgets.cut.command import Command
 from .validation_decorators import require_main_presenter
-from qtpy.QtWidgets import QFileDialog
+from mslice.util.qt.QtWidgets import QFileDialog
 from os.path import splitext
 import numpy as np
 import warnings

--- a/mslice/quickview/QuickView.py
+++ b/mslice/quickview/QuickView.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 import re
 from .ui_mock import GetInputFromUser,display_message
-from qtpy import QtWidgets
+from mslice.util.qt import QtWidgets
 
 
 class QuickView(QtWidgets.QWidget):

--- a/mslice/quickview/ui_mock.py
+++ b/mslice/quickview/ui_mock.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 from getter_ui import Ui_Dialog
-from qtpy import QtWidgets
+from mslice.util.qt import QtWidgets
 
 
 class GetInputFromUser(Ui_Dialog, QtWidgets.QDialog):

--- a/mslice/tests/app_test.py
+++ b/mslice/tests/app_test.py
@@ -1,4 +1,4 @@
-from qtpy import QtWidgets
+from mslice.util.qt import QtWidgets
 import mock
 from mock import patch
 import unittest

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -7,7 +7,7 @@ from tempfile import gettempdir
 from os.path import join
 
 import numpy as np
-from qtpy.QtWidgets import QFileDialog
+from mslice.util.qt.QtWidgets import QFileDialog
 
 from mslice.models.cut.cut_algorithm import CutAlgorithm
 from mslice.models.cut.cut_plotter import CutPlotter

--- a/mslice/util/qt/QtCore.py
+++ b/mslice/util/qt/QtCore.py
@@ -1,5 +1,5 @@
 try:
-    from qtpy.QtCore import *
+    from qtpy.QtCore import * # noqa: F401
 except (ImportError, ValueError):
-    from PyQt4.QtCore import *
-    from PyQt4.QtCore import pyqtSignal as Signal
+    from PyQt4.QtCore import * # noqa: F401
+    from PyQt4.QtCore import pyqtSignal as Signal # noqa: F401

--- a/mslice/util/qt/QtCore.py
+++ b/mslice/util/qt/QtCore.py
@@ -1,0 +1,5 @@
+try:
+    from qtpy.QtCore import *
+except (ImportError, ValueError):
+    from PyQt4.QtCore import *
+    from PyQt4.QtCore import pyqtSignal as Signal

--- a/mslice/util/qt/QtWidgets.py
+++ b/mslice/util/qt/QtWidgets.py
@@ -1,4 +1,4 @@
 try:
-    from qtpy.QtWidgets import *
+    from qtpy.QtWidgets import * # noqa: F401
 except (ImportError, ValueError):
-    from PyQt4.QtGui import *
+    from PyQt4.QtGui import * # noqa: F401

--- a/mslice/util/qt/QtWidgets.py
+++ b/mslice/util/qt/QtWidgets.py
@@ -1,0 +1,4 @@
+try:
+    from qtpy.QtWidgets import *
+except (ImportError, ValueError):
+    from PyQt4.QtGui import *

--- a/mslice/util/qt/__init__.py
+++ b/mslice/util/qt/__init__.py
@@ -1,0 +1,5 @@
+from .functions import load_ui
+try:
+    from qtpy import QT_VERSION as QT_VERSION
+except (ImportError, ValueError):
+    from pyqt4.Qt import QT_VERSION_STR as QT_VERSION

--- a/mslice/util/qt/__init__.py
+++ b/mslice/util/qt/__init__.py
@@ -1,5 +1,5 @@
-from .functions import load_ui
+from .functions import load_ui # noqa: F401
 try:
-    from qtpy import QT_VERSION as QT_VERSION
+    from qtpy import QT_VERSION as QT_VERSION # noqa: F401
 except (ImportError, ValueError):
-    from PyQt4.Qt import QT_VERSION_STR as QT_VERSION
+    from PyQt4.Qt import QT_VERSION_STR as QT_VERSION # noqa: F401

--- a/mslice/util/qt/__init__.py
+++ b/mslice/util/qt/__init__.py
@@ -2,4 +2,4 @@ from .functions import load_ui
 try:
     from qtpy import QT_VERSION as QT_VERSION
 except (ImportError, ValueError):
-    from pyqt4.Qt import QT_VERSION_STR as QT_VERSION
+    from PyQt4.Qt import QT_VERSION_STR as QT_VERSION

--- a/mslice/util/qt/functions.py
+++ b/mslice/util/qt/functions.py
@@ -1,4 +1,4 @@
-from qtpy.uic import loadUi, loadUiType
+from mslice.util.qt.uic import loadUi, loadUiType
 import os.path as osp
 
 def load_ui(caller_filename, ui_relfilename, baseinstance=None):

--- a/mslice/util/qt/uic.py
+++ b/mslice/util/qt/uic.py
@@ -1,0 +1,4 @@
+try:
+    from qtpy.uic import *
+except (ImportError, ValueError):
+    from PyQt4.uic import *

--- a/mslice/util/qt/uic.py
+++ b/mslice/util/qt/uic.py
@@ -1,4 +1,4 @@
 try:
-    from qtpy.uic import *
+    from qtpy.uic import * # noqa: F401
 except (ImportError, ValueError):
-    from PyQt4.uic import *
+    from PyQt4.uic import * # noqa: F401

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -5,8 +5,8 @@
 # -----------------------------------------------------------------------------
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QWidget
+from mslice.util.qt.QtCore import Signal
+from mslice.util.qt.QtWidgets import QWidget
 
 from mslice.models.cut.mantid_cut_algorithm import MantidCutAlgorithm
 from mslice.models.cut.matplotlib_cut_plotter import MatplotlibCutPlotter

--- a/mslice/widgets/projection/powder/powder.py
+++ b/mslice/widgets/projection/powder/powder.py
@@ -5,8 +5,8 @@
 # -----------------------------------------------------------------------------
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QWidget, QMessageBox
+from mslice.util.qt.QtCore import Signal
+from mslice.util.qt.QtWidgets import QWidget, QMessageBox
 
 from mslice.models.projection.powder.mantid_projection_calculator import MantidProjectionCalculator
 from mslice.presenters.powder_projection_presenter import PowderProjectionPresenter

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -5,8 +5,8 @@
 # -----------------------------------------------------------------------------
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QWidget
+from mslice.util.qt.QtCore import Signal
+from mslice.util.qt.QtWidgets import QWidget
 
 from mslice.models.slice.mantid_slice_algorithm import MantidSliceAlgorithm
 from mslice.models.slice.matplotlib_slice_plotter import MatplotlibSlicePlotter

--- a/mslice/widgets/status/status.py
+++ b/mslice/widgets/status/status.py
@@ -7,7 +7,7 @@ Displays information/errors to the user
 # -----------------------------------------------------------------------------
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy.QtWidgets import QWidget
+from mslice.util.qt.QtWidgets import QWidget
 
 from mslice.util.qt import load_ui
 

--- a/mslice/widgets/workspacemanager/inputdialog.py
+++ b/mslice/widgets/workspacemanager/inputdialog.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-from qtpy.QtWidgets import QDialog, QFormLayout, QLabel, QDoubleSpinBox, QPushButton, QCheckBox
+from mslice.util.qt.QtWidgets import QDialog, QFormLayout, QLabel, QDoubleSpinBox, QPushButton, QCheckBox
 
 class EfInputDialog(QDialog):
     def __init__(self, parent = None):

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QWidget, QListWidgetItem, QFileDialog, QInputDialog, QMessageBox
+from mslice.util.qt.QtCore import Signal
+from mslice.util.qt.QtWidgets import QWidget, QListWidgetItem, QFileDialog, QInputDialog, QMessageBox
 
 from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter


### PR DESCRIPTION
Adds a basic shim in `mslice.util.qt` to wrap `qtpy` which again wraps an actual Qt/Python binding. This is because `qtpy` is not installed on Windows versions of Mantid; and also is not compatible with running MSlice within a MantidPlot instance (because it initializes `PyQt4` with `sip` API version set to `1` for some functions whilst `qtpy` requires API version 2 for everything.

**To test:**

Download zip / `git clone` on Windows and check `mslicedevel.bat` runs ok. 

Run the attached script ([mslice_in_mantidplot.zip](https://github.com/mantidproject/mslice/files/1632400/mslice_in_mantidplot.zip)) within MantidPlot; download this branch `192_pyqt_bindings` and check that it runs ok.

Fixes #198
