### PR TITLE
Changes to cuts for new interface

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -75,6 +75,9 @@ class MainWindow(MainView, QMainWindow):
         self.data_loading.busy.connect(self.show_busy)
         self.actionQuit.triggered.connect(self.close)
 
+    def change_main_tab(self, tab):
+        self.tabWidget.setCurrentIndex(1)
+
     def ws_tab_changed(self, tab):
         self.enable_widget_tabs(tab)
         self.enable_buttons(tab)

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -114,10 +114,10 @@ class MainWindow(MainView, QMainWindow):
         self.workspace_presenter.notify(ws_command.CombineWorkspace)
 
     def button_plot(self):
-        self.cut_presenter.notify(cut_command.PlotOnly)
+        self.cut_presenter.notify(cut_command.PlotFromWorkspace)
 
     def button_overplot(self):
-        self.cut_presenter.notify(cut_command.PlotOverOnly)
+        self.cut_presenter.notify(cut_command.PlotOverFromWorkspace)
 
     def init_ui(self):
         self.busy_text = QLabel()

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -76,7 +76,7 @@ class MainWindow(MainView, QMainWindow):
         self.actionQuit.triggered.connect(self.close)
 
     def change_main_tab(self, tab):
-        self.tabWidget.setCurrentIndex(1)
+        self.tabWidget.setCurrentIndex(tab)
 
     def ws_tab_changed(self, tab):
         self.enable_widget_tabs(tab)

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -31,7 +31,7 @@
         <enum>QTabWidget::Rounded</enum>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <property name="iconSize">
         <size>
@@ -39,134 +39,220 @@
          <height>16</height>
         </size>
        </property>
-      <widget class="DataLoaderWidget" name="data_loading">
-       <attribute name="title">
-        <string>Data Loading</string>
-       </attribute>
-      </widget>
-      <widget class="QWidget" name="workspace_manager">
-       <attribute name="title">
-        <string>Workspace Manager</string>
-       </attribute>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="WorkspaceManagerWidget" name="wgtWorkspacemanager" native="true">
-          <property name="maximumSize">
-           <size>
-            <width>500</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="controls" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <item>
-            <widget class="QWidget" name="widget_3" native="true">
-             <layout class="QGridLayout" name="gridLayout_2">
-              <item row="6" column="1">
-               <widget class="QPushButton" name="btnHistory">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>History</string>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0">
-               <widget class="QPushButton" name="btnDelete">
-                <property name="text">
-                 <string>Delete</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QPushButton" name="btnRename">
-                <property name="text">
-                 <string>Rename</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QPushButton" name="btnSave">
-                <property name="text">
-                 <string>Save</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QPushButton" name="btnPlot">
-                <property name="text">
-                 <string>Plot</string>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0">
-               <widget class="QPushButton" name="btnMerge">
-                <property name="text">
-                 <string>Merge</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="1">
-               <widget class="QPushButton" name="btnOverplot">
-                <property name="text">
-                 <string>Overplot</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="1">
-               <widget class="QPushButton" name="btnSubtract">
-                <property name="text">
-                 <string>Subtract</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QPushButton" name="btnAdd">
-                <property name="text">
-                 <string>Add</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QTabWidget" name="tabWidget_2">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="currentIndex">
-              <number>0</number>
-             </property>
-             <widget class="PowderWidget" name="wgtPowder">
-              <attribute name="title">
-               <string>Powder</string>
-              </attribute>
+       <widget class="DataLoaderWidget" name="data_loading">
+        <attribute name="title">
+         <string>Data Loading</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="workspace_manager">
+        <attribute name="title">
+         <string>Workspace Manager</string>
+        </attribute>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="WorkspaceManagerWidget" name="wgtWorkspacemanager" native="true">
+           <property name="maximumSize">
+            <size>
+             <width>500</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="controls" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QWidget" name="widget_3" native="true">
+              <property name="maximumSize">
+               <size>
+                <width>250</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_2">
+               <item row="0" column="0">
+                <spacer name="verticalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="6" column="1">
+                <widget class="QPushButton" name="btnHistory">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>History</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="6" column="0">
+                <widget class="QPushButton" name="btnDelete">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Delete</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QPushButton" name="btnRename">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Rename</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="QPushButton" name="btnAdd">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Add</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0">
+                <widget class="QPushButton" name="btnSave">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Save</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="0">
+                <widget class="QPushButton" name="btnPlot">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Plot</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="7" column="0">
+                <widget class="QPushButton" name="btnMerge">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Merge</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="4" column="1">
+                <widget class="QPushButton" name="btnOverplot">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Overplot</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="1">
+                <widget class="QPushButton" name="btnSubtract">
+                 <property name="maximumSize">
+                  <size>
+                   <width>110</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Subtract</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="0">
+                <spacer name="verticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
              </widget>
-             <widget class="SliceWidget" name="wgtSlice">
-              <attribute name="title">
-               <string>Slice</string>
-              </attribute>
+            </item>
+            <item>
+             <widget class="QTabWidget" name="tabWidget_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="currentIndex">
+               <number>0</number>
+              </property>
+              <widget class="PowderWidget" name="wgtPowder">
+               <attribute name="title">
+                <string>Powder</string>
+               </attribute>
+              </widget>
+              <widget class="SliceWidget" name="wgtSlice">
+               <attribute name="title">
+                <string>Slice</string>
+               </attribute>
+              </widget>
+              <widget class="CutWidget" name="wgtCut">
+               <attribute name="title">
+                <string>Cut</string>
+               </attribute>
+              </widget>
              </widget>
