### PR TITLE
Fix norm to 1 blank slice bug

### DIFF
--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -47,7 +47,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         boundaries = [x_axis.start, x_axis.end, y_axis.start, y_axis.end]
         if norm_to_one:
             plot_data = self._norm_to_one(plot_data)
-        plot = [plot_data, None, None, None, None, None]
+        plot = [plot_data] + [None]*5
         return plot, boundaries
 
     def compute_boltzmann_dist(self, sample_temp, e_axis):
@@ -177,5 +177,5 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         return dvalues
 
     def _norm_to_one(self, data):
-        data_range = data.max() - data.min()
-        return (data - data.min())/data_range
+        data_range = np.nanmax(data) - np.nanmin(data)
+        return (data - np.nanmin(data))/data_range


### PR DESCRIPTION
Ticking the 'norm to 1' option in the slice widget would plot a blank slice. This is because the min/max methods used returned NaN values. They've been changed to methods which ignore the NaNs correctly.

**To test:**
- Plot a slice with 'norm to 1' ticked.

Fixes #213
