### PR TITLE
Re #199 - ensure plot window shows when plot clicked

### DIFF
--- a/mslice/plotting/pyplot.py
+++ b/mslice/plotting/pyplot.py
@@ -237,6 +237,7 @@ def sci(im):
 
 
 def raiseWindow(figure):
+    figure.show()
     window = figure.canvas.parent()
     window.raise_()
     window.activateWindow()


### PR DESCRIPTION
Adds `figure.show()` to end of each plot action. This ensures that even if the user has closed the figure (clicked `x` on the menu bar), that it will be re-opened again when they click plot. For some reason this was not necessary when the `ui`s were compiled but appears to be needed now that they are loaded using `uic.loadUi`

**To test:**

Make a slice or cut and plot it. Close the window. Click plot again and check the window reappears and data is correctly plotted.

Fixes #199
