### PR TITLE
Handle `displayNormalization` for event data

### DIFF
--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -6,6 +6,9 @@ class CutAlgorithm(object):
     def compute_cut_xye(self, selected_workspace, cut_axis, integration_start, integration_end, is_norm):
         pass
 
+    def get_arrays_from_workspace(self, workspace):
+        pass
+
     def is_cuttable(self, workspace):
         pass
 


### PR DESCRIPTION
`mslice` by default plots all data using the `NumEventsNormalization` whatever the underlying data type. This is fine for histogrammed data which is converted to MD but is incorrect for event data because the normalisation has already been applied during reduction. For these data, `NoNormalization` should be used. This is why SNS event data (autoreduced nexus files, rather than autoreduced `nxspe` files which are histogrammed) is displayed incorrectly.

Edit: also removed ascii saving code in `cut_presenter.py` which is no longer used (there will be a separate PR to add saving to ascii as an option for the `Save` button in addition to the default `nxs`), and moved a function which calls a mantid algorithm from `cut_presenter.py` to `mantid_cut_algorithm.py`.

**To test:**

Load an SNS event `nxs` dataset (these are large files, so are not attached here. A test set can be found on \\Babylon5\Public\duc\mslice_test_data). Compute projection and plot the slice / make cuts and check that the data looks ok (e.g. similar to the equivalent `nxspe` file).

Fixes #216.
