### PR TITLE
Split WorkspaceManager into tabs

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -7,6 +7,7 @@ from mslice.presenters.main_presenter import MainPresenter
 from mslice.util.qt import load_ui
 from mslice.views.mainview import MainView
 from mslice.widgets.ipythonconsole.ipython_widget import IPythonWidget
+from mslice.widgets.workspacemanager.command import Command as ws_command
 
 TAB_2D = 0
 TAB_EVENT = 1
@@ -32,21 +33,25 @@ class MainWindow(MainView, QMainWindow):
         self.tabs_to_show = {TAB_2D: [TAB_POWDER],
                              TAB_EVENT: [TAB_SLICE, TAB_CUT],
                              TAB_HISTO: []}
-        workspace_presenter = self.wgtWorkspacemanager.get_presenter()
+        self.workspace_presenter = self.wgtWorkspacemanager.get_presenter()
         dataloader_presenter = self.data_loading.get_presenter()
         slice_presenter = self.wgtSlice.get_presenter()
         powder_presenter = self.wgtPowder.get_presenter()
         cut_presenter = self.wgtCut.get_presenter()
-        self._presenter = MainPresenter(self, workspace_presenter, dataloader_presenter,
+        self._presenter = MainPresenter(self, self.workspace_presenter, dataloader_presenter,
                                         slice_presenter, powder_presenter, cut_presenter)
 
-        workspace_provider = workspace_presenter.get_workspace_provider()
+        workspace_provider = self.workspace_presenter.get_workspace_provider()
         dataloader_presenter.set_workspace_provider(workspace_provider)
         powder_presenter.set_workspace_provider(workspace_provider)
         slice_presenter.set_workspace_provider(workspace_provider)
         cut_presenter.set_workspace_provider(workspace_provider)
 
         self.wgtWorkspacemanager.tab_changed.connect(self.ws_tab_changed)
+        self.btnSave.clicked.connect(self.button_save)
+        self.btnRename.clicked.connect(self.button_rename)
+        self.btnDelete.clicked.connect(self.button_delete)
+        self.btnMerge.clicked.connect(self.button_merge)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
@@ -69,6 +74,18 @@ class MainWindow(MainView, QMainWindow):
                     self.tabWidget_2.setTabEnabled(tab_index, True)
         else:
             self.tabWidget_2.hide()
+
+    def button_save(self):
+        self.workspace_presenter.notify(ws_command.SaveSelectedWorkspace)
+
+    def button_rename(self):
+        self.workspace_presenter.notify(ws_command.RenameWorkspace)
+
+    def button_delete(self):
+        self.workspace_presenter.notify(ws_command.RemoveSelectedWorkspaces)
+
+    def button_merge(self):
+        self.workspace_presenter.notify(ws_command.CombineWorkspace)
 
     def init_ui(self):
         self.busy_text = QLabel()

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -37,6 +37,8 @@ class MainWindow(MainView, QMainWindow):
         slice_presenter.set_workspace_provider(workspace_provider)
         cut_presenter.set_workspace_provider(workspace_provider)
 
+        self.wgtWorkspacemanager.tab_changed.connect(self.ws_tab_changed)
+
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
         self.wgtWorkspacemanager.error_occurred.connect(self.show_error)
@@ -46,6 +48,9 @@ class MainWindow(MainView, QMainWindow):
         self.wgtSlice.busy.connect(self.show_busy)
         self.wgtWorkspacemanager.busy.connect(self.show_busy)
         self.wgtPowder.busy.connect(self.show_busy)
+
+    def ws_tab_changed(self, tab):
+        print(tab)
 
     def init_ui(self):
         self.busy_text = QLabel()

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+
 from mslice.util.qt.QtWidgets import QApplication, QMainWindow, QLabel
 
 from mslice.presenters.main_presenter import MainPresenter
@@ -7,7 +8,12 @@ from mslice.util.qt import load_ui
 from mslice.views.mainview import MainView
 from mslice.widgets.ipythonconsole.ipython_widget import IPythonWidget
 
-from mslice.widgets.dataloader.dataloader import DataLoaderWidget
+TAB_2D = 0
+TAB_EVENT = 1
+TAB_HISTO = 2
+TAB_SLICE = 1
+TAB_CUT = 2
+TAB_POWDER = 0
 
 # ==============================================================================
 # Classes
@@ -22,7 +28,10 @@ class MainWindow(MainView, QMainWindow):
         ipython = IPythonWidget()
         self.centralWidget().layout().addWidget(ipython)
         ipython.setFixedHeight(200)
-
+        self.tabs = [self.wgtSlice, self.wgtCut, self.wgtPowder]
+        self.tabs_to_show = {TAB_2D: [TAB_POWDER],
+                             TAB_EVENT: [TAB_SLICE, TAB_CUT],
+                             TAB_HISTO: []}
         workspace_presenter = self.wgtWorkspacemanager.get_presenter()
         dataloader_presenter = self.data_loading.get_presenter()
         slice_presenter = self.wgtSlice.get_presenter()
@@ -50,7 +59,16 @@ class MainWindow(MainView, QMainWindow):
         self.wgtPowder.busy.connect(self.show_busy)
 
     def ws_tab_changed(self, tab):
-        print(tab)
+        self.tabWidget_2.show()
+        tab_to_show = self.tabs_to_show[tab]
+        for tab_index in range(3):
+            self.tabWidget_2.setTabEnabled(tab_index, False)
+        if tab_to_show:
+            self.tabWidget_2.setCurrentIndex(tab_to_show[0])
+            for tab_index in tab_to_show:
+                    self.tabWidget_2.setTabEnabled(tab_index, True)
+        else:
+            self.tabWidget_2.hide()
 
     def init_ui(self):
         self.busy_text = QLabel()

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -27,12 +27,14 @@ class MainWindow(MainView, QMainWindow):
         load_ui(__file__, 'mainwindow.ui', self)
         self.init_ui()
         ipython = IPythonWidget()
-        self.centralWidget().layout().addWidget(ipython)
-        ipython.setFixedHeight(200)
+        self.splitter.addWidget(ipython)
+        self.splitter.setSizes([500, 250])
+
         self.tabs = [self.wgtSlice, self.wgtCut, self.wgtPowder]
         self.tabs_to_show = {TAB_2D: [TAB_POWDER],
                              TAB_EVENT: [TAB_SLICE, TAB_CUT],
                              TAB_HISTO: []}
+
         self.workspace_presenter = self.wgtWorkspacemanager.get_presenter()
         dataloader_presenter = self.data_loading.get_presenter()
         slice_presenter = self.wgtSlice.get_presenter()

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -52,6 +52,7 @@ class MainWindow(MainView, QMainWindow):
         self.btnRename.clicked.connect(self.button_rename)
         self.btnDelete.clicked.connect(self.button_delete)
         self.btnMerge.clicked.connect(self.button_merge)
+        self.btnMerge.setEnabled(False)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
@@ -64,6 +65,7 @@ class MainWindow(MainView, QMainWindow):
         self.wgtPowder.busy.connect(self.show_busy)
 
     def ws_tab_changed(self, tab):
+        self.btnMerge.setEnabled(tab == TAB_EVENT)
         self.tabWidget_2.show()
         tab_to_show = self.tabs_to_show[tab]
         for tab_index in range(3):

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -53,6 +53,8 @@ class MainWindow(MainView, QMainWindow):
         self.btnDelete.clicked.connect(self.button_delete)
         self.btnMerge.clicked.connect(self.button_merge)
         self.btnMerge.setEnabled(False)
+        self.tabWidget_2.setTabEnabled(1, False)
+        self.tabWidget_2.setTabEnabled(2, False)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -30,7 +30,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="iconSize">
        <size>
@@ -55,7 +55,31 @@
          <widget class="QWidget" name="controls" native="true">
           <layout class="QVBoxLayout" name="verticalLayout_2">
            <item>
-            <widget class="QWidget" name="widget_3" native="true"/>
+            <widget class="QWidget" name="widget_3" native="true">
+             <layout class="QGridLayout" name="gridLayout_2">
+              <item row="0" column="0">
+               <widget class="QPushButton" name="btnSave">
+                <property name="text">
+                 <string>Save</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPushButton" name="btnRename">
+                <property name="text">
+                 <string>Rename</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QPushButton" name="btnDelete">
+                <property name="text">
+                 <string>Delete</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
            <item>
             <widget class="QTabWidget" name="tabWidget_2">
@@ -66,8 +90,13 @@
               </sizepolicy>
              </property>
              <property name="currentIndex">
-              <number>2</number>
+              <number>0</number>
              </property>
+             <widget class="PowderWidget" name="wgtPowder">
+              <attribute name="title">
+               <string>Powder</string>
+              </attribute>
+             </widget>
              <widget class="SliceWidget" name="wgtSlice">
               <attribute name="title">
                <string>Slice</string>
@@ -76,11 +105,6 @@
              <widget class="CutWidget" name="wgtCut">
               <attribute name="title">
                <string>Cut</string>
-              </attribute>
-             </widget>
-             <widget class="PowderWidget" name="wgtPowder">
-              <attribute name="title">
-               <string>Powder</string>
               </attribute>
              </widget>
             </widget>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -15,111 +15,113 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
-    <property name="sizeConstraint">
-     <enum>QLayout::SetDefaultConstraint</enum>
-    </property>
     <item row="0" column="0">
-     <widget class="QTabWidget" name="tabWidget">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
+     <widget class="QSplitter" name="splitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
       </property>
-      <property name="tabShape">
-       <enum>QTabWidget::Rounded</enum>
-      </property>
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <property name="iconSize">
-       <size>
-        <width>16</width>
-        <height>16</height>
-       </size>
-      </property>
-      <widget class="DataLoaderWidget" name="data_loading">
-       <attribute name="title">
-        <string>Data Loading</string>
-       </attribute>
-      </widget>
-      <widget class="QWidget" name="workspace_manager">
-       <attribute name="title">
-        <string>Workspace Manager</string>
-       </attribute>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="WorkspaceManagerWidget" name="wgtWorkspacemanager" native="true"/>
-        </item>
-        <item>
-         <widget class="QWidget" name="controls" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <item>
-            <widget class="QWidget" name="widget_3" native="true">
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="0" column="0">
-               <widget class="QPushButton" name="btnSave">
-                <property name="text">
-                 <string>Save</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QPushButton" name="btnRename">
-                <property name="text">
-                 <string>Rename</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QPushButton" name="btnDelete">
-                <property name="text">
-                 <string>Delete</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QPushButton" name="btnMerge">
-                <property name="text">
-                 <string>Merge</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QTabWidget" name="tabWidget_2">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="currentIndex">
-              <number>0</number>
-             </property>
-             <widget class="PowderWidget" name="wgtPowder">
-              <attribute name="title">
-               <string>Powder</string>
-              </attribute>
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="tabShape">
+        <enum>QTabWidget::Rounded</enum>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+       <widget class="DataLoaderWidget" name="data_loading">
+        <attribute name="title">
+         <string>Data Loading</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="workspace_manager">
+        <attribute name="title">
+         <string>Workspace Manager</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="WorkspaceManagerWidget" name="wgtWorkspacemanager" native="true"/>
+         </item>
+         <item>
+          <widget class="QWidget" name="controls" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QWidget" name="widget_3" native="true">
+              <layout class="QGridLayout" name="gridLayout_2">
+               <item row="0" column="0">
+                <widget class="QPushButton" name="btnSave">
+                 <property name="text">
+                  <string>Save</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QPushButton" name="btnRename">
+                 <property name="text">
+                  <string>Rename</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QPushButton" name="btnDelete">
+                 <property name="text">
+                  <string>Delete</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QPushButton" name="btnMerge">
+                 <property name="text">
+                  <string>Merge</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </widget>
-             <widget class="SliceWidget" name="wgtSlice">
-              <attribute name="title">
-               <string>Slice</string>
-              </attribute>
+            </item>
+            <item>
+             <widget class="QTabWidget" name="tabWidget_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <widget class="PowderWidget" name="wgtPowder">
+               <attribute name="title">
+                <string>Powder</string>
+               </attribute>
+              </widget>
+              <widget class="SliceWidget" name="wgtSlice">
+               <attribute name="title">
+                <string>Slice</string>
+               </attribute>
+              </widget>
+              <widget class="CutWidget" name="wgtCut">
+               <attribute name="title">
+                <string>Cut</string>
+               </attribute>
+              </widget>
              </widget>
-             <widget class="CutWidget" name="wgtCut">
-              <attribute name="title">
-               <string>Cut</string>
-              </attribute>
-             </widget>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </widget>
     </item>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -30,7 +30,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="iconSize">
        <size>
@@ -75,6 +75,13 @@
                <widget class="QPushButton" name="btnDelete">
                 <property name="text">
                  <string>Delete</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QPushButton" name="btnMerge">
+                <property name="text">
+                 <string>Merge</string>
                 </property>
                </widget>
               </item>

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -13,6 +13,9 @@ class MainPresenter(MainPresenterInterface):
     def get_selected_workspaces(self):
         return self._workspace_presenter.get_selected_workspaces()
 
+    def change_ws_tab(self, tab):
+        self._workspace_presenter.change_tab(tab)
+
     def set_selected_workspaces(self, workspace_list):
         self._workspace_presenter.set_selected_workspaces(workspace_list)
 

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -44,6 +44,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
     def _get_main_presenter(self):
         return self._main_presenter
 
+    def change_tab(self, tab):
+        self._workspace_manager_view.change_tab(tab)
+
     def _confirm_workspace_overwrite(self, ws_name):
         if ws_name in self._workspace_provider.get_workspace_names():
             return self._workspace_manager_view.confirm_overwrite_workspace()

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -23,9 +23,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
     def notify(self, command):
         self._clear_displayed_error()
         self._workspace_manager_view.busy.emit(True)
-        if command == Command.LoadWorkspace:
-            self._load_workspace()
-        elif command == Command.SaveSelectedWorkspace:
+        if command == Command.SaveSelectedWorkspace:
             self._save_selected_workspace()
         elif command == Command.RemoveSelectedWorkspaces:
             self._remove_selected_workspaces()

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -33,6 +33,8 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
                             TAB_HISTO: self.listWorkspacesHisto}
         self.tabWidget.currentChanged.connect(self.tab_changed)
         self.listWorkspaces2D.itemSelectionChanged.connect(self.list_item_changed)
