### PR TITLE
Show and hide markers with overplot lines

### DIFF
--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -134,6 +134,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
             line = self.overplot_lines[workspace][key]
             line.set_linestyle('-')  # make visible
             line.set_label(label)  # add to legend
+            line.set_markersize(6) # show markers - 6.0 is default size
         else:
             momentum_axis = self.slice_cache[workspace]['momentum_axis']
             if recoil:
@@ -153,6 +154,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
             line = self.overplot_lines[workspace][key]
             line.set_linestyle('')
             line.set_label('')
+            line.set_markersize(0)
 
     def add_sample_temperature_field(self, field_name):
         self._sample_temp_fields.append(field_name)


### PR DESCRIPTION
Showing / hiding an overplot line on a slice using the `Information` menu now also correctly shows/hides the line markers.

**To Test:**
- Plot a recoil line over a slice
- Double-click the line and change the marker
- Check hiding and showing line again also shows/hides the markers.

Fixes #244
