### PR TITLE
Add sample temperature by text box

### DIFF
--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -156,6 +156,9 @@ class MatplotlibSlicePlotter(SlicePlotter):
         temp = self._slice_algorithm.sample_temperature(workspace, self._sample_temp_fields)
         self.slice_cache[workspace]['sample_temp'] = temp
 
+    def set_sample_temperature(self, workspace, temp):
+        self.slice_cache[workspace]['sample_temp'] = temp
+
     def compute_boltzmann_dist(self, workspace):
         if self.slice_cache[workspace]['sample_temp'] is None:
             raise ValueError('sample temperature not found')

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -125,11 +125,19 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
             painter.drawPixmap(0,0,pixmap_image)
             painter.end()
 
+    def error_box(self, message):
+        error_box = QtWidgets.QMessageBox(self)
+        error_box.setWindowTitle("Error")
+        error_box.setIcon(QtWidgets.QMessageBox.Warning)
+        error_box.setText(message)
+        error_box.show()
+
     def update_grid(self):
         if self._xgrid:
             self.canvas.figure.gca().grid(True, axis='x')
         if self._ygrid:
             self.canvas.figure.gca().grid(True, axis='y')
+
 
     def get_window_title(self):
         return six.text_type(self.windowTitle())

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -223,9 +223,11 @@ class SlicePlot(object):
             else:
                 try:
                     temp_value = float(temp_value)
+                    if temp_value < 0:
+                        raise ValueError
                 except ValueError:
-                    self.plot_figure.error_box("Invalid value entered for sample temperature. Enter a number or a \
-                                               sample log field.")
+                    self.plot_figure.error_box("Invalid value entered for sample temperature. Enter a value in Kelvin \
+                                               or a sample log field.")
                     self.intensity_selection(previous)
                     return False
                 else:
@@ -237,8 +239,8 @@ class SlicePlot(object):
         ws_name = ws_name[:ws_name.rfind("_")]
         ws = AnalysisDataService[ws_name]
         temp_field, confirm = QtWidgets.QInputDialog.getItem(self.plot_figure, 'Sample Temperature',
-                                                             'Sample Temperature not found. ' +
-                                                             'Select the sample temperature field or enter a value:',
+                                                             'Sample Temperature not found. Select the sample ' +
+                                                             'temperature field or enter a value in Kelvin:',
                                                              ws.run().keys())
         if not confirm:
             raise RuntimeError("sample_temperature_dialog cancelled")

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -217,8 +217,13 @@ class SlicePlot(object):
             except RuntimeError:  # if cancel is clicked, go back to previous selection
                 self.intensity_selection(previous)
                 return False
-            self._slice_plotter.add_sample_temperature_field(field)
-            self._slice_plotter.update_sample_temperature(self._ws_title)
+            try:
+                field = int(field)
+            except ValueError:
+                self._slice_plotter.add_sample_temperature_field(field)
+                self._slice_plotter.update_sample_temperature(self._ws_title)
+            else:
+                self._slice_plotter.set_sample_temperature(self._ws_title, field)
             slice_plotter_method(self._ws_title)
         return True
 
@@ -228,8 +233,8 @@ class SlicePlot(object):
         ws = AnalysisDataService[ws_name]
         temp_field, confirm = QtWidgets.QInputDialog.getItem(self.plot_figure, 'Sample Temperature',
                                                              'Sample Temperature not found. ' +
-                                                             'Select the sample temperature field:',
-                                                             ws.run().keys(), False)
+                                                             'Select the sample temperature field or enter a value:',
+                                                             ws.run().keys())
         if not confirm:
             raise RuntimeError("sample_temperature_dialog cancelled")
         else:


### PR DESCRIPTION
A sample temperature can now be entered by value rather than using a sample log entry. 

**To test:**
- Plot a slice
- Change Intensity option
- Enter a number instead of choosing from the list

Fixes #212