### PR TITLE
Make Zoom in control toggle correctly

### DIFF
--- a/mslice/plotting/plot_window/plot_window.ui
+++ b/mslice/plotting/plot_window/plot_window.ui
@@ -112,6 +112,9 @@
    </property>
   </action>
   <action name="actionZoom_In">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>Zoom In</string>
    </property>

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -302,6 +302,7 @@ class SlicePlot(object):
             if self.plot_figure.actionZoom_In.isChecked():
                 self.plot_figure.actionZoom_In.setChecked(False)
                 self.plot_figure.actionZoom_In.triggered.emit(False)  # turn off zoom
+            self.plot_figure.actionZoom_In.setEnabled(False)
             self.plot_figure.picking_connected(False)
             self.plot_figure.actionKeep.trigger()
             self.plot_figure.actionKeep.setEnabled(False)
@@ -309,6 +310,7 @@ class SlicePlot(object):
             self.plot_figure.actionSave_Cut.setVisible(True)
             self._canvas.setCursor(Qt.CrossCursor)
         else:
+            self.plot_figure.actionZoom_In.setEnabled(True)
             self.plot_figure.picking_connected(True)
             self.plot_figure.actionKeep.setEnabled(True)
             self.plot_figure.actionMakeCurrent.setEnabled(True)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -299,6 +299,9 @@ class SlicePlot(object):
 
     def interactive_cuts(self):
         if not self.icut:
+            if self.plot_figure.actionZoom_In.isChecked():
+                self.plot_figure.actionZoom_In.setChecked(False)
+                self.plot_figure.actionZoom_In.triggered.emit(False)  # turn off zoom
             self.plot_figure.picking_connected(False)
             self.plot_figure.actionKeep.trigger()
             self.plot_figure.actionKeep.setEnabled(False)


### PR DESCRIPTION
The zoom in control now appears checkable to match its behaviour, and turns off automatically when 'Interactive cuts' is clicked. 

Fixes #248 
