### PR TITLE
Highlight when tab has new workspaces

### DIFF
--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -82,7 +82,7 @@ class CutPresenter(PresenterUtility):
 
     def _plot_cut(self, params, plot_over):
         self._cut_plotter.plot_cut(*params, plot_over=plot_over)
-        self._main_presenter.change_ws_tab(2)
+        self._main_presenter.highlight_ws_tab(2)
 
     def _save_cut_to_workspace(self, params, _):
         cut_params = params[:5]

--- a/mslice/presenters/interfaces/main_presenter.py
+++ b/mslice/presenters/interfaces/main_presenter.py
@@ -32,3 +32,7 @@ class MainPresenterInterface(object):
     @abc.abstractmethod
     def change_ws_tab(self, tab):
         pass
+
+    @abc.abstractmethod
+    def highlight_ws_tab(self, tab):
+        pass

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -16,6 +16,9 @@ class MainPresenter(MainPresenterInterface):
     def change_ws_tab(self, tab):
         self._workspace_presenter.change_tab(tab)
 
+    def highlight_ws_tab(self, tab):
+        self._workspace_presenter.highlight_tab(tab)
+
     def show_workspace_manager_tab(self):
         self._mainView.change_main_tab(1)
 

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -52,6 +52,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
     def change_tab(self, tab):
         self._workspace_manager_view.change_tab(tab)
 
+    def highlight_tab(self, tab):
+        self._workspace_manager_view.highlight_tab(tab)
+
     def _confirm_workspace_overwrite(self, ws_name):
         if ws_name in self._workspace_provider.get_workspace_names():
             return self._workspace_manager_view.confirm_overwrite_workspace()

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -59,7 +59,9 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         self.tabWidget.setCurrentIndex(tab)
 
     def highlight_tab(self, tab):
-        self.tabWidget.setTabText(tab, self.tabWidget.tabText(tab) + '*')
+        tab_text = self.tabWidget.tabText(tab)
+        if not tab_text.endswith('*'):
+            self.tabWidget.setTabText(tab, tab_text + '*')
 
     def _btn_clicked(self):
         sender = self.sender()

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -44,6 +44,8 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def tab_changed_method(self, tab_index):
         self.clear_selection()
+        if self.tabWidget.tabText(tab_index)[-1:] == "*":
+            self.tabWidget.setTabText(tab_index, self.tabWidget.tabText(tab_index)[:-1])
         self.tab_changed.emit(tab_index)
 
     def clear_selection(self):
@@ -55,6 +57,9 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def change_tab(self, tab):
         self.tabWidget.setCurrentIndex(tab)
+
+    def highlight_tab(self, tab):
+        self.tabWidget.setTabText(tab, self.tabWidget.tabText(tab) + '*')
 
     def _btn_clicked(self):
         sender = self.sender()


### PR DESCRIPTION
Appends an asterisk to the `MD Histo` tab to show new workspaces instead of changing to it automatically.
(This was by far the easiest way to implement tab highlighting, changing font color/style is possible but requires more code.)

**To test:**
- Create a cut
- Instead of switching to `MD Histo` tab, it should appear as `MD Histo*`
- Upon clicking the `MD Histo` tab, asterisk disappears.

Fixes #256
