### PR TITLE
Save slices as ASCII or matlab

### DIFF
--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -37,7 +37,8 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         y_dim = workspace.getDimension(y_dim_id)
         xbinning = x_dim.getName() + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
         ybinning = y_dim.getName() + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
-        thisslice = BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning)
+        thisslice = BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
+                          OutputWorkspace='__' + selected_workspace)
         # perform number of events normalization
         with np.errstate(invalid='ignore'):
             if thisslice.displayNormalization() == MDNormalization.NoNormalization:

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -24,7 +24,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
     def __init__(self):
         self._workspace_provider = MantidWorkspaceProvider()
 
-    def compute_slice(self, selected_workspace, x_axis, y_axis, smoothing, norm_to_one):
+    def compute_slice(self, selected_workspace, x_axis, y_axis, norm_to_one):
         workspace = self._workspace_provider.get_workspace_handle(selected_workspace)
         assert isinstance(workspace, IMDEventWorkspace)
         self._fill_in_missing_input(x_axis, workspace)
@@ -48,7 +48,6 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
                 plot_data = thisslice.getSignalArray() / thisslice.getNumEventsArray()
         # rot90 switches the x and y axis to to plot what user expected.
         plot_data = np.rot90(plot_data)
-        self._workspace_provider.delete_workspace(thisslice)
         boundaries = [x_axis.start, x_axis.end, y_axis.start, y_axis.end]
         if norm_to_one:
             plot_data = self._norm_to_one(plot_data)

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -26,7 +26,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
                    colourmap):
         sample_temp = self._slice_algorithm.sample_temperature(selected_ws, self._sample_temp_fields)
         plot_data, boundaries = self._slice_algorithm.compute_slice(selected_ws, x_axis, y_axis,
-                                                                    smoothing, norm_to_one)
+                                                                    norm_to_one)
         norm = Normalize(vmin=intensity_start, vmax=intensity_end)
         self._cache_slice(plot_data, selected_ws, boundaries, colourmap, norm, sample_temp, x_axis, y_axis)
         if selected_ws not in self.overplot_lines:

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -2,7 +2,7 @@
 
 class SliceAlgorithm(object):
 
-    def compute_slice(self, selected_workspace, x_axis, y_axis, smoothing, norm_to_one):
+    def compute_slice(self, selected_workspace, x_axis, y_axis, norm_to_one):
         """Return a numpy masked matrix ready for plotting """
         pass
 

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -32,7 +32,9 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
             ext_to_qtfilter = {'.nxs': 'Nexus (*.nxs)', '.txt': 'Ascii (*.txt)', '.mat': 'Matlab (*.mat)', }
             file_dialog.selectNameFilter(ext_to_qtfilter[default_ext])
         if (file_dialog.exec_()):
-            path = file_dialog.selectedFiles()[0] + file_dialog.selectedFilter()[-5:-1]
+            path = file_dialog.selectedFiles()[0]
+            if not path.rfind("."): # add extension unless there's one in the name
+                path += file_dialog.selectedFilter()[-5:-1]
             ext = path[path.rfind('.'):]
             return os.path.dirname(path), os.path.basename(path), ext
         else:

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -89,6 +89,11 @@ def _save_cut_to_ascii(workspace, ws_name, output_path):
 def _save_slice_to_ascii(workspace, output_path):
     header = 'MSlice Slice of workspace "%s"' % (workspace.name())
     x, y, e = _get_slice_mdhisto_xye(workspace)
+    dim_sz = [workspace.getDimension(i).getNBins() for i in range(workspace.getNumDims())]
+    nbins = np.prod(dim_sz)
+    x = [np.reshape(x0, nbins) for x0 in np.broadcast_arrays(*x)]
+    y = np.reshape(y, nbins)
+    e = np.reshape(e, nbins)
     out_data = np.column_stack(tuple(x+[y, e]))
     _output_data_to_ascii(output_path, out_data, header)
 
@@ -131,12 +136,7 @@ def _get_slice_mdhisto_xye(histo_ws):
         x.append(np.reshape(np.linspace(start, end, dim_sz[i]), tuple(nshape)))
     y = histo_ws.getSignalArray()
     e = np.sqrt(histo_ws.getErrorSquaredArray())
