### PR TITLE
Fix duplicate recoil lines being displayed

### DIFF
--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -134,6 +134,8 @@ class MatplotlibSlicePlotter(SlicePlotter):
             line = self.overplot_lines[workspace][key]
             line.set_linestyle('-')  # make visible
             line.set_label(label)  # add to legend
+            if line not in plt.gca().get_children():
+                plt.gca().add_artist(line)
         else:
             momentum_axis = self.slice_cache[workspace]['momentum_axis']
             if recoil:

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -12,7 +12,7 @@ from .plot_options import CutPlotOptions
 
 class CutPlot(object):
 
-    def __init__(self, plot_figure, canvas, cut_plotter, new_figure):
+    def __init__(self, plot_figure, canvas, cut_plotter):
         self.plot_figure = plot_figure
         self._canvas = canvas
         self._cut_plotter = cut_plotter
@@ -21,14 +21,15 @@ class CutPlot(object):
         self._legends_visible = []
         self._legend_dict = {}
         self._lines = self.line_containers()
-        if new_figure:
-            self.setup_connections(plot_figure)
+        self.setup_connections(plot_figure)
 
     def setup_connections(self, plot_figure):
         plot_figure.menuIntensity.setDisabled(True)
         plot_figure.menuInformation.setDisabled(True)
         plot_figure.actionSave_Cut.triggered.connect(self.save_icut)
-        self.plot_figure.move_window(self.plot_figure.width() / 2, 0)
+
+    def disconnect(self, plot_figure):
+        plot_figure.actionSave_Cut.triggered.disconnect()
 
     def plot_options(self):
         new_config = CutPlotOptionsPresenter(CutPlotOptions(), self).get_new_config()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -12,7 +12,7 @@ from .plot_options import CutPlotOptions
 
 class CutPlot(object):
 
-    def __init__(self, plot_figure, canvas, cut_plotter):
+    def __init__(self, plot_figure, canvas, cut_plotter, new_figure):
         self.plot_figure = plot_figure
         self._canvas = canvas
         self._cut_plotter = cut_plotter
@@ -21,6 +21,10 @@ class CutPlot(object):
         self._legends_visible = []
         self._legend_dict = {}
         self._lines = self.line_containers()
+        if new_figure:
+            self.setup_connections(plot_figure)
+
+    def setup_connections(self, plot_figure):
         plot_figure.menuIntensity.setDisabled(True)
         plot_figure.menuInformation.setDisabled(True)
         plot_figure.actionSave_Cut.triggered.connect(self.save_icut)

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -77,10 +77,10 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         self.show()  # is not a good idea in non interactive mode
 
     def add_slice_plot(self, slice_plotter):
-        self._plot_handler = SlicePlot(self, self.canvas, slice_plotter)
+        self._plot_handler = SlicePlot(self, self.canvas, slice_plotter, self._plot_handler is None)
 
     def add_cut_plot(self, cut_plotter):
-        self._plot_handler = CutPlot(self, self.canvas, cut_plotter)
+        self._plot_handler = CutPlot(self, self.canvas, cut_plotter, self._plot_handler is None)
 
     def is_icut(self, is_icut):
         self._plot_handler.is_icut(is_icut)

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -77,10 +77,18 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         self.show()  # is not a good idea in non interactive mode
 
     def add_slice_plot(self, slice_plotter):
-        self._plot_handler = SlicePlot(self, self.canvas, slice_plotter, self._plot_handler is None)
+        if self._plot_handler is None:
+            self.move_window(-self.width() / 2, 0)
+        else:
+            self._plot_handler.disconnect(self)
+        self._plot_handler = SlicePlot(self, self.canvas, slice_plotter)
 
     def add_cut_plot(self, cut_plotter):
-        self._plot_handler = CutPlot(self, self.canvas, cut_plotter, self._plot_handler is None)
+        if self._plot_handler is None:
+            self.move_window(self.width() / 2, 0)
+        else:
+            self._plot_handler.disconnect(self)
+        self._plot_handler = CutPlot(self, self.canvas, cut_plotter)
 
     def is_icut(self, is_icut):
         self._plot_handler.is_icut(is_icut)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -6,6 +6,7 @@ from mslice.util.qt.QtCore import Qt
 
 import os.path as path
 import matplotlib.colors as colors
+from matplotlib.lines import Line2D
 
 from mantid.simpleapi import AnalysisDataService
 
@@ -175,12 +176,15 @@ class SlicePlot(object):
 
     def update_legend(self):
         lines = []
+        labels = []
         axes = self._canvas.figure.gca()
-        for line in axes.get_lines():
+        line_artists = [artist for artist in axes.get_children() if isinstance(artist, Line2D)]
+        for line in line_artists:
             if str(line.get_linestyle()) != 'None' and line.get_label() != '':
                 lines.append(line)
+                labels.append(line.get_label())
         if len(lines) > 0:
-            legend = axes.legend(fontsize='small')
+            legend = axes.legend(lines, labels, fontsize='small')
             for legline, line in zip(legend.get_lines(), lines):
                 legline.set_picker(5)
                 self._legend_dict[legline] = line
@@ -276,8 +280,8 @@ class SlicePlot(object):
         for line in lines:
             if line.isChecked():
                 self._slice_plotter.add_overplot_line(self._ws_title, *lines[line])
-                self.update_legend()
-                self._canvas.draw()
+        self.update_legend()
+        self._canvas.draw()
 
     def get_line_data(self, target):
         line_options = {}

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -139,7 +139,7 @@ class SlicePlot(object):
             if str(line.get_linestyle()) == 'None':
                 if isinstance(key, int):
                     key = self._slice_plotter.get_recoil_label(key)
