### PR TITLE
Disable IPython console.

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -6,7 +6,6 @@ from mslice.util.qt.QtWidgets import QApplication, QMainWindow, QLabel
 from mslice.presenters.main_presenter import MainPresenter
 from mslice.util.qt import load_ui
 from mslice.views.mainview import MainView
-from mslice.widgets.ipythonconsole.ipython_widget import IPythonWidget
 from mslice.widgets.workspacemanager.command import Command as ws_command
 from mslice.widgets.cut.command import Command as cut_command
 
@@ -130,10 +129,6 @@ class MainWindow(MainView, QMainWindow):
         self.cut_presenter.notify(cut_command.PlotOverFromWorkspace)
 
     def init_ui(self):
-        ipython = IPythonWidget()
-        self.splitter.addWidget(ipython)
-        self.splitter.setSizes([500, 250])
-
         self.busy_text = QLabel()
         self.statusBar().addPermanentWidget(self.busy_text)
         self.busy_text.setText("  Idle  ")

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Mantid Mslice</string>
+   <string>Mantid MSlice</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">


### PR DESCRIPTION
Description of work.

Starting the new gui layout in MantidPlot leads to a malfunctioning IPython terminal. As it is not really useful until the CLI is ready it was decided that we should disable it.

**To test:**

Start the GUI and observe that the IPython terminal is not loaded.