-    nbins = np.prod(dim_sz)
-    x = [np.reshape(x0, nbins) for x0 in np.broadcast_arrays(*x)]
-    y = np.reshape(y, nbins)
-    e = np.reshape(e, nbins)
     return x, y, e
-
 
 
 def _output_data_to_ascii(output_path, out_data, header):

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -258,7 +258,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
     def get_slice_MDHisto(self, workspace, ws_name):
         from mslice.models.slice.mantid_slice_algorithm import MantidSliceAlgorithm
         try:
-           return self.get_workspace_handle('__' + ws_name)
+            return self.get_workspace_handle('__' + ws_name)
         except KeyError:
             slice_alg = MantidSliceAlgorithm()
             x_axis = self.get_axis_from_dimension(workspace, ws_name, 0)

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -24,6 +24,64 @@ from mslice.presenters.slice_plotter_presenter import Axis
 # Classes and functions
 # -----------------------------------------------------------------------------
 
+def _output_data_to_ascii(output_path, out_data, header):
+    np.savetxt(str(output_path), out_data, fmt='%12.9e', header=header)
+
+
+def _get_mdhisto_xye(histo_ws):
+    dim = histo_ws.getDimension(0)
+    start = dim.getMinimum()
+    end = dim.getMaximum()
+    step = dim.getBinWidth()
+    x = np.arange(start, end, step)
+    y = histo_ws.getSignalArray()
+    e = np.sqrt(histo_ws.getErrorSquaredArray())
+    return x, y, e
+
+
+def _get_slice_mdhisto_xye(histo_ws):
+    dim_sz = [histo_ws.getDimension(i).getNBins() for i in range(histo_ws.getNumDims())]
+    nz_dim = [i for i, v in enumerate(dim_sz) if v > 1]
+    numdim = len(nz_dim)
+    x = []
+    for i in nz_dim:
+        dim = histo_ws.getDimension(i)
+        start = dim.getMinimum()
+        end = dim.getMaximum()
+        nshape = [1] * numdim
+        nshape[i] = dim_sz[i]
+        x.append(np.reshape(np.linspace(start, end, dim_sz[i]), tuple(nshape)))
+    y = histo_ws.getSignalArray()
+    e = np.sqrt(histo_ws.getErrorSquaredArray())
+    nbins = np.prod(dim_sz)
+    x = [np.reshape(x0, nbins) for x0 in np.broadcast_arrays(*x)]
+    y = np.reshape(y, nbins)
+    e = np.reshape(e, nbins)
+    return x, y, e
+
+
+def _save_cut_to_ascii(workspace, ws_name, output_path):
+    # get integration ranges from the name
+    int_ranges = ws_name[ws_name.find('('):]
+    int_start = int_ranges[1:int_ranges.find(',')]
+    int_end = int_ranges[int_ranges.find(',')+1:-1]
+    ws_name = ws_name[:ws_name.find('_cut')]
+
+    dim = workspace.getDimension(0)
+    units = dim.getUnits()
+
+    x, y, e = _get_mdhisto_xye(workspace)
+    header = 'MSlice Cut of workspace "%s" along "%s" between %s and %s' % (ws_name, units, int_start, int_end)
+    out_data = np.c_[x, y, e]
+    _output_data_to_ascii(output_path, out_data, header)
+
+
+def _save_slice_to_ascii(workspace, output_path):
+    header = 'MSlice Slice of workspace "%s"' % (workspace.name())
+    x, y, e = _get_slice_mdhisto_xye(workspace)
+    out_data = np.column_stack(tuple(x+[y, e]))
+    _output_data_to_ascii(output_path, out_data, header)
+
 
 class MantidWorkspaceProvider(WorkspaceProvider):
     def __init__(self):
@@ -209,39 +267,25 @@ class MantidWorkspaceProvider(WorkspaceProvider):
     def _save_ascii(self, workspace, path):
         workspace_handle = self.get_workspace_handle(workspace)
         if isinstance(workspace_handle, IMDEventWorkspace):
-            workspace_handle = self.get_slice_MDHisto(workspace_handle, workspace)
-        if isinstance(workspace_handle, IMDHistoWorkspace):
-            self._save_cut_to_ascii(workspace_handle, workspace, path)
+            workspace_handle = self._get_slice_mdhisto(workspace_handle, workspace)
+            _save_slice_to_ascii(workspace_handle, path)
+        elif isinstance(workspace_handle, IMDHistoWorkspace):
+            _save_cut_to_ascii(workspace_handle, workspace, path)
         else:
             SaveAscii(InputWorkspace=workspace, Filename=path)
