### PR TITLE
Swapping of min/max/step values when slice axes change

### DIFF
--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -99,7 +99,8 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
         try:
             self._slice_plotter.plot_slice(selected_workspace, x_axis, y_axis, smoothing, intensity_start,intensity_end,
                                            norm_to_one, colourmap)
-
+        except RuntimeError as e:
+            self._slice_view.error(e.args[0])
         except ValueError as e:
             # This gets thrown by matplotlib if the supplied intensity_min > data_max_value or vise versa
             # will break if matplotlib change exception eror message
@@ -151,9 +152,13 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
         axis = self._slice_plotter.get_available_axis(workspace_selection)
         self._slice_view.populate_slice_x_options(axis)
         self._slice_view.populate_slice_y_options(axis[::-1])
+        self.populate_slice_params()
+
+    def populate_slice_params(self):
+        workspace_selection = self._get_main_presenter().get_selected_workspaces()[0]
         try:
-            x_min, x_max, x_step = self._slice_plotter.get_axis_range(workspace_selection,self._slice_view.get_slice_x_axis())
-            y_min, y_max, y_step = self._slice_plotter.get_axis_range(workspace_selection,self._slice_view.get_slice_y_axis())
+            x_min, x_max, x_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_x_axis())
+            y_min, y_max, y_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_y_axis())
         except (KeyError, RuntimeError):
             self._slice_view.clear_input_fields()
             self._slice_view.disable()

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -38,6 +38,8 @@ class SliceWidget(SlicePlotterView, QWidget):
         self._minimumStep = {}
         self.lneSliceXStep.editingFinished.connect(lambda: self._step_edited('x', self.lneSliceXStep))
         self.lneSliceYStep.editingFinished.connect(lambda: self._step_edited('y', self.lneSliceYStep))
+        self.cmbSliceXAxis.currentIndexChanged.connect(lambda ind: self._change_axes(1, ind))
+        self.cmbSliceYAxis.currentIndexChanged.connect(lambda ind: self._change_axes(2, ind))
 
     def get_presenter(self):
         return self._presenter
@@ -61,6 +63,21 @@ class SliceWidget(SlicePlotterView, QWidget):
                 self._display_error('Step size too small!')
                 return False
         return True
+
+    def _change_axes(self, axis, idx):
+        """Makes sure u1 and u2 are always different, and updates default limits/steps values."""
+        num_items = self.cmbSliceXAxis.count()
+        if num_items < 2:
+            return
+        curr_axis = axis - 1
+        other_axis = axis % 2
+        axes = [self.cmbSliceXAxis.currentText(), self.cmbSliceYAxis.currentText()]
+        index = [self.cmbSliceXAxis.currentIndex(), self.cmbSliceYAxis.currentIndex()]
+        axes_set = [self.cmbSliceXAxis.setCurrentIndex, self.cmbSliceYAxis.setCurrentIndex]
+        if axes[curr_axis] == axes[other_axis]:
+            new_index = (index[other_axis] + 1) % num_items
+            axes_set[other_axis](new_index)
+        self._presenter.populate_slice_params()
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)


### PR DESCRIPTION
Makes sure the min / max / step values of the axes in a slice are updated when the user changes which axis should be x and y.

**To test:**

Load a workspace and create a projection. In the slices tab, change the axes and check that the values are updated correctly. 

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #242
