### PR TITLE
Recoil lines for 2theta slices.

### DIFF
--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -12,8 +12,7 @@ from mslice.models.alg_workspace_ops import AlgWorkspaceOps
 from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 KB_MEV = constants.value('Boltzmann constant in eV/K') * 1000
-HBAR_MEV = constants.value('Planck constant over 2 pi in eV s') * 1000
-E_TO_K = np.sqrt(2*constants.neutron_mass)/HBAR_MEV
+E_TO_K = np.sqrt(2 * constants.neutron_mass * constants.elementary_charge / 1000) / constants.hbar
 E2L = 1.e23 * constants.h**2 / (2 * constants.m_n * constants.e)  # energy to wavelength conversion E = h^2/(2*m_n*l^2)
 crystal_structure = {'Copper': ['3.6149 3.6149 3.6149', 'F m -3 m', 'Cu 0 0 0 1.0 0.05'],
                      'Aluminium': ['4.0495 4.0495 4.0495', 'F m -3 m', 'Al 0 0 0 1.0 0.05'],
@@ -127,11 +126,22 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         sample_temp = float(''.join(c for c in k_string if c.isdigit()))
         return sample_temp
 
-    def compute_recoil_line(self, axis, relative_mass=1):
-        momentum_transfer = np.arange(axis.start, axis.end, axis.step)
-        line = np.square(momentum_transfer * 1.e10 * constants.hbar) / (2 * relative_mass * constants.neutron_mass) /\
-            (constants.elementary_charge / 1000)
-        return momentum_transfer, line
+    def compute_recoil_line(self, ws_name, axis, relative_mass=1):
+        efixed = self._workspace_provider.get_EFixed(self._workspace_provider.get_parent_by_name(ws_name))
+        x_axis = np.arange(axis.start, axis.end, axis.step)
+        if axis.units == 'MomentumTransfer':
+            momentum_transfer = x_axis
+            line = np.square(momentum_transfer * 1.e10 * constants.hbar) / (2 * relative_mass * constants.neutron_mass) /\
+                (constants.elementary_charge / 1000)
+        elif axis.units == 'Degrees':
+            tth = x_axis * np.pi / 180.
+            if 'Direct' in self._workspace_provider.get_EMode(self._workspace_provider.get_parent_by_name(ws_name)):
+                line = efixed * (2 - 2 * np.cos(tth)) / (relative_mass + 1 - np.cos(tth))
+            else:
+                line = efixed * (2 - 2 * np.cos(tth)) / (relative_mass - 1 + np.cos(tth))
+        else:
+            raise RuntimeError("units of axis not recognised")
+        return x_axis, line
 
     def compute_powder_line(self, ws_name, axis, element, cif_file=False):
         efixed = self._workspace_provider.get_EFixed(self._workspace_provider.get_parent_by_name(ws_name))

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -133,7 +133,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
         else:
             momentum_axis = self.slice_cache[workspace]['momentum_axis']
             if recoil:
-                x, y = self._slice_algorithm.compute_recoil_line(momentum_axis, key)
+                x, y = self._slice_algorithm.compute_recoil_line(workspace, momentum_axis, key)
             else:
                 x, y = self._slice_algorithm.compute_powder_line(workspace, momentum_axis, key, cif_file=extra_info)
             color = overplot_colors[key] if key in overplot_colors else 'c'


### PR DESCRIPTION
Puts in the correct equation for the recoil lines for `2theta`-`DeltaE` slices. The derivation involves equating the expression for the energy transfer `E` vs the momentum transfer `Q` (`E = hbar^2 Q^2 / 2 m`) and the expression for the momentum transfer in terms of the scattering angle (obtained by squaring the vector expression for **Q** = **k_i** - **k_f** (`Q^2 = k_i^2 + k_f^2 - 2|k_i||k_f|cos(2theta)`). 

The derivation is here and relies on the Taylor expansion of the square root term (to second order):
![recoil_tth_derivation](https://user-images.githubusercontent.com/14106963/36439553-37c6f664-1665-11e8-90fc-bf8b40d115a3.png)

**To test:**

Run `mslice` and make a `2theta`-`energy` projection. Plot the projected workspace as a slice. Then overplot the recoil lines. Check that it goes up to ~50-60 degrees rather than cuts off below 10 degrees as previously.

Fixes #214.