-
-    def _save_cut_to_ascii(self, workspace, ws_name, output_path):
-        # get integration ranges from the name
-        int_ranges = ws_name[ws_name.find('('):]
-        int_start = int_ranges[1:int_ranges.find(',')]
-        int_end = int_ranges[int_ranges.find(',')+1:-1]
-        ws_name = ws_name[:ws_name.find('_cut')]
-
-        dim = workspace.getDimension(0)
-        units = dim.getUnits()
-
-        x, y, e = self.get_md_histo_xye(workspace)
-        header = 'MSlice Cut of workspace "%s" along "%s" between %s and %s' % (ws_name, units, int_start, int_end)
-        out_data = np.c_[x, y, e]
-        np.savetxt(str(output_path), out_data, fmt='%12.9e', header=header)
 
     def _save_matlab(self, workspace, path):
         workspace_handle = self.get_workspace_handle(workspace)
         if isinstance(workspace_handle, IMDEventWorkspace):
-            workspace_handle = self.get_slice_MDHisto(workspace_handle, workspace)
-        if isinstance(workspace_handle, IMDHistoWorkspace):
-            x, y, e = self.get_md_histo_xye(workspace_handle)
+            workspace_handle = self._get_slice_mdhisto(workspace_handle, workspace)
+            x, y, e  = _get_slice_mdhisto_xye(workspace_handle)
+        elif isinstance(workspace_handle, IMDHistoWorkspace):
+            x, y, e = _get_mdhisto_xye(workspace_handle)
         else:
             x = workspace_handle.extractX()
             y = workspace_handle.extractY()
             e = workspace_handle.extractE()
-        mdict = {'x': x, 'y': y, 'e': e}
-        savemat(path, mdict=mdict)
+        savemat(path, mdict={'x': x, 'y': y, 'e': e})
 
     def load_from_ascii(self, file_path, ws_name):
         file = open(file_path, 'r')
@@ -255,7 +299,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         CreateMDHistoWorkspace(SignalInput=y, ErrorInput=e, Dimensionality=1, Extents=extents, NumberOfBins=nbins,
                                Names='Dim1', Units=units, OutputWorkspace=ws_name)
 
-    def get_slice_MDHisto(self, workspace, ws_name):
+    def _get_slice_mdhisto(self, workspace, ws_name):
         from mslice.models.slice.mantid_slice_algorithm import MantidSliceAlgorithm
         try:
             return self.get_workspace_handle('__' + ws_name)
@@ -266,21 +310,10 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             slice_alg.compute_slice(ws_name, x_axis, y_axis, False)
             return self.get_workspace_handle('__' + ws_name)
 
-
     def get_axis_from_dimension(self, workspace, ws_name, id):
         dim = workspace.getDimension(id).getName()
         min, max, step = self._limits[ws_name][dim]
         return Axis(dim, min, max, step)
-
-    def get_md_histo_xye(self, histo_ws):
-        dim = histo_ws.getDimension(0)
-        start = dim.getMinimum()
-        end = dim.getMaximum()
-        step = dim.getBinWidth()
-        x = np.arange(start, end, step)
-        y = histo_ws.getSignalArray()
-        e = np.sqrt(histo_ws.getErrorSquaredArray())
-        return x, y, e
 
     def is_pixel_workspace(self, workspace_name):
         from mantid.api import IMDEventWorkspace

--- a/mslice/models/workspacemanager/workspace_provider.py
+++ b/mslice/models/workspacemanager/workspace_provider.py
@@ -37,7 +37,7 @@ class WorkspaceProvider(object):
         pass
 
     @abc.abstractmethod
-    def save_workspace(self, workspaces, path, save_name, extension):
+    def save_workspaces(self, workspaces, path, save_name, extension):
         pass
 
     def is_pixel_workspace(self, workspace_name):

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -145,7 +145,7 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         file_path, save_name, ext = get_save_directory(save_as_image=True)
         workspace = self._plot_handler.ws_name
         try:
-            self._plot_handler.workspace_provider().save_workspace([workspace], file_path, save_name, ext)
+            self._plot_handler.workspace_provider().save_workspaces([workspace], file_path, save_name, ext)
         except RuntimeError as e:
             if e.message == "unrecognised file extension":
                 self.save_image(os.path.join(file_path, save_name))

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -45,6 +45,7 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                 else:
                     self.check_efixed(ws_name, multi)
                     self._main_presenter.show_workspace_manager_tab()
