### PR TITLE
Add right-click condition to plot options

### DIFF
--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -85,11 +85,11 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         self.canvas.draw()
 
     def plot_clicked(self, event):
-        if event.dblclick:
+        if event.dblclick or event.button == 3:
             self._plot_handler.plot_clicked(event.x, event.y)
 
     def object_clicked(self, event):
-        if event.mouseevent.dblclick:
+        if event.mouseevent.dblclick or event.mouseevent.button == 3:
             self._plot_handler.object_clicked(event.artist)
 
     def toggle_data_cursor(self):


### PR DESCRIPTION
Allows the plot options to be accessed by right-clicking as well as double-clicking.

**To test:**
- Check the options for axis, titles, and lines on a plot figure open on right-click.

Fixes #211