-                action_checked = getattr(self, 'action' + key)
+                action_checked = getattr(self.plot_figure, 'action' + key)
                 action_checked.setChecked(False)
 
     def toggle_overplot_line(self, action, key, recoil, checked, cif_file=None):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -17,7 +17,7 @@ from .plot_options import SlicePlotOptions
 
 class SlicePlot(object):
 
-    def __init__(self, plot_figure, canvas, slice_plotter, new_figure):
+    def __init__(self, plot_figure, canvas, slice_plotter):
         self.plot_figure = plot_figure
         self._canvas = canvas
         self._slice_plotter = slice_plotter
@@ -29,13 +29,10 @@ class SlicePlot(object):
         self._legend_dict = {}
         self.icut_event = [None, None]
         self.icut = None
-        if new_figure:
-            self.setup_connections(plot_figure)
+        self.setup_connections(plot_figure)
         self._update_lines()
 
     def setup_connections(self, plot_figure):
-        self.plot_figure.move_window(-self.plot_figure.width() / 2, 0)
-
         plot_figure.actionInteractive_Cuts.setVisible(True)
         plot_figure.actionInteractive_Cuts.triggered.connect(self.interactive_cuts)
         plot_figure.actionSave_Cut.triggered.connect(self.save_icut)
@@ -278,10 +275,9 @@ class SlicePlot(object):
                  self.plot_figure.actionCIF_file:[self._cif_file, False, self._cif_path]}
         for line in lines:
             if line.isChecked():
-                if  lines[line][0] in self._slice_plotter.overplot_lines[self._ws_title]:
-                    self._slice_plotter.overplot_lines[self._ws_title].pop(lines[line][0])
                 self._slice_plotter.add_overplot_line(self._ws_title, *lines[line])
                 self.update_legend()
+                self._canvas.draw()
 
     def get_line_data(self, target):
         line_options = {}
@@ -329,6 +325,25 @@ class SlicePlot(object):
 
     def update_workspaces(self):
         self._slice_plotter.update_displayed_workspaces()
+
+    def disconnect(self, plot_figure):
+        plot_figure.actionInteractive_Cuts.triggered.disconnect()
+        plot_figure.actionSave_Cut.triggered.disconnect()
+        plot_figure.actionS_Q_E.triggered.disconnect()
+        plot_figure.actionChi_Q_E.triggered.disconnect()
+        plot_figure.actionChi_Q_E_magnetic.triggered.disconnect()
+        plot_figure.actionD2sigma_dOmega_dE.triggered.disconnect()
+        plot_figure.actionSymmetrised_S_Q_E.triggered.disconnect()
+        plot_figure.actionGDOS.triggered.disconnect()
+        plot_figure.actionHydrogen.triggered.disconnect()
+        plot_figure.actionDeuterium.triggered.disconnect()
+        plot_figure.actionHelium.triggered.disconnect()
+        plot_figure.actionArbitrary_nuclei.triggered.disconnect()
+        plot_figure.actionAluminium.triggered.disconnect()
+        plot_figure.actionCopper.triggered.disconnect()
+        plot_figure.actionNiobium.triggered.disconnect()
+        plot_figure.actionTantalum.triggered.disconnect()
+        plot_figure.actionCIF_file.triggered.disconnect()
 
     @property
     def colorbar_label(self):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -17,7 +17,7 @@ from .plot_options import SlicePlotOptions
 
 class SlicePlot(object):
 
-    def __init__(self, plot_figure, canvas, slice_plotter):
+    def __init__(self, plot_figure, canvas, slice_plotter, new_figure):
         self.plot_figure = plot_figure
         self._canvas = canvas
         self._slice_plotter = slice_plotter
@@ -29,6 +29,11 @@ class SlicePlot(object):
         self._legend_dict = {}
         self.icut_event = [None, None]
         self.icut = None
+        if new_figure:
+            self.setup_connections(plot_figure)
+        self._update_lines()
+
+    def setup_connections(self, plot_figure):
         self.plot_figure.move_window(-self.plot_figure.width() / 2, 0)
 
         plot_figure.actionInteractive_Cuts.setVisible(True)
@@ -71,7 +76,6 @@ class SlicePlot(object):
         plot_figure.actionTantalum.triggered.connect(
             partial(self.toggle_overplot_line, plot_figure.actionTantalum, 'Tantalum', False))
         plot_figure.actionCIF_file.triggered.connect(partial(self.cif_file_powder_line))
-        self._update_lines()
 
     def plot_options(self):
         new_config = SlicePlotOptionsPresenter(SlicePlotOptions(), self).get_new_config()

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -55,8 +55,8 @@ class SlicePlotTest(unittest.TestCase):
         action1 = PropertyMock()
         type(self.slice_plot).action1 = action1
         self.slice_plot.reset_info_checkboxes()
-        self.slice_plot.action0.setChecked.assert_called_once_with(False)
-        self.slice_plot.action1.setChecked.assert_not_called()
+        self.plot_figure.action0.setChecked.assert_called_once_with(False)
+        self.plot_figure.action1.setChecked.assert_not_called()
 
     def test_lines_redrawn(self):
         self.slice_plot._ws_title = 'some_title'


### PR DESCRIPTION
There was a problem where multiple recoil lines would sometimes be plotted after multiple slices have been displayed. This is because a single `PlotFigureManager` is used for all slices, but it creates a new `SlicePlot` object every time.
This PR addresses this issue whilst retaining the behaviour of the recoil lines to display being kept between plots.

**To test:**
- Display a slice
- Display a different slice and overplot recoil lines
- Check that the recoil lines currently displayed remains constant between both slices, and there are no duplicate lines/legend entries.

Fixes #243 