-             <widget class="CutWidget" name="wgtCut">
-              <attribute name="title">
-               <string>Cut</string>
-              </attribute>
-             </widget>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </widget>
     </item>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -31,7 +31,7 @@
         <enum>QTabWidget::Rounded</enum>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <property name="iconSize">
         <size>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -49,7 +49,14 @@
        </attribute>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="WorkspaceManagerWidget" name="wgtWorkspacemanager" native="true"/>
+         <widget class="WorkspaceManagerWidget" name="wgtWorkspacemanager" native="true">
+          <property name="maximumSize">
+           <size>
+            <width>500</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
         </item>
         <item>
          <widget class="QWidget" name="controls" native="true">
@@ -57,21 +64,17 @@
            <item>
             <widget class="QWidget" name="widget_3" native="true">
              <layout class="QGridLayout" name="gridLayout_2">
-              <item row="0" column="0">
-               <widget class="QPushButton" name="btnSave">
+              <item row="6" column="1">
+               <widget class="QPushButton" name="btnHistory">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
                 <property name="text">
-                 <string>Save</string>
+                 <string>History</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QPushButton" name="btnRename">
-                <property name="text">
-                 <string>Rename</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
+              <item row="6" column="0">
                <widget class="QPushButton" name="btnDelete">
                 <property name="text">
                  <string>Delete</string>
@@ -79,9 +82,51 @@
                </widget>
               </item>
               <item row="1" column="1">
+               <widget class="QPushButton" name="btnRename">
+                <property name="text">
+                 <string>Rename</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QPushButton" name="btnSave">
+                <property name="text">
+                 <string>Save</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QPushButton" name="btnPlot">
+                <property name="text">
+                 <string>Plot</string>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0">
                <widget class="QPushButton" name="btnMerge">
                 <property name="text">
                  <string>Merge</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QPushButton" name="btnOverplot">
+                <property name="text">
+                 <string>Overplot</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QPushButton" name="btnSubtract">
+                <property name="text">
+                 <string>Subtract</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QPushButton" name="btnAdd">
+                <property name="text">
+                 <string>Add</string>
                 </property>
                </widget>
               </item>

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -12,9 +12,6 @@ class CutAlgorithm(object):
     def is_cut(self, workspace):
         pass
 
-    def get_cut_params(self, cut_workspace):
-        pass
-
     def get_available_axis(self, workspace):
         pass
 

--- a/mslice/models/cut/cut_plotter.py
+++ b/mslice/models/cut/cut_plotter.py
@@ -5,3 +5,6 @@ class CutPlotter(object):
     def plot_cut(self, selected_workspace, cut_axis, integration_start, integration_end, norm_to_one, intensity_start,
                  intensity_end, plot_over):
         raise NotImplementedError('This class is an abstract interface')
+
+    def plot_cut_from_x_y_e(self, x, y, e, selected_workspace, plot_over):
+        raise NotImplementedError('This class is an abstract interface')

--- a/mslice/models/cut/cut_plotter.py
+++ b/mslice/models/cut/cut_plotter.py
@@ -6,5 +6,5 @@ class CutPlotter(object):
                  intensity_end, plot_over):
         raise NotImplementedError('This class is an abstract interface')
 
-    def plot_cut_from_x_y_e(self, x, y, e, selected_workspace, plot_over):
+    def plot_cut_from_x_y_e(self, x, y, e, x_units, selected_workspace, plot_over):
         raise NotImplementedError('This class is an abstract interface')

--- a/mslice/models/cut/cut_plotter.py
+++ b/mslice/models/cut/cut_plotter.py
@@ -6,5 +6,5 @@ class CutPlotter(object):
                  intensity_end, plot_over):
         raise NotImplementedError('This class is an abstract interface')
 
-    def plot_cut_from_x_y_e(self, x, y, e, x_units, selected_workspace, plot_over):
+    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, plot_over):
         raise NotImplementedError('This class is an abstract interface')

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -103,28 +103,6 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         workspace = self._workspace_provider.get_workspace_handle(workspace)
         return isinstance(workspace, IMDEventWorkspace) and workspace.getNumDims() == 2
 
-    def get_cut_params(self, cut_workspace):
-        cut_workspace = self._workspace_provider.get_workspace_handle(cut_workspace)
-        assert isinstance(cut_workspace, IMDHistoWorkspace)
-        is_norm = self._was_previously_normalized(cut_workspace)
-        bin_md = None
-        history = cut_workspace.getHistory()
-        for i in range(history.size()-1,-1,-1):
-            algorithm = history.getAlgorithm(i)
-            if algorithm.name() == 'BinMD':
-                bin_md = algorithm
-                break
-        integration_binning = bin_md.getPropertyValue("AlignedDim1").split(",")
-        integration_range = float(integration_binning[1]), float(integration_binning[2])
-
-        cut_binning = bin_md.getPropertyValue("AlignedDim0").split(",")
-        # The axis name is retreived from the workspace directly and not the binning string to avoid
-        # adding/removing trailing spaces
-        dim_name = cut_workspace.getDimension(0).getName()
-        cut_axis = Axis(dim_name, *list(map(float,cut_binning[1:])))
-        cut_axis.step = (cut_axis.end - cut_axis.start)/float(cut_binning[-1])
-        return cut_axis, integration_range, is_norm
-
     def set_saved_cut_parameters(self, workspace, axis, parameters):
         self._workspace_provider.setCutParameters(workspace, axis, parameters)
 

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -49,7 +49,6 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         return x, plot_data, errors
 
     def compute_cut(self, selected_workspace, cut_axis, integration_start, integration_end, is_norm):
