### PR TITLE
Check for `nan` in `EFixed` when loading indirect `nxspe`

### DIFF
--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -262,7 +262,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         return emode
 
     def get_EFixed(self, ws_handle):
-        efix=None
+        efix = np.nan
         try:
             efix = self._get_ws_EFixed(ws_handle)
         except RuntimeError:  # Efixed not defined
@@ -278,7 +278,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
 
     def _get_ws_EFixed(self, ws_handle):
         try:
-            efixed = ws_handle.getEFixed(1)
+            efixed = ws_handle.getEFixed(ws_handle.getDetector(0).getID())
         except AttributeError: # workspace is not matrix workspace
             try:
                 efixed = self._get_exp_info_using(ws_handle, lambda e: ws_handle.getExperimentInfo(e).getEFixed(1))

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -274,7 +274,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             except AttributeError:
                 if ws_handle.getExperimentInfo(0).run().hasProperty('Ei'):
                     efix = ws_handle.getExperimentInfo(0).run().getProperty('Ei').value
-        return efix
+        return efix if not np.isnan(efix) else None
 
     def _get_ws_EFixed(self, ws_handle):
         try:


### PR DESCRIPTION
Adds a check for `nan` when loading an indirect `nxspe` file.

**To test:**

Load the attached file: [iris67606_graphite002_red.zip](https://github.com/mantidproject/mslice/files/1793298/iris67606_graphite002_red.zip)

Calculate projection and then check that the default values for Q are not nan.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #258.