+        self.listWorkspacesEvent.itemSelectionChanged.connect(self.list_item_changed)
+        self.listWorkspacesHisto.itemSelectionChanged.connect(self.list_item_changed)
         self._presenter = WorkspaceManagerPresenter(self, MantidWorkspaceProvider())
 
     def _display_error(self, error_string):
@@ -40,6 +42,9 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def current_list(self):
         return self.tab_to_list[self.tabWidget.currentIndex()]
+
+    def change_tab(self, tab):
+        self.tabWidget.setCurrentIndex(tab)
 
     def _btn_clicked(self):
         sender = self.sender()
@@ -84,7 +89,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def get_workspace_selected(self):
         selected_workspaces = [str(x.text()) for x in self.current_list().selectedItems()]
-        return list(selected_workspaces)
+        return selected_workspaces
 
     def set_workspace_selected(self, index):
         current_list = self.current_list()

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -19,21 +19,9 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
         load_ui(__file__, 'workspacemanager.ui', self)
-        self.btnWorkspaceSave.clicked.connect(self._btn_clicked)
-        self.btnLoad.clicked.connect(self._btn_clicked)
-        self.btnWorkspaceCompose.clicked.connect(self._btn_clicked)
-        self.btnWorkspaceRemove.clicked.connect(self._btn_clicked)
-        self.btnRename.clicked.connect(self._btn_clicked)
-        self.btnCombine.clicked.connect(self._btn_clicked)
-        self.button_mappings = {self.btnWorkspaceRemove: Command.RemoveSelectedWorkspaces,
-                                self.btnWorkspaceSave: Command.SaveSelectedWorkspace,
-                                self.btnWorkspaceCompose: Command.ComposeWorkspace,
-                                self.btnLoad: Command.LoadWorkspace,
-                                self.btnRename: Command.RenameWorkspace,
-                                self.btnCombine: Command.CombineWorkspace
-                                }
+        self.button_mappings = {}
         self._main_window = None