-
         input_workspace_name = selected_workspace
         selected_workspace = self._workspace_provider.get_workspace_handle(selected_workspace)
         self._fill_in_missing_input(cut_axis, selected_workspace)

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -8,7 +8,6 @@ from mantid.api import IMDEventWorkspace, IMDHistoWorkspace
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
 from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
-from mslice.presenters.slice_plotter_presenter import Axis
 
 
 class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -58,14 +58,10 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         cut_binning = " ,".join(map(str, (cut_axis.units, cut_axis.start, cut_axis.end, n_steps)))
         integration_binning = integration_axis + "," + str(integration_start) + "," + str(integration_end) + ",1"
 
-        output_workspace_name = input_workspace_name + "_cut"
+        output_ws_name = input_workspace_name + "_cut(" + str(integration_start) + "," + str(integration_end) + ")"
         index = 1
-        existing_workspaces = self._workspace_provider.get_workspace_names()
-        while output_workspace_name + str(index) in existing_workspaces:
-            index += 1
-        output_workspace_name += str(index)
-        cut = BinMD(selected_workspace, OutputWorkspace=output_workspace_name, AxisAligned="1", AlignedDim1=integration_binning,
-                    AlignedDim0=cut_binning)
+        cut = BinMD(selected_workspace, OutputWorkspace=output_ws_name, AxisAligned="1",
+                    AlignedDim1=integration_binning, AlignedDim0=cut_binning)
         if is_norm:
             self._normalize_workspace(cut)
         return cut

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -21,11 +21,8 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         cut_computed = False
         copy_created = False
         copy_name = '_to_be_normalized_xyx_123_qme78hj'  # This is just a valid name
-        if not self.is_cut(selected_workspace):
-            cut = self.compute_cut(selected_workspace, cut_axis, integration_start, integration_end, is_norm=False)
-            cut_computed = True
-        else:
-            cut = self._workspace_provider.get_workspace_handle(selected_workspace)
+        cut = self.compute_cut(selected_workspace, cut_axis, integration_start, integration_end, is_norm=False)
+        cut_computed = True
         if is_norm:
             # If the cut previously existed in the ADS we will not modify it
             if not cut_computed:
@@ -69,29 +66,6 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         all_axis = self.get_available_axis(workspace)
         all_axis.remove(axis.units)
         return all_axis[0]
-
-    def is_cut(self, workspace):
-        workspace = self._workspace_provider.get_workspace_handle(workspace)
-        if not isinstance(workspace, IMDHistoWorkspace):
-            return False
-        if workspace.getNumDims() != 2 or len(workspace.getNonIntegratedDimensions()) != 1:
-            return False
-        history = workspace.getHistory()
-        # If any of these were set in the last BinMD call then this is not a cut
-        empty_params = ('AlignedDim2','AlignedDim3', 'AlignedDim4', 'AlignedDim5')
-        # If these were not set then this is not a cut
-        used_params = ('AxisAligned', 'AlignedDim0', 'AlignedDim1')
-        for i in range(history.size()-1, -1, -1):
-            try:
-                algorithm = history.getAlgorithm(i)
-            except RuntimeError:
-                return False
-            if algorithm.name() == 'BinMD':
-                if all([not algorithm.getPropertyValue(x) for x in empty_params])\
-                        and all([algorithm.getPropertyValue(x) for x in used_params]):
-                    return True
-                break
-        return False
 
     def is_cuttable(self, workspace):
         workspace = self._workspace_provider.get_workspace_handle(workspace)

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -17,25 +17,15 @@ class MatplotlibCutPlotter(CutPlotter):
                                                       norm_to_one)
         integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis)
         legend = self._generate_legend(selected_workspace, integrated_dim, integration_start, integration_end)
