### PR TITLE
Add icons to plot window

### DIFF
--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -7,6 +7,7 @@ import six
 from mslice.util.qt import QT_VERSION
 from mslice.util.qt.QtCore import Qt
 from mslice.util.qt import QtWidgets
+import qtawesome as qta
 
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.cut_plot import CutPlot
@@ -55,9 +56,10 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         self.actionKeep.triggered.connect(self._report_as_kept_to_manager)
         self.actionMakeCurrent.triggered.connect(self._report_as_current_to_manager)
 
-        self.actionDataCursor.toggled.connect(self.toggle_data_cursor)
         self.stock_toolbar = NavigationToolbar2QT(self.canvas, self)
+        self.stock_toolbar.message.connect(self.statusbar.showMessage)
         self.stock_toolbar.hide()
+        self.set_icons()
 
         self.actionZoom_In.triggered.connect(self.stock_toolbar.zoom)
         self.actionZoom_Out.triggered.connect(self.stock_toolbar.back)
@@ -92,15 +94,6 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         if event.mouseevent.dblclick or event.mouseevent.button == 3:
             self._plot_handler.object_clicked(event.artist)
 
-    def toggle_data_cursor(self):
-        if self.actionDataCursor.isChecked():
-            self.stock_toolbar.message.connect(self.statusbar.showMessage)
-            self.canvas.setCursor(Qt.CrossCursor)
-
-        else:
-            self.stock_toolbar.message.disconnect()
-            self.canvas.setCursor(Qt.ArrowCursor)
-
     def _display_status(self, status):
         if status == "kept":
             self.actionKeep.setChecked(True)
@@ -124,6 +117,13 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
             painter = QtWidgets.QPainter(printer)
             painter.drawPixmap(0,0,pixmap_image)
             painter.end()
+
+    def set_icons(self):
+        self.action_save_image.setIcon(qta.icon('fa.save'))
+        self.action_Print_Plot.setIcon(qta.icon('fa.print'))
+        self.actionZoom_In.setIcon(qta.icon('fa.search-plus'))
+        self.actionZoom_Out.setIcon(qta.icon('fa.search-minus'))
+        self.actionPlotOptions.setIcon(qta.icon('fa.cog'))
 
     def update_grid(self):
         if self._xgrid:

--- a/mslice/plotting/plot_window/plot_window.ui
+++ b/mslice/plotting/plot_window/plot_window.ui
@@ -79,14 +79,14 @@
    </attribute>
    <addaction name="actionZoom_In"/>
    <addaction name="actionZoom_Out"/>
+   <addaction name="actionToggleLegends"/>
    <addaction name="separator"/>
-   <addaction name="actionMakeCurrent"/>
    <addaction name="actionKeep"/>
+   <addaction name="actionMakeCurrent"/>
    <addaction name="separator"/>
    <addaction name="action_save_image"/>
    <addaction name="action_Print_Plot"/>
    <addaction name="actionPlotOptions"/>
-   <addaction name="actionToggleLegends"/>
   </widget>
   <action name="action_save_image">
    <property name="text">

--- a/mslice/plotting/plot_window/plot_window.ui
+++ b/mslice/plotting/plot_window/plot_window.ui
@@ -77,14 +77,16 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="action_save_image"/>
-   <addaction name="action_Print_Plot"/>
    <addaction name="actionZoom_In"/>
    <addaction name="actionZoom_Out"/>
+   <addaction name="separator"/>
+   <addaction name="actionMakeCurrent"/>
+   <addaction name="actionKeep"/>
+   <addaction name="separator"/>
+   <addaction name="action_save_image"/>
+   <addaction name="action_Print_Plot"/>
    <addaction name="actionPlotOptions"/>
    <addaction name="actionToggleLegends"/>
-   <addaction name="actionKeep"/>
-   <addaction name="actionMakeCurrent"/>
   </widget>
   <action name="action_save_image">
    <property name="text">
@@ -145,8 +147,14 @@
    </property>
   </action>
   <action name="actionToggleLegends">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
    <property name="text">
-    <string>Toggle Legends</string>
+    <string>Legends</string>
    </property>
   </action>
   <action name="action_Print_Plot">

--- a/mslice/plotting/plot_window/plot_window.ui
+++ b/mslice/plotting/plot_window/plot_window.ui
@@ -81,7 +81,6 @@
    <addaction name="action_Print_Plot"/>
    <addaction name="actionZoom_In"/>
    <addaction name="actionZoom_Out"/>
-   <addaction name="actionDataCursor"/>
    <addaction name="actionPlotOptions"/>
    <addaction name="actionToggleLegends"/>
    <addaction name="actionKeep"/>
@@ -116,14 +115,6 @@
   <action name="actionZoom_Out">
    <property name="text">
     <string>Zoom Out</string>
-   </property>
-  </action>
-  <action name="actionDataCursor">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Data Cursor</string>
    </property>
   </action>
   <action name="actionKeep">


### PR DESCRIPTION
Replaces the text in the toolbar of the plot window with icons for the most obvious controls.

Fixes #232 