-        self.lstWorkspaces.itemSelectionChanged.connect(self.list_item_changed)
+        self.lstWorkspaces2D.itemSelectionChanged.connect(self.list_item_changed)
         self._presenter = WorkspaceManagerPresenter(self, MantidWorkspaceProvider())
 
     def _display_error(self, error_string):
@@ -49,20 +37,20 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def display_loaded_workspaces(self, workspaces):
         onscreen_workspaces = []
-        for index in range(self.lstWorkspaces.count()):
-            qitem = self.lstWorkspaces.item(index)
+        for index in range(self.lstWorkspaces2D.count()):
+            qitem = self.lstWorkspaces2D.item(index)
             onscreen_workspaces.append(str(qitem.text()))
         for workspace in workspaces:
             if workspace in onscreen_workspaces:
                 onscreen_workspaces.remove(workspace)
                 continue
             item = QListWidgetItem(workspace)
-            self.lstWorkspaces.addItem(item)
+            self.lstWorkspaces2D.addItem(item)
 
         # remove any onscreen workspaces that are no longer here
         items = [] #items contains (qlistitem, index) tuples
-        for index in range(self.lstWorkspaces.count()):
-            items.append(self.lstWorkspaces.item(index))
+        for index in range(self.lstWorkspaces2D.count()):
+            items.append(self.lstWorkspaces2D.item(index))
         for item in items:
             if str(item.text()) in onscreen_workspaces:
                 self.remove_item_from_list(item)
