### PR TITLE
Maintain overplot lines between figures

### DIFF
--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -26,7 +26,8 @@ class MatplotlibSlicePlotter(SlicePlotter):
                                                                     smoothing, norm_to_one)
         norm = Normalize(vmin=intensity_start, vmax=intensity_end)
         self._cache_slice(plot_data, selected_ws, boundaries, colourmap, norm, sample_temp, x_axis, y_axis)
-        self.overplot_lines[selected_ws] = {}
+        if selected_ws not in self.overplot_lines:
+            self.overplot_lines[selected_ws] = {}
         self.show_scattering_function(selected_ws)
         plt.gcf().canvas.set_window_title(selected_ws)
         plt.gcf().canvas.manager.add_slice_plot(self)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -62,6 +62,7 @@ class SlicePlot(object):
         plot_figure.actionTantalum.triggered.connect(
             partial(self.toggle_overplot_line, plot_figure.actionTantalum, 'Tantalum', False))
         plot_figure.actionCIF_file.triggered.connect(partial(self.cif_file_powder_line))
+        self._update_lines()
 
     def plot_options(self):
         new_config = SlicePlotOptionsPresenter(SlicePlotOptions(), self).get_new_config()
@@ -248,7 +249,8 @@ class SlicePlot(object):
                  self.plot_figure.actionCIF_file:[self._cif_file, False, self._cif_path]}
         for line in lines:
             if line.isChecked():
-                self._slice_plotter.overplot_lines[self._ws_title].pop(lines[line][0])
+                if  lines[line][0] in self._slice_plotter.overplot_lines[self._ws_title]:
+                    self._slice_plotter.overplot_lines[self._ws_title].pop(lines[line][0])
                 self._slice_plotter.add_overplot_line(self._ws_title, *lines[line])
                 self.update_legend()
 

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -57,3 +57,11 @@ class SlicePlotTest(unittest.TestCase):
         self.slice_plot.reset_info_checkboxes()
         self.slice_plot.action0.setChecked.assert_called_once_with(False)
         self.slice_plot.action1.setChecked.assert_not_called()
+
+    def test_lines_redrawn(self):
+        self.slice_plot._ws_title = 'some_title'
+        self.slice_plot.toggle_overplot_line(self.slice_plot.plot_figure.actionHelium, 4, True, True)
+        new_slice_plot = SlicePlot(self.plot_figure, self.canvas, self.slice_plotter)
+
+        self.assertTrue(new_slice_plot.plot_figure.actionHelium.checked)
+        self.slice_plotter.add_overplot_line.assert_called_with(self.plot_figure.title, 4, True, '')

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -64,4 +64,4 @@ class SlicePlotTest(unittest.TestCase):
         new_slice_plot = SlicePlot(self.plot_figure, self.canvas, self.slice_plotter)
 
         self.assertTrue(new_slice_plot.plot_figure.actionHelium.checked)
-        self.slice_plotter.add_overplot_line.assert_called_with(self.plot_figure.title, 4, True, '')
+        self.slice_plotter.add_overplot_line.assert_any_call(self.plot_figure.title, 4, True, '')


### PR DESCRIPTION
Before, closing or re-plotting the figure in any way would remove the overplot lines, but they would still appear as ticked in the menu. Now the lines are shown again when the figure is opened.

**To test:**
- Plot a slice and some overplot lines
- Close and reopen it / change the colourmap / plot a different slice / etc.
- Check lines are still there.

Fixes #215 
