### PR TITLE
Fix quick_options error when editing recoil/powder lines

### DIFF
--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -307,7 +307,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         row3.addWidget(self.line_marker)
 
         if line_options['shown'] is not None and line_options['legend'] is not None:
-            self.show_line_label = QtWidgets.QLabel(self)
+            self.show_line_label = QtWidgets.QLabel(self) 
             self.show_line_label.setText("Show: ")
             self.show_line = QtWidgets.QCheckBox(self)
             self.show_line.setChecked(line_options['shown'])

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -287,17 +287,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         chosen_marker_as_string = self.markers[line_options['marker']]
         self.line_marker.setCurrentIndex(self.line_marker.findText(chosen_marker_as_string))
 
-        self.show_line_label = QtWidgets.QLabel(self)
-        self.show_line_label.setText("Show: ")
-        self.show_line = QtWidgets.QCheckBox(self)
-        self.show_line.setChecked(line_options['shown'])
-
-        self.show_legend_label = QtWidgets.QLabel(self)
-        self.show_legend_label.setText("Show legend: ")
-        self.show_legend = QtWidgets.QCheckBox(self)
-        self.show_legend.setChecked(line_options['legend'])
-        self.show_legend.setEnabled(line_options['shown'])
-
         layout = QtWidgets.QVBoxLayout(self)
         row1 = QtWidgets.QHBoxLayout()
         layout.addLayout(row1)
@@ -305,11 +294,9 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         layout.addLayout(row2)
         row3 = QtWidgets.QHBoxLayout()
         layout.addLayout(row3)
-        row4 = QtWidgets.QHBoxLayout()
-        layout.addLayout(row4)
         layout.addStretch()
 
-        row1.addWidget(self.show_legend)
+        # row1.addWidget(self.show_legend)
         row1.addWidget(self.legendText)
         row2.addWidget(self.color_label)
         row2.addWidget(self.line_color)
@@ -319,14 +306,35 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         row3.addWidget(self.line_width)
         row3.addWidget(self.marker_label)
         row3.addWidget(self.line_marker)
-        row4.addWidget(self.show_line_label)
-        row4.addWidget(self.show_line)
-        row4.addWidget(self.show_legend_label)
-        row4.addWidget(self.show_legend)
+
+        if line_options['shown'] is not None and line_options['legend'] is not None:
+            self.show_line_label = QtWidgets.QLabel(self)
+            self.show_line_label.setText("Show: ")
+            self.show_line = QtWidgets.QCheckBox(self)
+            self.show_line.setChecked(line_options['shown'])
+
+            self.show_legend_label = QtWidgets.QLabel(self)
+            self.show_legend_label.setText("Show legend: ")
+            self.show_legend = QtWidgets.QCheckBox(self)
+            self.show_legend.setChecked(line_options['legend'])
+            self.show_legend.setEnabled(line_options['shown'])
+
+            row4 = QtWidgets.QHBoxLayout()
+            layout.addLayout(row4)
+
+            row4.addWidget(self.show_line_label)
+            row4.addWidget(self.show_line)
+            row4.addWidget(self.show_legend_label)
+            row4.addWidget(self.show_legend)
+
+            self.show_line.stateChanged.connect(lambda state: self.show_line_changed(state))
+        else:
+            self.show_line = None
+            self.show_legend = None
 
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
-        self.show_line.stateChanged.connect(lambda state: self.show_line_changed(state))
+
 
     def color_valid(self, index):
         if self.color_validator is None:
@@ -346,6 +354,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     @property
     def legend(self):
+        if self.show_legend is None:
+            return None
         return self.show_legend.checkState()
 
     @property
@@ -354,6 +364,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     @property
     def shown(self):
+        if self.show_line is None:
+            return None
         return bool(self.show_line.checkState())
 
     @property

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -307,7 +307,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         row3.addWidget(self.line_marker)
 
         if line_options['shown'] is not None and line_options['legend'] is not None:
-            self.show_line_label = QtWidgets.QLabel(self) 
+            self.show_line_label = QtWidgets.QLabel(self)
             self.show_line_label.setText("Show: ")
             self.show_line = QtWidgets.QCheckBox(self)
             self.show_line.setChecked(line_options['shown'])

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -296,7 +296,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         layout.addLayout(row3)
         layout.addStretch()
 
-        # row1.addWidget(self.show_legend)
         row1.addWidget(self.legendText)
         row2.addWidget(self.color_label)
         row2.addWidget(self.line_color)
@@ -334,7 +333,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
-
 
     def color_valid(self, index):
         if self.color_validator is None:

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -252,6 +252,24 @@ class SlicePlot(object):
                 self._slice_plotter.add_overplot_line(self._ws_title, *lines[line])
                 self.update_legend()
 
+    def get_line_data(self, target):
+        line_options = {}
+        line_options['label'] = target.get_label()
+        line_options['legend'] = None
+        line_options['shown'] = None
+        line_options['color'] = target.get_color()
+        line_options['style'] = target.get_linestyle()
+        line_options['width'] = str(int(target.get_linewidth()))
+        line_options['marker'] = target.get_marker()
+        return line_options
+
+    def set_line_data(self, line, line_options):
+        line.set_label(line_options['label'])
+        line.set_linestyle(line_options['style'])
+        line.set_marker(line_options['marker'])
+        line.set_color(line_options['color'])
+        line.set_linewidth(line_options['width'])
+
     @property
     def colorbar_label(self):
         return self._canvas.figure.get_axes()[1].get_ylabel()


### PR DESCRIPTION
Recent changes broke the option to change the style of recoil / powder lines by double-clicking. This fixes the issue.

**To test:**
- Plot a slice
- Plot a line using the information menu
- Double click the line (or legend) and change the properties
- Press ok
- Verify that the line changed correctly

Fixes #210