-        plt.errorbar(x, y, yerr=e, label=legend, hold=plot_over, marker='o', picker=picker)
-        leg = plt.legend(fontsize='medium')
-        leg.draggable()
-        plt.xlabel(self._getDisplayName(cut_axis.units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
-        plt.ylabel(INTENSITY_LABEL, picker=picker)
-        plt.autoscale()
+        self.plot_cut_from_xye(x, y, e, cut_axis.units, selected_workspace, plot_over, legend)
         plt.ylim(intensity_start, intensity_end)
-        plt.gcf().canvas.manager.add_cut_plot(self)
-        if not plot_over:
-            plt.gcf().canvas.manager.update_grid()
-        plt.draw_all()
 
-    def plot_cut_from_x_y_e(self, x, y, e, x_units, selected_workspace, plot_over):
-        legend = selected_workspace
+    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, plot_over, legend=None):
+        legend = selected_workspace if legend is None else legend
         plt.errorbar(x, y, yerr=e, label=legend, hold=plot_over, marker='o', picker=picker)
         leg = plt.legend(fontsize='medium')
         leg.draggable()
-        plt.xlabel(self._getDisplayName(x_units, self._cut_algorithm.getComment(selected_workspace)),
-                   picker=picker)
+        plt.xlabel(self._getDisplayName(x_units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
         plt.ylabel(INTENSITY_LABEL, picker=picker)
         plt.autoscale()
         plt.gcf().canvas.manager.add_cut_plot(self)

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -29,6 +29,22 @@ class MatplotlibCutPlotter(CutPlotter):
             plt.gcf().canvas.manager.update_grid()
         plt.draw_all()
 
+    def plot_cut_from_x_y_e(self, x, y, e, selected_workspace, plot_over):
+        # integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis)
+        # legend = self._generate_legend(selected_workspace, integrated_dim, integration_start, integration_end)
+        legend= None
+        plt.errorbar(x, y, yerr=e, label=legend, hold=plot_over, marker='o', picker=picker)
+        leg = plt.legend(fontsize='medium')
+        leg.draggable()
+        # plt.xlabel(self._getDisplayName(cut_axis.units, self._cut_algorithm.getComment(selected_workspace)),
+        #            picker=picker)
+        plt.ylabel(INTENSITY_LABEL, picker=picker)
+        plt.autoscale()
+        plt.gcf().canvas.manager.add_cut_plot(self)
+        if not plot_over:
+            plt.gcf().canvas.manager.update_grid()
+        plt.draw_all()
+
     def _getDisplayName(self, axisUnits, comment=None):
         if 'DeltaE' in axisUnits:
             # Matplotlib 1.3 doesn't handle LaTeX very well. Sometimes no legend appears if we use LaTeX

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -29,15 +29,13 @@ class MatplotlibCutPlotter(CutPlotter):
             plt.gcf().canvas.manager.update_grid()
         plt.draw_all()
 
-    def plot_cut_from_x_y_e(self, x, y, e, selected_workspace, plot_over):
-        # integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis)
-        # legend = self._generate_legend(selected_workspace, integrated_dim, integration_start, integration_end)
-        legend= None
+    def plot_cut_from_x_y_e(self, x, y, e, x_units, selected_workspace, plot_over):
+        legend = selected_workspace
         plt.errorbar(x, y, yerr=e, label=legend, hold=plot_over, marker='o', picker=picker)
         leg = plt.legend(fontsize='medium')
         leg.draggable()
-        # plt.xlabel(self._getDisplayName(cut_axis.units, self._cut_algorithm.getComment(selected_workspace)),
-        #            picker=picker)
+        plt.xlabel(self._getDisplayName(x_units, self._cut_algorithm.getComment(selected_workspace)),
+                   picker=picker)
         plt.ylabel(INTENSITY_LABEL, picker=picker)
         plt.autoscale()
         plt.gcf().canvas.manager.add_cut_plot(self)

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -43,10 +43,6 @@ class CutPresenter(PresenterUtility):
             self._plot_cut_from_workspace(plot_over=True)
         elif command == Command.SaveToWorkspace:
             self._cut(output_method=self._save_cut_to_workspace)
-        elif command == Command.SaveToAscii:
-            fname = str(QFileDialog.getSaveFileName(caption='Select File for Saving'))
-            if fname:
-                self._cut(output_method=self._save_cut_to_file, save_to_file=fname)
         elif command == Command.AxisChanged:
             self._cut_axis_changed()
         self._cut_view.busy.emit(False)
@@ -91,14 +87,6 @@ class CutPresenter(PresenterUtility):
     def _plot_cut(self, params, plot_over, _):
         self._cut_plotter.plot_cut(*params, plot_over=plot_over)
         self._main_presenter.change_ws_tab(2)
-
-    def _save_cut_to_file(self, params, plot_over, output_file):
-        cut_params = params[:5]
-        x, y, e = self._cut_algorithm.compute_cut_xye(*cut_params)
-        header = 'MSlice Cut of workspace "%s" along "%s" between %f and %f' % (params[:4])
-        header += ' %s normalising to unity' % ('with' if params[4] else 'without')
-        out_data = np.c_[x, y, e]
-        np.savetxt(str(output_file), out_data, fmt='%12.9e', header=header)
 
     def _save_cut_to_workspace(self, params, _, __):
         cut_params = params[:5]

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -49,10 +49,15 @@ class CutPresenter(PresenterUtility):
 
     def _cut(self, output_method, histo_ws=False, plot_over=False, save_to_file=None):
         selected_workspaces = self._main_presenter.get_selected_workspaces()
-        self._parse_step()
+        try:
+            self._parse_step()
+            parsed_params = self._parse_input()
+        except ValueError:
+            return
         for workspace in selected_workspaces:
-            params = (workspace,) + self._parse_input()
+            params = (workspace,) + parsed_params
             self._run_cut_method(params, output_method, plot_over, save_to_file)
+            plot_over = True # The first plot will respect which button the user pressed. The rest will over plot
 
     def _run_cut_method(self, params, output_method, plot_over=False, save_to_file=None):
             width = params[-1]

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -104,8 +104,9 @@ class CutPresenter(PresenterUtility):
         mantid_ws = MantidWorkspaceProvider().get_workspace_handle(workspace)
         dim = mantid_ws.getDimension(0)
         x = np.linspace(dim.getMinimum(), dim.getMaximum(), dim.getNBins())
-        y = mantid_ws.getSignalArray() / mantid_ws.getNumEventsArray()
-        e = np.sqrt(mantid_ws.getErrorSquaredArray()/mantid_ws.getNumEventsArray())
+        with np.errstate(invalid='ignore'):
+            y = mantid_ws.getSignalArray() / mantid_ws.getNumEventsArray()
+            e = np.sqrt(mantid_ws.getErrorSquaredArray())/mantid_ws.getNumEventsArray()
         e = e.squeeze()
         return x, y, e, dim.getUnits()
 

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -36,7 +36,7 @@ class CutPresenter(PresenterUtility):
         elif command == Command.PlotOver:
             self._process_cuts(plot_over=True)
         elif command == Command.SaveToWorkspace:
-            self._process_cuts(save_to_workspace=True)
+            self._process_cuts(save_to_workspace_only=True)
         elif command == Command.SaveToAscii:
             fname = str(QFileDialog.getSaveFileName(caption='Select File for Saving'))
             if fname:
@@ -46,7 +46,7 @@ class CutPresenter(PresenterUtility):
         self._cut_view.busy.emit(False)
 
 
-    def _process_cuts(self, plot_over=False, save_to_workspace=False, save_to_file=None, workspace_index=0):
+    def _process_cuts(self, plot_over=False, save_to_workspace_only=False, save_to_file=None, workspace_index=0):
         """This function handles the width parameter. If it is not specified a single cut is plotted from
         integration_start to integration_end """
         selected_workspaces = self._main_presenter.get_selected_workspaces()
@@ -55,7 +55,7 @@ class CutPresenter(PresenterUtility):
             params = self._parse_input(workspace_index)
         except ValueError:
             return
-        if save_to_workspace:
+        if save_to_workspace_only:
             def handler(*args):
                 self._save_cut_to_workspace(args[0])
         elif save_to_file is not None:
@@ -63,6 +63,7 @@ class CutPresenter(PresenterUtility):
                 self._save_cut_to_file(params, save_to_file)
         else:
             def handler(params, plot_over, _):
+                self._save_cut_to_workspace(params)
                 self._plot_cut(params, plot_over)
 
         width = params[-1]
@@ -90,11 +91,12 @@ class CutPresenter(PresenterUtility):
         if workspace_index < len(selected_workspaces) - 1:
             workspace_index += 1
             self._populate_fields_using_workspace(selected_workspaces[workspace_index], plotting=True)
-            self._process_cuts(plot_over=True, save_to_workspace=save_to_workspace, save_to_file=save_to_file,
+            self._process_cuts(plot_over=True, save_to_workspace_only=save_to_workspace_only, save_to_file=save_to_file,
                                workspace_index=workspace_index)
 
     def _plot_cut(self, params, plot_over):
         self._cut_plotter.plot_cut(*params, plot_over=plot_over)
+        self._main_presenter.change_ws_tab(2)
 
     def _save_cut_to_file(self, params, output_file):
         cut_params = params[:5]

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -1,7 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-from mantid.api import IMDHistoWorkspace
-
 from mslice.models.cut.cut_algorithm import CutAlgorithm
 from mslice.models.cut.cut_plotter import CutPlotter
 from mslice.presenters.presenter_utility import PresenterUtility

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -122,8 +122,8 @@ class CutPresenter(PresenterUtility):
         selected_workspaces = self._main_presenter.get_selected_workspaces()
         for workspace in selected_workspaces:
             x, y, e, units = self.get_arrays_from_workspace(workspace)
-            self._cut_plotter.plot_cut_from_x_y_e(x, y, e, units, workspace, plot_over)
-            # plot over should become true after first loop
+            self._cut_plotter.plot_cut_from_xye(x, y, e, units, workspace, plot_over)
+            # TODO: plot over should become true after first loop
 
     def get_arrays_from_workspace(self, workspace):
         mantid_ws = MantidWorkspaceProvider().get_workspace_handle(workspace)
@@ -211,22 +211,29 @@ class CutPresenter(PresenterUtility):
         self._cut_view.set_minimum_step(self._minimumStep[axis[0]])
 
     def workspace_selection_changed(self):
-        if self._previous_cut is not None and self._previous_axis is not None:
-            if not self._cut_view.is_fields_cleared():
-                self._cut_algorithm.set_saved_cut_parameters(self._previous_cut, self._previous_axis,
-                                                             self._cut_view.get_input_fields())
-            else:
-                self._previous_cut = None
-                self._previous_axis = None
-
+        #
+        # if self._previous_cut is not None and self._previous_axis is not None:
+        #     if not self._cut_view.is_fields_cleared():
+        #         self._cut_algorithm.set_saved_cut_parameters(self._previous_cut, self._previous_axis,
+        #                                                      self._cut_view.get_input_fields())
+        #     else:
+        #         self._previous_cut = None
+        #         self._previous_axis = None
+        #
         workspace_selection = self._main_presenter.get_selected_workspaces()
-        if len(workspace_selection) < 1:
-            self._cut_view.clear_input_fields()
-            self._cut_view.disable()
-            self._previous_cut = None
-            self._previous_axis = None
-            return
-        self._populate_fields_using_workspace(workspace_selection[0])
+        # if len(workspace_selection) < 1:
+        #     self._cut_view.clear_input_fields()
+        #     self._cut_view.disable()
+        #     self._previous_cut = None
+        #     self._previous_axis = None
+        #     return
+        self._populate_fields_using_workspace_2(workspace_selection[0])
+
+    def _populate_fields_using_workspace_2(self, workspace):
+        if self._cut_algorithm.is_cuttable(workspace):
+            print("cuttable")
+            self._cut_view.populate_cut_axis_options(self._cut_algorithm.get_available_axis(workspace))
+            self._cut_view.enable()
 
     def _populate_fields_using_workspace(self, workspace, plotting=False):
         if self._cut_algorithm.is_cuttable(workspace):

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -35,8 +35,12 @@ class CutPresenter(PresenterUtility):
             self._process_cuts(plot_over=False)
         elif command == Command.PlotOver:
             self._process_cuts(plot_over=True)
+        elif command == Command.PlotOnly:
+            self._process_cuts(plot_over=False, save_to_workspace=False)
+        elif command == Command.PlotOverOnly:
+            self._process_cuts(plot_over=True, save_to_workspace=False)
         elif command == Command.SaveToWorkspace:
-            self._process_cuts(save_to_workspace_only=True)
+            self._process_cuts(plot=False)
         elif command == Command.SaveToAscii:
             fname = str(QFileDialog.getSaveFileName(caption='Select File for Saving'))
             if fname:
@@ -46,7 +50,7 @@ class CutPresenter(PresenterUtility):
         self._cut_view.busy.emit(False)
 
 
-    def _process_cuts(self, plot_over=False, save_to_workspace_only=False, save_to_file=None, workspace_index=0):
+    def _process_cuts(self, plot_over=False, save_to_workspace=True, plot=True, save_to_file=None, workspace_index=0):
         """This function handles the width parameter. If it is not specified a single cut is plotted from
         integration_start to integration_end """
         selected_workspaces = self._main_presenter.get_selected_workspaces()
@@ -55,17 +59,15 @@ class CutPresenter(PresenterUtility):
             params = self._parse_input(workspace_index)
         except ValueError:
             return
-        if save_to_workspace_only:
-            def handler(*args):
-                self._save_cut_to_workspace(args[0])
-        elif save_to_file is not None:
+        if save_to_file is not None:
             def handler(params, _, save_to_file):
                 self._save_cut_to_file(params, save_to_file)
         else:
             def handler(params, plot_over, _):
-                self._save_cut_to_workspace(params)
-                self._plot_cut(params, plot_over)
-
+                if plot:
+                    self._plot_cut(params, plot_over)
+                if save_to_workspace:
+                    self._save_cut_to_workspace(params)
         width = params[-1]
         params = params[:-1]
         if width is not None:
@@ -91,8 +93,8 @@ class CutPresenter(PresenterUtility):
         if workspace_index < len(selected_workspaces) - 1:
             workspace_index += 1
             self._populate_fields_using_workspace(selected_workspaces[workspace_index], plotting=True)
-            self._process_cuts(plot_over=True, save_to_workspace_only=save_to_workspace_only, save_to_file=save_to_file,
-                               workspace_index=workspace_index)
+            self._process_cuts(plot_over=True, save_to_workspace=save_to_workspace, plot=plot,
+                               save_to_file=save_to_file, workspace_index=workspace_index)
 
     def _plot_cut(self, params, plot_over):
         self._cut_plotter.plot_cut(*params, plot_over=plot_over)

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -40,6 +40,7 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     not_opened.append(ws_name)
                 else:
                     self.check_efixed(ws_name, multi)
+                    self._main_presenter.show_workspace_manager_tab()
         self._report_load_errors(ws_names, not_opened, not_loaded)
         self._main_presenter.update_displayed_workspaces()
         self._view.busy.emit(False)

--- a/mslice/presenters/interfaces/main_presenter.py
+++ b/mslice/presenters/interfaces/main_presenter.py
@@ -28,3 +28,7 @@ class MainPresenterInterface(object):
     @abc.abstractmethod
     def register_workspace_selector(self, workspace_selector):
         pass
+
+    @abc.abstractmethod
+    def change_ws_tab(self, tab):
+        pass

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -16,6 +16,9 @@ class MainPresenter(MainPresenterInterface):
     def change_ws_tab(self, tab):
         self._workspace_presenter.change_tab(tab)
 
+    def show_workspace_manager_tab(self):
+        self._mainView.change_main_tab(1)
+
     def set_selected_workspaces(self, workspace_list):
         self._workspace_presenter.set_selected_workspaces(workspace_list)
 

--- a/mslice/presenters/powder_projection_presenter.py
+++ b/mslice/presenters/powder_projection_presenter.py
@@ -52,8 +52,8 @@ class PowderProjectionPresenter(PresenterUtility, PowderProjectionPresenterInter
         for workspace in selected_workspaces:
             outws.append(self._projection_calculator.calculate_projection(workspace, axis1, axis2, units))
         self._get_main_presenter().update_displayed_workspaces()
-        self._get_main_presenter().set_selected_workspaces(outws)
         self._get_main_presenter().change_ws_tab(1)
+        self._get_main_presenter().set_selected_workspaces(outws)
 
     @require_main_presenter
     def _get_main_presenter(self):

--- a/mslice/presenters/powder_projection_presenter.py
+++ b/mslice/presenters/powder_projection_presenter.py
@@ -53,6 +53,7 @@ class PowderProjectionPresenter(PresenterUtility, PowderProjectionPresenterInter
             outws.append(self._projection_calculator.calculate_projection(workspace, axis1, axis2, units))
         self._get_main_presenter().update_displayed_workspaces()
         self._get_main_presenter().set_selected_workspaces(outws)
+        self._get_main_presenter().change_ws_tab(1)
 
     @require_main_presenter
     def _get_main_presenter(self):

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -96,28 +96,6 @@ class CutPresenterTest(unittest.TestCase):
         self.view.populate_input_fields.assert_called_with(fields)
         self.cut_algorithm.set_saved_cut_parameters.assert_called_with(new_workspace, available_dimensions[0], fields)
 
-    def test_workspace_selection_changed_single_cut_workspace(self):
-        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
-        cut_presenter.register_master(self.main_presenter)
-        workspace = 'workspace'
-        self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
-        self.cut_algorithm.is_cuttable = mock.Mock(return_value=False)
-        self.cut_algorithm.is_cut = mock.Mock(return_value=True)
-        cut_axis = Axis( "units", 0, 10, .1)
-        integration_limits = (11, 12)
-        formatted_integration_limits = ("11.00000", "12.00000")
-        is_normed = False
-        self.cut_algorithm.get_cut_params = mock.Mock(return_value=[cut_axis, integration_limits, is_normed])
-        cut_presenter.workspace_selection_changed()
-        self.view.populate_cut_axis_options.assert_called_with([cut_axis.units])
-        self.view.populate_integration_params.assert_called_with(*formatted_integration_limits)
-        self.view.plotting_params_only.assert_called_once()
-        self.view.enable.assert_not_called()
-        is_normed = True
-        self.cut_algorithm.get_cut_params = mock.Mock(return_value=[cut_axis, integration_limits, is_normed])
-        cut_presenter.workspace_selection_changed()
-        self.view.force_normalization.assert_called_with()
-
     def test_workspace_selection_changed_single_noncut_workspace(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
@@ -252,7 +230,6 @@ class CutPresenterTest(unittest.TestCase):
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
 
         cut_presenter.notify(Command.Plot)
-        self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_called_with(selected_workspace=workspace, cut_axis=processed_axis,
                                                      integration_start=integration_start, integration_end=integration_end,
                                                      norm_to_one=is_norm, intensity_start=intensity_start,
@@ -274,7 +251,6 @@ class CutPresenterTest(unittest.TestCase):
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         cut_presenter.notify(Command.PlotOver)
-        self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_called_with(selected_workspace=workspace, cut_axis=processed_axis,
                                                      integration_start=integration_start, integration_end=integration_end,
                                                      norm_to_one=is_norm, intensity_start=None,
@@ -299,37 +275,6 @@ class CutPresenterTest(unittest.TestCase):
         cut_presenter.notify(Command.SaveToWorkspace)
         self.cut_algorithm.compute_cut.assert_called_with(workspace, processed_axis, integration_start,
                                                           integration_end, is_norm)
-        self.cut_plotter.plot_cut.assert_not_called()
-
-    def test_cut_save_ascii(self):
-        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
-        cut_presenter.register_master(self.main_presenter)
-        axis = Axis("units", "0", "100", "1")
-        processed_axis = Axis("units", 0, 100, 1)
-        integration_start = 3
-        integration_end = 5
-        width = ""
-        intensity_start = 11
-        intensity_end = 30
-        is_norm = True
-        workspace = "workspace"
-        integrated_axis = 'integrated axis'
-        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
-                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
-        # Create a view that will return a path on call to get_workspace_to_load_path
-        tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
-        path_to_savefile = join(tempdir,'out.txt')
-        x = np.array([1, 2, 3])
-        y = np.array([1, 4, 9])
-        e = np.array([1, 1, 1])
-        self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=(x, y, e))
-        QFileDialog.getSaveFileName = mock.Mock(return_value=path_to_savefile)
-        np.savetxt = mock.Mock()
-        cut_presenter.notify(Command.SaveToAscii)
-        self.cut_algorithm.compute_cut_xye.assert_called_with(workspace, processed_axis, integration_start,
-                                                              integration_end, is_norm)
-        QFileDialog.getSaveFileName.assert_called_once()
-        np.savetxt.assert_called_once()
         self.cut_plotter.plot_cut.assert_not_called()
 
     def test_plot_multiple_cuts_with_width(self):
@@ -360,7 +305,6 @@ class CutPresenterTest(unittest.TestCase):
                  integration_end=8,norm_to_one=is_norm,intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=True)
         ]
-        self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
 
     def test_plot_multiple_workspaces_cut(self):
@@ -390,45 +334,7 @@ class CutPresenterTest(unittest.TestCase):
                  norm_to_one=is_norm, intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=True),
         ]
-        self.cut_algorithm.compute_cut.assert_not_called()
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
-
-    def test_multiple_cut_save_ascii(self):
-        cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
-        cut_presenter.register_master(self.main_presenter)
-        axis = Axis("units", "0", "100", "1")
-        processed_axis = Axis("units", 0, 100, 1)
-        integration_start = 3
-        integration_end = 8
-        width = "2"
-        intensity_start = 11
-        intensity_end = 30
-        is_norm = True
-        workspace = "workspace"
-        integrated_axis = 'integrated axis'
-        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
-                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
-        # Create a view that will return a path on call to get_workspace_to_load_path
-        tempdir = gettempdir()  # To insure sample paths are valid on platform of execution
-        path_to_savefile = join(tempdir,'out.txt')
-        x = np.array([1, 2, 3])
-        y = np.array([1, 4, 9])
-        e = np.array([1, 1, 1])
-        self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=(x, y, e))
-        QFileDialog.getSaveFileName = mock.Mock(return_value=path_to_savefile)
-        np.savetxt = mock.Mock()
-        cut_presenter.notify(Command.SaveToAscii)
-        QFileDialog.getSaveFileName.assert_called_once()
-        w = float(width)
-        call_list = [
-            call(workspace, processed_axis, integration_start, integration_start+w, is_norm),
-            call(workspace, processed_axis, integration_start+w, integration_start+w+w, is_norm),
-            call(workspace, processed_axis, integration_start+w+w, integration_end, is_norm),
-        ]
-        self.cut_algorithm.compute_cut_xye.assert_has_calls(call_list)
-        callargs = np.savetxt.call_args[0]
-        self.assertEqual(callargs[0], join(tempdir, 'out_2.txt'))  # Indexed from zero
-        self.cut_plotter.plot_cut.assert_not_called()
 
     def test_change_axis(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)

--- a/mslice/widgets/cut/command.py
+++ b/mslice/widgets/cut/command.py
@@ -16,5 +16,5 @@ class Command(object):
     SaveToWorkspace = -997
     SaveToAscii = -996
     AxisChanged = -995
-    PlotOnly = -994
-    PlotOverOnly = -993
+    PlotFromWorkspace = -994
+    PlotOverFromWorkspace = -993

--- a/mslice/widgets/cut/command.py
+++ b/mslice/widgets/cut/command.py
@@ -16,3 +16,5 @@ class Command(object):
     SaveToWorkspace = -997
     SaveToAscii = -996
     AxisChanged = -995
+    PlotOnly = -994
+    PlotOverOnly = -993

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -31,8 +31,7 @@ class CutWidget(CutView, QWidget):
         self._command_lookup = {
             self.btnCutPlot: Command.Plot,
             self.btnCutPlotOver: Command.PlotOver,
-            self.btnCutSaveToWorkspace: Command.SaveToWorkspace,
-            self.btnCutSaveAscii: Command.SaveToAscii
+            self.btnCutSaveToWorkspace: Command.SaveToWorkspace
         }
         for button in self._command_lookup.keys():
             button.clicked.connect(self._btn_clicked)
@@ -199,7 +198,6 @@ class CutWidget(CutView, QWidget):
         self.btnCutPlot.setEnabled(False)
         self.btnCutPlotOver.setEnabled(False)
 
-        self.btnCutSaveAscii.setEnabled(True)
         self.btnCutSaveToWorkspace.setEnabled(True)
         self.btnCutPlot.setEnabled(True)
         self.btnCutPlotOver.setEnabled(True)
@@ -218,7 +216,6 @@ class CutWidget(CutView, QWidget):
         self.lneCutIntensityEnd.setEnabled(False)
         self.rdoCutNormToOne.setEnabled(False)
 
-        self.btnCutSaveAscii.setEnabled(False)
         self.btnCutSaveToWorkspace.setEnabled(False)
         self.btnCutPlot.setEnabled(False)
         self.btnCutPlotOver.setEnabled(False)

--- a/mslice/widgets/cut/cut.ui
+++ b/mslice/widgets/cut/cut.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>402</width>
-    <height>150</height>
+    <width>542</width>
+    <height>197</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -149,16 +149,6 @@
       <widget class="QPushButton" name="btnCutPlot">
        <property name="text">
         <string>Plot</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0" colspan="2">
-      <widget class="QPushButton" name="btnCutSaveAscii">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Save Ascii</string>
        </property>
       </widget>
      </item>

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -31,7 +31,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         self.tab_to_list = {TAB_2D: self.listWorkspaces2D,
                             TAB_EVENT: self.listWorkspacesEvent,
                             TAB_HISTO: self.listWorkspacesHisto}
-        self.tabWidget.currentChanged.connect(self.tab_changed)
+        self.tabWidget.currentChanged.connect(self.tab_changed_method)
         self.listWorkspaces2D.itemSelectionChanged.connect(self.list_item_changed)
         self.listWorkspacesEvent.itemSelectionChanged.connect(self.list_item_changed)
         self.listWorkspacesHisto.itemSelectionChanged.connect(self.list_item_changed)
@@ -39,6 +39,14 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
+
+    def tab_changed_method(self, tab_index):
+        self.clear_selection()
+        self.tab_changed.emit(tab_index)
+
+    def clear_selection(self):
+        for ws_list in [self.listWorkspaces2D, self.listWorkspacesEvent, self.listWorkspacesHisto]:
+            ws_list.clearSelection()
 
     def current_list(self):
         return self.tab_to_list[self.tabWidget.currentIndex()]
@@ -94,9 +102,9 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
     def set_workspace_selected(self, index):
         current_list = self.current_list()
         for item_index in range(current_list.count()):
-            self.listWorkspaces2D.setItemSelected(current_list.item(item_index), False)
+            current_list.setItemSelected(current_list.item(item_index), False)
         for this_index in (index if hasattr(index, "__iter__") else [index]):
-            self.listWorkspaces2D.setItemSelected(current_list.item(this_index), True)
+            current_list.setItemSelected(current_list.item(this_index), True)
 
     def get_workspace_index(self, ws_name):
         current_list = self.current_list()


### PR DESCRIPTION
**Not to be merged until after #209**

- Add some workspace type specific controls to `main_window`
- Each cut is now saved as a workspace
- Some refactoring to `mslice.models.cut` to allow `MDHistoWorkspaces` to be loaded / plotted independently. Before, the cut parameters and parent workspace were cached and re-run every time the cut was plotted. Now, the data is saved and read from the `MDHistoWorkspace`.
- Changed name of cuts that are saved to a file to include integration limits -  before, they looked like `MAR21335_Ei60.00meV_QE_cut1` with an incrementing index on the end. Now they look like this: `MAR21335_Ei60_meV_QE_cut(-1.0,1.0) `
- Automatically change tabs after load/powder/plot cut operations

**To test:**
- Test all buttons that appear on each workspace tab function as expected
- save a cut to a file, then load it in a different session and plot (without a need for the parent workspace)

Fixes #51 
Fixes #220 