@@ -73,24 +61,24 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         Must be done in seperate function because items are removed by index and removing an items may alter the indexes
         of other items"""
         text = qlistwidget_item.text()
-        for index in range(self.lstWorkspaces.count()):
-            if self.lstWorkspaces.item(index).text() == text:
-                self.lstWorkspaces.takeItem(index)
+        for index in range(self.lstWorkspaces2D.count()):
+            if self.lstWorkspaces2D.item(index).text() == text:
+                self.lstWorkspaces2D.takeItem(index)
                 return
 
     def get_workspace_selected(self):
-        selected_workspaces = [str(x.text()) for x in self.lstWorkspaces.selectedItems()]
+        selected_workspaces = [str(x.text()) for x in self.lstWorkspaces2D.selectedItems()]
         return list(selected_workspaces)
 
     def set_workspace_selected(self, index):
-        for item_index in range(self.lstWorkspaces.count()):
-            self.lstWorkspaces.setItemSelected(self.lstWorkspaces.item(item_index), False)
+        for item_index in range(self.lstWorkspaces2D.count()):
+            self.lstWorkspaces2D.setItemSelected(self.lstWorkspaces2D.item(item_index), False)
         for this_index in (index if hasattr(index, "__iter__") else [index]):
-            self.lstWorkspaces.setItemSelected(self.lstWorkspaces.item(this_index), True)
+            self.lstWorkspaces2D.setItemSelected(self.lstWorkspaces2D.item(this_index), True)
 
     def get_workspace_index(self, ws_name):
-        for index in range(self.lstWorkspaces.count()):
-            if str(self.lstWorkspaces.item(index).text()) == ws_name:
+        for index in range(self.lstWorkspaces2D.count()):
+            if str(self.lstWorkspaces2D.item(index).text()) == ws_name:
                 return index
         return -1
 

--- a/mslice/widgets/workspacemanager/workspacemanager.ui
+++ b/mslice/widgets/workspacemanager/workspacemanager.ui
@@ -23,7 +23,7 @@
       </size>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab2D">
       <attribute name="title">
@@ -45,7 +45,11 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="QListWidget" name="listWorkspacesEvent"/>
+        <widget class="QListWidget" name="listWorkspacesEvent">
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -55,7 +59,11 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="QListWidget" name="listWorkspacesHisto"/>
+        <widget class="QListWidget" name="listWorkspacesHisto">
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/mslice/widgets/workspacemanager/workspacemanager.ui
+++ b/mslice/widgets/workspacemanager/workspacemanager.ui
@@ -6,114 +6,59 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>529</width>
-    <height>225</height>
+    <width>620</width>
+    <height>352</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QPushButton" name="btnWorkspaceSave">
-     <property name="text">
-      <string>Save</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btnWorkspaceRemove">
-     <property name="text">
-      <string>Remove</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>186</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="3">
-    <widget class="QGroupBox" name="groupBox_6">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
      <property name="minimumSize">
       <size>
-       <width>120</width>
+       <width>300</width>
        <height>0</height>
       </size>
      </property>
-     <property name="title">
-      <string>Workspace Options</string>
+     <property name="currentIndex">
+      <number>2</number>
      </property>
-     <property name="flat">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QPushButton" name="btnLoad">
-        <property name="text">
-         <string>Load</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="btnWorkspaceCompose">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Compose</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QPushButton" name="btnRename">
-        <property name="text">
-         <string>Rename</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QPushButton" name="btnCombine">
-        <property name="text">
-         <string>Combine</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QListWidget" name="lstWorkspaces">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
+     <widget class="QWidget" name="tab2D">
+      <attribute name="title">
+       <string>2D</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QListWidget" name="lstWorkspaces2D">
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabEvent">
+      <attribute name="title">
+       <string>MD Event</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QListWidget" name="listWorkspacesEvent"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabHisto">
+      <attribute name="title">
+       <string>MD Histo</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QListWidget" name="lstWorkspacesHisto"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/mslice/widgets/workspacemanager/workspacemanager.ui
+++ b/mslice/widgets/workspacemanager/workspacemanager.ui
@@ -31,7 +31,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QListWidget" name="lstWorkspaces2D">
+        <widget class="QListWidget" name="listWorkspaces2D">
          <property name="selectionMode">
           <enum>QAbstractItemView::ExtendedSelection</enum>
          </property>
@@ -55,7 +55,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="QListWidget" name="lstWorkspacesHisto"/>
+        <widget class="QListWidget" name="listWorkspacesHisto"/>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
**Not to be merged until after #208**

Implements new `WorkspaceManager` design with tabs for each workspace type. The save / rename / combine controls remain but have moved. The `Load` command is now handled by the `DataLoaderWidget`, not the `WorkspaceManager`. 

**To test:**

- Using the `Data Loading` tab, load workspaces of each type (`Workspace2D`, `MDEventWorkspace`, `MDHistoWorkspace`) and check they are placed in the correct `WorkspaceManager` tab.
- Also check that the save / rename / combine controls function as previously.

Fixes #207 