+                    self._main_presenter.show_tab_for_workspace(self._workspace_provider.get_workspace_handle(ws_name))
         self._report_load_errors(ws_names, not_opened, not_loaded)
         self._main_presenter.update_displayed_workspaces()
         self._view.busy.emit(False)

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 from .interfaces.main_presenter import MainPresenterInterface
+from mantid.api import IMDHistoWorkspace, IMDEventWorkspace
 import collections
 
 
@@ -18,6 +19,14 @@ class MainPresenter(MainPresenterInterface):
 
     def show_workspace_manager_tab(self):
         self._mainView.change_main_tab(1)
+
+    def show_tab_for_workspace(self, ws):
+        tab = 0
+        if isinstance(ws, IMDHistoWorkspace):
+            tab = 2
+        elif isinstance(ws, IMDEventWorkspace):
+            tab = 1
+        self.change_ws_tab(tab)
 
     def set_selected_workspaces(self, workspace_list):
         self._workspace_presenter.set_selected_workspaces(workspace_list)

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -82,7 +82,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_invalid_save_path()
             return
         try:
-            self._workspace_provider.save_workspace(selected_workspaces, save_directory, save_name, extension)
+            self._workspace_provider.save_workspaces(selected_workspaces, save_directory, save_name, extension)
         except RuntimeError:
             self._workspace_manager_view.error_unable_to_save()
 

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -82,7 +82,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False,
                                               default_ext='.nxs')
-        self.workspace_provider.save_workspace.assert_called_once_with(
+        self.workspace_provider.save_workspaces.assert_called_once_with(
             [workspace_to_save], path_to_save_to, 'file1', '.nxs')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
@@ -97,7 +97,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.SaveSelectedWorkspaceAscii)
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False, default_ext='.txt')
         self.view.get_workspace_selected.assert_called_once_with()
-        self.workspace_provider.save_workspace.assert_called_once_with(
+        self.workspace_provider.save_workspaces.assert_called_once_with(
             [workspace_to_save], path_to_save_to, 'file1', '.txt')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
@@ -113,7 +113,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.SaveSelectedWorkspaceMatlab)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False, default_ext='.mat')
-        self.workspace_provider.save_workspace.assert_called_once_with(
+        self.workspace_provider.save_workspaces.assert_called_once_with(
             [workspace_to_save], path_to_save_to, 'file1', '.mat')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
@@ -123,12 +123,12 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         path_to_save_to = r'A:\file\path'
         self.view.get_workspace_selected = mock.Mock(return_value=['file1','file2'])
         save_dir_mock.return_value=(path_to_save_to, None, '.nxs')
-        self.workspace_provider.save_workspace = mock.Mock(side_effect=[True,RuntimeError])
+        self.workspace_provider.save_workspaces = mock.Mock(side_effect=[True, RuntimeError])
 
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=True, save_as_image=False, default_ext='.nxs')
-        self.workspace_provider.save_workspace.assert_called_with(['file1', 'file2'], path_to_save_to, None, '.nxs')
+        self.workspace_provider.save_workspaces.assert_called_with(['file1', 'file2'], path_to_save_to, None, '.nxs')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_workspace_non_selected_prompt_user(self, save_dir_mock):
@@ -140,7 +140,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.error_select_one_workspace.assert_called_once_with()
         save_dir_mock.assert_not_called()
-        self.workspace_provider.save_workspace.assert_not_called()
+        self.workspace_provider.save_workspaces.assert_not_called()
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_workspace_cancelled(self, save_dir_mock):
@@ -157,7 +157,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False, default_ext='.nxs')
         self.view.error_invalid_save_path.assert_called_once()
-        self.workspace_provider.save_workspace.assert_not_called()
+        self.workspace_provider.save_workspaces.assert_not_called()
 
     def test_remove_workspace(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)


### PR DESCRIPTION
**Shouldn't merge until after #253**

Output a slice to ASCII or matlab. Works by caching the `MDHistoWorkspace` outputted by `BinMD` in `SliceAlgorithm`'s `compute_slice` as a hidden workspace. If no hidden workspace is found, runs `compute_slice` with default parameters.

Fixes #255 
