### PR TITLE
Non-PSD Mode

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -55,6 +55,7 @@ class MainWindow(MainView, QMainWindow):
         self.cut_presenter.set_workspace_provider(workspace_provider)
 
         self.wgtWorkspacemanager.tab_changed.connect(self.ws_tab_changed)
+        self.wgtWorkspacemanager.nonpsd.connect(self.switch_nonpsd_mode)
         self.btnSave.clicked.connect(self.button_save)
         self.btnAdd.clicked.connect(self.button_add)
         self.btnRename.clicked.connect(self.button_rename)
@@ -84,6 +85,10 @@ class MainWindow(MainView, QMainWindow):
     def ws_tab_changed(self, tab):
         self.enable_widget_tabs(tab)
         self.enable_buttons(tab)
+
+    def switch_nonpsd_mode(self, nonpsd):
+        self.wgtCut.enable_integration_axis(nonpsd)
+        self.wgtSlice.enable_units_choice(nonpsd)
 
     def enable_widget_tabs(self, workspace_tab):
         '''enables correct powder/slice/cut tabs based on workspace tab'''

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -12,6 +12,7 @@ from mslice.widgets.cut.command import Command as cut_command
 TAB_2D = 0
 TAB_EVENT = 1
 TAB_HISTO = 2
+TAB_NONPSD = 3
 TAB_SLICE = 1
 TAB_CUT = 2
 TAB_POWDER = 0
@@ -31,11 +32,13 @@ class MainWindow(MainView, QMainWindow):
         self.tabs = [self.wgtSlice, self.wgtCut, self.wgtPowder]
         self.tabs_to_show = {TAB_2D: [TAB_POWDER],
                              TAB_EVENT: [TAB_SLICE, TAB_CUT],
-                             TAB_HISTO: []}
+                             TAB_HISTO: [],
+                             TAB_NONPSD: [TAB_SLICE, TAB_CUT]}
 
         self.buttons_to_enable = {TAB_2D: [self.btnAdd, self.btnSubtract],
                                   TAB_EVENT: [self.btnMerge],
-                                  TAB_HISTO: [self.btnPlot, self.btnOverplot]}
+                                  TAB_HISTO: [self.btnPlot, self.btnOverplot],
+                                  TAB_NONPSD: [self.btnAdd, self.btnSubtract]}
 
         self.workspace_presenter = self.wgtWorkspacemanager.get_presenter()
         dataloader_presenter = self.data_loading.get_presenter()

--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -28,6 +28,8 @@ class AlgWorkspaceOps(object):
             axis.step = (axis.end - axis.start)/100
 
     def get_available_axis(self, workspace):
+        if not self._workspace_provider.is_PSD(workspace):
+            return ['|Q|', 'Degrees', 'DeltaE']
         dim_names = []
         if isinstance(workspace, string_types):
             workspace = self._workspace_provider.get_workspace_handle(workspace)

--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -11,6 +11,9 @@ class AlgWorkspaceOps(object):
     def set_workspace_provider(self, workspace_provider):
         self._workspace_provider = workspace_provider
 
+    def get_workspace_provider(self):
+        return self._workspace_provider
+
     def getComment(self, workspace):
         return self._workspace_provider.getComment(workspace)
 

--- a/mslice/models/cut/cut_plotter.py
+++ b/mslice/models/cut/cut_plotter.py
@@ -2,7 +2,7 @@ class CutPlotter(object):
     def __init__(self, _cut_algorithm):
         raise Exception('This class is an interface')
 
-    def plot_cut(self, selected_workspace, cut_axis, integration_start, integration_end, norm_to_one, intensity_start,
+    def plot_cut(self, selected_workspace, cut_axis, integration_axis, norm_to_one, intensity_start,
                  intensity_end, plot_over):
         raise NotImplementedError('This class is an abstract interface')
 

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -1,9 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 
-from mantid.simpleapi import BinMD
-from mantid.api import MDNormalization
-from mantid.api import IMDEventWorkspace, IMDHistoWorkspace
+from mantid.simpleapi import BinMD, SofQW3, Rebin2D, ConvertSpectrumAxis, Transpose, CreateMDHistoWorkspace
+from mantid.dataobjects import Workspace2D
+from mantid.api import MDNormalization, IMDEventWorkspace, IMDHistoWorkspace, WorkspaceUnitValidator
 
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
@@ -13,15 +13,16 @@ from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorks
 class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
     def __init__(self):
         self._workspace_provider = MantidWorkspaceProvider()
+        self._converted_nonpsd = None   # Cache for ConvertSpectrumAxis for non-PSD data.
 
-    def compute_cut_xye(self, selected_workspace, cut_axis, integration_start, integration_end, is_norm):
+    def compute_cut_xye(self, selected_workspace, cut_axis, integration_axis, is_norm):
         # TODO Note To reviewer
         # if the is_norm flag is True then _num_events_normalized_array will be called twice, is this OK?
         # Will it cause a significant slowdown on large data? would it be worth caching this?
         cut_computed = False
         copy_created = False
         copy_name = '_to_be_normalized_xyx_123_qme78hj'  # This is just a valid name
-        cut = self.compute_cut(selected_workspace, cut_axis, integration_start, integration_end, is_norm=False)
+        cut = self.compute_cut(selected_workspace, cut_axis, integration_axis, is_norm=False)
         cut_computed = True
         if is_norm:
             # If the cut previously existed in the ADS we will not modify it
@@ -48,22 +49,81 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
             self._workspace_provider.delete_workspace(copy_name)
         return x, plot_data, errors
 
-    def compute_cut(self, selected_workspace, cut_axis, integration_start, integration_end, is_norm):
+    def compute_cut(self, selected_workspace, cut_axis, integration_axis, is_norm):
         input_workspace_name = selected_workspace
         selected_workspace = self._workspace_provider.get_workspace_handle(selected_workspace)
+        integration_start = integration_axis.start
+        integration_end = integration_axis.end
+        integration_units = integration_axis.units
+
+        output_ws_name = input_workspace_name + "_cut(" + "{:.3f}".format(integration_start) + "," + "{:.3f}".format(
+            integration_end) + ")"
+
+        if self._workspace_provider.is_PSD(input_workspace_name):
+            cut = self._compute_cut_PSD(input_workspace_name, output_ws_name, selected_workspace, cut_axis,
+                                        integration_start, integration_end)
+        else:
+            cut = self._compute_cut_nonPSD(input_workspace_name, output_ws_name, selected_workspace, cut_axis,
+                                           integration_start, integration_end, integration_units)
+
+        if is_norm:
+            self._normalize_workspace(cut)
+        return cut
+
+    def _compute_cut_PSD(self, input_workspace_name, output_ws_name, selected_workspace, cut_axis,
+                         integration_start, integration_end):
         self._fill_in_missing_input(cut_axis, selected_workspace)
         n_steps = self._get_number_of_steps(cut_axis)
         integration_axis = self.get_other_axis(selected_workspace, cut_axis)
 
         cut_binning = " ,".join(map(str, (cut_axis.units, cut_axis.start, cut_axis.end, n_steps)))
         integration_binning = integration_axis + "," + str(integration_start) + "," + str(integration_end) + ",1"
-
-        output_ws_name = input_workspace_name + "_cut(" + "{:.3f}".format(integration_start) + "," + "{:.3f}".format(
-            integration_end) + ")"
         cut = BinMD(selected_workspace, OutputWorkspace=output_ws_name, AxisAligned="1",
                     AlignedDim1=integration_binning, AlignedDim0=cut_binning)
-        if is_norm:
-            self._normalize_workspace(cut)
+        return cut
+
+    def _compute_cut_nonPSD(self, input_workspace_name, output_ws_name, selected_workspace, cut_axis,
+                            integration_start, integration_end, integration_units):
+        cut_binning = " ,".join(map(str, (cut_axis.start, cut_axis.step, cut_axis.end)))
+        int_binning = " ,".join(map(str, (integration_start, integration_end - integration_start, integration_end)))
+        emode = self._workspace_provider.get_EMode(input_workspace_name)
+        if self._converted_nonpsd and self._converted_nonpsd[0] != input_workspace_name:
+            self._converted_nonpsd = None
+        if cut_axis.units == '|Q|':
+            SofQW3(selected_workspace, OutputWorkspace=output_ws_name, EMode=emode,
+                   QAxisBinning=cut_binning, EAxisBinning=int_binning)
+            idx = 1
+            unit = 'MomentumTransfer'
+            name = '|Q|'
+        elif cut_axis.units == 'Degrees':
+            if not self._converted_nonpsd:
+                self._converted_nonpsd = (input_workspace_name, 
+                                          ConvertSpectrumAxis(selected_workspace, Target='theta', 
+                                                              OutputWorkspace='__convToTheta', StoreInADS=False))
+            Rebin2D(self._converted_nonpsd[1], OutputWorkspace=output_ws_name, Axis1Binning=int_binning, Axis2Binning=cut_binning)
+            idx = 1
+            unit = 'Degrees'
+            name = 'Theta'
+        elif integration_units == '|Q|':
+            SofQW3(selected_workspace, OutputWorkspace=output_ws_name, EMode=emode,
+                   QAxisBinning=int_binning, EAxisBinning=cut_binning)
+            idx = 0
+            unit = 'DeltaE'
+            name = 'EnergyTransfer'
+        else:
+            if not self._converted_nonpsd:
+                self._converted_nonpsd = (input_workspace_name, 
+                                          ConvertSpectrumAxis(selected_workspace, Target='theta', 
+                                                              OutputWorkspace='__convToTheta', StoreInADS=False))
+            Rebin2D(self._converted_nonpsd[1], OutputWorkspace=output_ws_name, Axis1Binning=cut_binning, Axis2Binning=int_binning)
+            idx = 0
+            unit = 'DeltaE'
+            name = 'EnergyTransfer'
+        ws_out = self._workspace_provider.get_workspace_handle(output_ws_name)
+        xdim = ws_out.getDimension(idx)
+        extents = " ,".join(map(str, (xdim.getMinimum(), xdim.getMaximum())))
+        cut = CreateMDHistoWorkspace(OutputWorkspace=output_ws_name, SignalInput=ws_out.extractY(), ErrorInput=ws_out.extractE(),
+                                     Dimensionality=1, Extents=extents, NumberOfBins=xdim.getNBins(), Names=name, Units=unit)
         return cut
 
     def get_arrays_from_workspace(self, workspace):
@@ -90,7 +150,17 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
 
     def is_cuttable(self, workspace):
         workspace = self._workspace_provider.get_workspace_handle(workspace)
-        return isinstance(workspace, IMDEventWorkspace) and workspace.getNumDims() == 2
+        try:
+            is2D = workspace.getNumDims() == 2
+        except AttributeError:
+            is2D = False
+        if not is2D:
+            return False
+        if isinstance(workspace, IMDEventWorkspace):
+            return True
+        else:
+            validator = WorkspaceUnitValidator('DeltaE')
+            return isinstance(workspace, Workspace2D) and validator.isValid(workspace) == ''
 
     def set_saved_cut_parameters(self, workspace, axis, parameters):
         self._workspace_provider.setCutParameters(workspace, axis, parameters)

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -13,12 +13,13 @@ class MatplotlibCutPlotter(CutPlotter):
         self.background = None
         self.icut = None
 
-    def plot_cut(self, selected_workspace, cut_axis, integration_start, integration_end, norm_to_one, intensity_start,
+    def plot_cut(self, selected_workspace, cut_axis, integration_axis, norm_to_one, intensity_start,
                  intensity_end, plot_over):
-        x, y, e = self._cut_algorithm.compute_cut_xye(selected_workspace, cut_axis, integration_start, integration_end,
-                                                      norm_to_one)
-        integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis)
-        legend = self._generate_legend(selected_workspace, integrated_dim, integration_start, integration_end)
+        x, y, e = self._cut_algorithm.compute_cut_xye(selected_workspace, cut_axis, integration_axis, norm_to_one)
+        
+        integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis) \
+            if integration_axis.units == "" else  integration_axis.units
+        legend = self._generate_legend(selected_workspace, integrated_dim, integration_axis.start, integration_axis.end)
         self.plot_cut_from_xye(x, y, e, cut_axis.units, selected_workspace, plot_over, legend)
         plt.ylim(intensity_start, intensity_end)
 

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -96,6 +96,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
             retval = TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
             retval = RenameWorkspace(InputWorkspace=output_workspace, OutputWorkspace=output_workspace+'_cm')
             retval.setComment('MSlice_in_wavenumber')
+            output_workspace += '_cm'
         elif units != MEV_LABEL:
             raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))
         self._workspace_provider.propagate_properties(input_workspace, output_workspace)

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -82,6 +82,8 @@ class MantidProjectionCalculator(ProjectionCalculator):
 
     def calculate_projection(self, input_workspace, axis1, axis2, units):
         """Calculate the projection workspace AND return a python handle to it"""
+        if not self._workspace_provider.is_PSD(input_workspace):
+            raise RuntimeError('Cannot calculate projections for non-PSD workspaces')
         emode = self.get_emode(input_workspace)
         # Calculates the projection - can have Q-E or 2theta-E or their transpose.
         if (axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL) or (axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL):

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -3,7 +3,8 @@ from six import string_types
 import numpy as np
 
 from mantid.simpleapi import BinMD, LoadCIF, SofQW3, ConvertSpectrumAxis, Rebin2D
-from mantid.api import IMDEventWorkspace, MDNormalization
+from mantid.api import IMDEventWorkspace, MDNormalization, WorkspaceUnitValidator
+from mantid.dataobjects import Workspace2D
 from mantid.geometry import CrystalStructure, ReflectionGenerator, ReflectionConditionFilter
 from scipy import constants
 
@@ -224,3 +225,11 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
     def _norm_to_one(self, data):
         data_range = np.nanmax(data) - np.nanmin(data)
         return (data - np.nanmin(data))/data_range
+
+    def is_sliceable(self, workspace):
+        workspace = self._workspace_provider.get_workspace_handle(workspace)
+        if isinstance(workspace, IMDEventWorkspace):
+            return True
+        else:
+            validator = WorkspaceUnitValidator('DeltaE')
+            return isinstance(workspace, Workspace2D) and validator.isValid(workspace) == ''

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -74,7 +74,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         ebin = '%f, %f, %f' % (axes[e_axis].start, axes[e_axis].step, axes[e_axis].end)
         qbin = '%f, %f, %f' % (axes[q_axis].start, axes[q_axis].step, axes[q_axis].end)
         if axes[q_axis].units == '|Q|':
-            thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin, 
+            thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin,
                                EMode=self._workspace_provider.get_EMode(workspace))
         else:
             thisslice = ConvertSpectrumAxis(InputWorkspace=workspace, Target='Theta')
@@ -165,7 +165,8 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
     def compute_recoil_line(self, ws_name, axis, relative_mass=1):
         efixed = self._workspace_provider.get_EFixed(self._workspace_provider.get_workspace_handle(ws_name))
         x_axis = np.arange(axis.start, axis.end, axis.step)
-        if axis.units == 'MomentumTransfer':
+        print(axis)
+        if axis.units == 'MomentumTransfer' or axis.units == '|Q|':
             momentum_transfer = x_axis
             line = np.square(momentum_transfer * 1.e10 * constants.hbar) / (2 * relative_mass * constants.neutron_mass) /\
                 (constants.elementary_charge / 1000)
@@ -181,7 +182,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
 
     def compute_powder_line(self, ws_name, axis, element, cif_file=False):
         efixed = self._workspace_provider.get_EFixed(self._workspace_provider.get_workspace_handle(ws_name))
-        if axis.units == 'MomentumTransfer':
+        if axis.units == 'MomentumTransfer' or axis.units == '|Q|':
             x0 = self._compute_powder_line_momentum(ws_name, axis, element, cif_file)
         elif axis.units == 'Degrees':
             x0 = self._compute_powder_line_degrees(ws_name, axis, element, efixed, cif_file)

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -165,7 +165,6 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
     def compute_recoil_line(self, ws_name, axis, relative_mass=1):
         efixed = self._workspace_provider.get_EFixed(self._workspace_provider.get_workspace_handle(ws_name))
         x_axis = np.arange(axis.start, axis.end, axis.step)
-        print(axis)
         if axis.units == 'MomentumTransfer' or axis.units == '|Q|':
             momentum_transfer = x_axis
             line = np.square(momentum_transfer * 1.e10 * constants.hbar) / (2 * relative_mass * constants.neutron_mass) /\

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -28,9 +28,9 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
     def compute_slice(self, selected_workspace, x_axis, y_axis, norm_to_one):
         workspace = self._workspace_provider.get_workspace_handle(selected_workspace)
         if self._workspace_provider.is_PSD(selected_workspace):
-            plot_data = self._compute_slice_PSD(workspace, x_axis, y_axis, smoothing, norm_to_one)
+            plot_data = self._compute_slice_PSD(workspace, x_axis, y_axis, norm_to_one)
         else:
-            plot_data = self._compute_slice_nonPSD(workspace, x_axis, y_axis, smoothing, norm_to_one)
+            plot_data = self._compute_slice_nonPSD(workspace, x_axis, y_axis, norm_to_one)
         # rot90 switches the x and y axis to to plot what user expected.
         plot_data = np.rot90(plot_data)
         boundaries = [x_axis.start, x_axis.end, y_axis.start, y_axis.end]
@@ -39,7 +39,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         plot = [plot_data] + [None]*5
         return plot, boundaries
 
-    def _compute_slice_PSD(self, workspace, x_axis, y_axis, smoothing, norm_to_one):
+    def _compute_slice_PSD(self, workspace, x_axis, y_axis, norm_to_one):
         assert isinstance(workspace, IMDEventWorkspace)
         self._fill_in_missing_input(x_axis, workspace)
         self._fill_in_missing_input(y_axis, workspace)
@@ -52,7 +52,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         xbinning = x_dim.getName() + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
         ybinning = y_dim.getName() + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
         thisslice = BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
-                          OutputWorkspace='__' + selected_workspace)
+                          OutputWorkspace='__' + self._workspace_provider.get_workspace_name(workspace))
         # perform number of events normalization
         with np.errstate(invalid='ignore'):
             if thisslice.displayNormalization() == MDNormalization.NoNormalization:
@@ -60,10 +60,10 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
                 plot_data[np.where(thisslice.getNumEventsArray() == 0)] = np.nan
             else:
                 plot_data = thisslice.getSignalArray() / thisslice.getNumEventsArray()
-        self._workspace_provider.delete_workspace(thisslice)
         return plot_data
 
-    def _compute_slice_nonPSD(self, workspace, x_axis, y_axis, smoothing, norm_to_one):
+    def _compute_slice_nonPSD(self, workspace, x_axis, y_axis, norm_to_one):
+        ws_name = self._workspace_provider.get_workspace_name(workspace)
         axes = [x_axis, y_axis]
         if x_axis.units == 'DeltaE':
             e_axis = 0
@@ -76,12 +76,14 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         qbin = '%f, %f, %f' % (axes[q_axis].start, axes[q_axis].step, axes[q_axis].end)
         if axes[q_axis].units == '|Q|':
             thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin,
-                               EMode=self._workspace_provider.get_EMode(workspace))
+                               EMode=self._workspace_provider.get_EMode(workspace),
+                               OutputWorkspace='__' + ws_name)
         else:
             thisslice = ConvertSpectrumAxis(InputWorkspace=workspace, Target='Theta')
-            thisslice = Rebin2D(InputWorkspace=thisslice, Axis1Binning=ebin, Axis2Binning=qbin)
+            thisslice = Rebin2D(InputWorkspace=thisslice, Axis1Binning=ebin, Axis2Binning=qbin,
+                                OutputWorkspace='__' + ws_name)
         plot_data = thisslice.extractY()
-        self._workspace_provider.delete_workspace(thisslice)
+        self._workspace_provider.propagate_properties(ws_name, '__' + ws_name)
         if e_axis == 0:
             plot_data = np.transpose(plot_data)
         return plot_data

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -40,7 +40,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
     def _cache_slice(self, plot_data, ws, boundaries, colourmap, norm, sample_temp, x_axis, y_axis):
         self.slice_cache[ws] = {'plot_data': plot_data, 'boundaries': boundaries, 'colourmap': colourmap,
                                 'norm': norm, 'sample_temp': sample_temp, 'boltzmann_dist': None}
-        if x_axis.units == 'MomentumTransfer' or x_axis.units == 'Degrees':
+        if x_axis.units == 'MomentumTransfer' or x_axis.units == 'Degrees' or x_axis.units == '|Q|':
             self.slice_cache[ws]['momentum_axis'] = x_axis
             self.slice_cache[ws]['energy_axis'] = y_axis
             self.slice_cache[ws]['rotated'] = False

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -217,8 +217,14 @@ class MatplotlibSlicePlotter(SlicePlotter):
     def get_recoil_label(self, key):
         return recoil_labels[key]
 
+    def is_sliceable(self, workspace):
+        return self._slice_algorithm.is_sliceable(workspace)
+
     def update_displayed_workspaces(self):
         self.listener.update_workspaces()
 
     def set_workspace_provider(self, workspace_provider):
         self._slice_algorithm.set_workspace_provider(workspace_provider)
+
+    def get_workspace_provider(self):
+        return self._slice_algorithm.get_workspace_provider()

--- a/mslice/models/slice/slice_plotter.py
+++ b/mslice/models/slice/slice_plotter.py
@@ -33,3 +33,6 @@ class SlicePlotter():
 
     def update_sample_temperature(self, workspace):
         pass
+
+    def is_sliceable(self, workspace):
+        pass

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import os.path
-from mantid.api import IMDHistoWorkspace
+from mantid.api import IMDHistoWorkspace, MDNormalization
 from mantid.simpleapi import CreateMDHistoWorkspace, SaveMD, SaveNexus, SaveAscii
 from mslice.util.qt.QtWidgets import QFileDialog
 
@@ -32,8 +32,8 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
             ext_to_qtfilter = {'.nxs': 'Nexus (*.nxs)', '.txt': 'Ascii (*.txt)', '.mat': 'Matlab (*.mat)', }
             file_dialog.selectNameFilter(ext_to_qtfilter[default_ext])
         if (file_dialog.exec_()):
-            path = file_dialog.selectedFiles()[0]
-            if not path.rfind("."): # add extension unless there's one in the name
+            path = str(file_dialog.selectedFiles()[0])
+            if '.' not in path: # add extension unless there's one in the name
                 path += file_dialog.selectedFilter()[-5:-1]
             ext = path[path.rfind('.'):]
             return os.path.dirname(path), os.path.basename(path), ext
@@ -42,30 +42,38 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
 
 
 def save_nexus(workspace, path, is_slice):
-    if is_slice:
-        SaveMD(InputWorkspace=workspace.name()[2:], Filename=path)
-    elif isinstance(workspace, IMDHistoWorkspace):
-        SaveMD(InputWorkspace=workspace.name(), Filename=path)
+    if isinstance(workspace, IMDHistoWorkspace):
+        if is_slice:
+            SaveMD(InputWorkspace=workspace.name()[2:], Filename=path)
+        else:
+            SaveMD(InputWorkspace=workspace.name(), Filename=path)
     else:
         SaveNexus(InputWorkspace=workspace.name(), Filename=path)
 
 
 def save_ascii(workspace, path, is_slice):
-    if is_slice:
-        _save_slice_to_ascii(workspace, path)
-    elif isinstance(workspace, IMDHistoWorkspace):
-        _save_cut_to_ascii(workspace, workspace.name(), path)
+    if isinstance(workspace, IMDHistoWorkspace):
+        if is_slice:
+            _save_slice_to_ascii(workspace, path)
+        else:
+            _save_cut_to_ascii(workspace, workspace.name(), path)
     else:
         SaveAscii(InputWorkspace=workspace, Filename=path)
 
 
 def save_matlab(workspace, path, is_slice):
-    if is_slice:
-        x, y, e = _get_slice_mdhisto_xye(workspace)
-    elif isinstance(workspace, IMDHistoWorkspace):
-        x, y, e = _get_md_histo_xye(workspace)
+    if isinstance(workspace, IMDHistoWorkspace):
+        if is_slice:
+            x, y, e = _get_slice_mdhisto_xye(workspace)
+        else:
+            x, y, e = _get_md_histo_xye(workspace)
     else:
-        x = workspace.extractX()
+        if is_slice:
+            x = []
+            for dim in [workspace.getDimension(i) for i in range(2)]:
+                x.append(np.linspace(dim.getMinimum(), dim.getMaximum(), dim.getNBins()))
+        else:
+            x = workspace.extractX()
         y = workspace.extractY()
         e = workspace.extractE()
     mdict = {'x': x, 'y': y, 'e': e}
@@ -117,10 +125,14 @@ def _get_md_histo_xye(histo_ws):
     dim = histo_ws.getDimension(0)
     start = dim.getMinimum()
     end = dim.getMaximum()
-    step = dim.getBinWidth()
-    x = np.arange(start, end, step)
+    nbin = dim.getNBins()
+    x = np.linspace(start, end, nbin)
     y = histo_ws.getSignalArray()
     e = np.sqrt(histo_ws.getErrorSquaredArray())
+    if histo_ws.displayNormalization() == MDNormalization.NumEventsNormalization:
+        num_events = histo_ws.getNumEventsArray()
+        y = y / num_events
+        e = e / num_events
     return x, y, e
 
 
@@ -138,6 +150,10 @@ def _get_slice_mdhisto_xye(histo_ws):
         x.append(np.reshape(np.linspace(start, end, dim_sz[i]), tuple(nshape)))
     y = histo_ws.getSignalArray()
     e = np.sqrt(histo_ws.getErrorSquaredArray())
+    if histo_ws.displayNormalization() == MDNormalization.NumEventsNormalization:
+        num_events = histo_ws.getNumEventsArray()
+        y = y / num_events
+        e = e / num_events
     return x, y, e
 
 

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -236,7 +236,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         finally:
             self.delete_workspace(scaled_bg_ws)
 
-    def save_workspaces(self, workspaces, path, save_name, extension):
+    def save_workspaces(self, workspaces, path, save_name, extension, slice_nonpsd=False):
         '''
         :param workspaces: list of workspaces to save
         :param path: directory to save to
@@ -252,14 +252,14 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         else:
             raise RuntimeError("unrecognised file extension")
         for workspace in workspaces:
-            self._save_single_ws(workspace, save_name, save_method, path, extension)
+            self._save_single_ws(workspace, save_name, save_method, path, extension, slice_nonpsd)
 
-    def _save_single_ws(self, workspace, save_name, save_method, path, extension):
+    def _save_single_ws(self, workspace, save_name, save_method, path, extension, slice_nonpsd):
         slice = False
         save_as = save_name if save_name is not None else str(workspace) + extension
         full_path = os.path.join(str(path), save_as)
         workspace = self.get_workspace_handle(workspace)
-        if self.is_pixel_workspace(workspace):
+        if self.is_pixel_workspace(workspace) or (slice_nonpsd and not self.is_PSD(workspace)):
             slice = True
             workspace = self._get_slice_mdhisto(workspace, workspace.name())
         save_method(workspace, full_path, slice)

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -58,7 +58,8 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             return minimum, maximum, (maximum - minimum) / 100.
 
     def is_PSD(self, workspace):
-        return self._isPSD[workspace] if (workspace in self._isPSD) else None
+        ws_name = workspace if isinstance(workspace, string_types) else self.get_workspace_name(workspace)
+        return self._isPSD[ws_name] if (ws_name in self._isPSD) else None
 
     def _processEfixed(self, workspace):
         """Checks whether the fixed energy is defined for this workspace"""

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -29,8 +29,8 @@ class InteractiveCut(object):
     def plot_cut(self, x1, x2, y1, y2):
         if x2 > x1 and y2 > y1:
             ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
-            self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_start, integration_end,
-                                       False, None, None, False)
+            integration_axis = Axis('', integration_start, integration_end, 0)
+            self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False)
 
     def get_cut_parameters(self, pos1, pos2):
         start = pos1[not self.horizontal]
@@ -61,6 +61,9 @@ class InteractiveCut(object):
 
     def update_workspaces(self):
         self.slice_plot.update_workspaces()
+
+    def set_workspace_provider(self, workspace_provider):
+        self._cut_algorithm.set_workspace_provider(workspace_provider)
 
     def clear(self):
         self._cut_plotter.set_icut(False)

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -146,7 +146,7 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         file_path, save_name, ext = get_save_directory(save_as_image=True)
         workspace = self._plot_handler.ws_name
         try:
-            self._plot_handler.workspace_provider().save_workspaces([workspace], file_path, save_name, ext)
+            self._plot_handler.workspace_provider().save_workspaces([workspace], file_path, save_name, ext, slice_nonpsd=True)
         except RuntimeError as e:
             if e.message == "unrecognised file extension":
                 self.save_image(os.path.join(file_path, save_name))

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -328,6 +328,7 @@ class SlicePlot(object):
             self.icut = None
         else:
             self.icut = InteractiveCut(self, self._canvas, self._ws_title)
+            self.icut.set_workspace_provider(self._slice_plotter.get_workspace_provider())
 
     def save_icut(self):
         self.icut.save_cut()

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -72,7 +72,7 @@ class CutPresenter(PresenterUtility):
         cut_start, cut_end = integration_start, min(integration_start + width, integration_end)
         index = 0
         while cut_start != cut_end:
-            params = params[:2] + (Axis(params[2].unit, cut_start, cut_end, 0.)) + params[3:]
+            params = params[:2] + (Axis(params[2].units, cut_start, cut_end, 0.),) + params[3:]
             output_method(params, plot_over)
             index += 1
             cut_start, cut_end = cut_end, min(cut_end + width, integration_end)

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -41,6 +41,8 @@ class CutPresenter(PresenterUtility):
             self._cut(output_method=self._save_cut_to_workspace)
         elif command == Command.AxisChanged:
             self._cut_axis_changed()
+        elif command == Command.IntegrationAxisChanged:
+            self._integration_axis_changed()
         self._cut_view.busy.emit(False)
 
     def _cut(self, output_method, plot_over=False):
@@ -65,11 +67,12 @@ class CutPresenter(PresenterUtility):
 
     def _plot_with_width(self, params, output_method, width, plot_over):
         """This function handles the width parameter."""
-        integration_start, integration_end = params[2:4]
+        integration_start = params[2].start
+        integration_end = params[2].end
         cut_start, cut_end = integration_start, min(integration_start + width, integration_end)
         index = 0
         while cut_start != cut_end:
-            params = params[:2] + (cut_start, cut_end) + params[4:]
+            params = params[:2] + (Axis(params[2].unit, cut_start, cut_end, 0.)) + params[3:]
             output_method(params, plot_over)
             index += 1
             cut_start, cut_end = cut_end, min(cut_end + width, integration_end)
@@ -85,7 +88,7 @@ class CutPresenter(PresenterUtility):
         self._main_presenter.change_ws_tab(2)
 
     def _save_cut_to_workspace(self, params, _):
-        cut_params = params[:5]
+        cut_params = params[:4]
         self._cut_plotter.save_cut(cut_params)
         self._main_presenter.update_displayed_workspaces()
 
@@ -128,16 +131,16 @@ class CutPresenter(PresenterUtility):
             self._cut_view.error_invalid_cut_axis_parameters()
             raise ValueError("Invalid cut axis parameters")
 
-        integration_start = self._cut_view.get_integration_start()
-        integration_end = self._cut_view.get_integration_end()
+        integration_axis = Axis(self._cut_view.get_integration_axis(), self._cut_view.get_integration_start(),
+                                self._cut_view.get_integration_end(), 0.)
         try:
-            integration_start = float(integration_start)
-            integration_end = float(integration_end)
+            integration_axis.start = float(integration_axis.start)
+            integration_axis.end = float(integration_axis.end)
         except ValueError:
             self._cut_view.error_invalid_integration_parameters()
             raise ValueError("Invalid integration parameters")
 
-        if None not in (integration_start, integration_end) and integration_start >= integration_end:
+        if None not in (integration_axis.start, integration_axis.end) and integration_axis.start >= integration_axis.end:
             self._cut_view.error_invalid_integration_parameters()
             raise ValueError("Integration start >= Integration End")
 
@@ -160,8 +163,7 @@ class CutPresenter(PresenterUtility):
                 raise ValueError("Invalid width")
         else:
             width = None
-        return cut_axis, integration_start, integration_end, norm_to_one, intensity_start, \
-            intensity_end, width
+        return cut_axis, integration_axis, norm_to_one, intensity_start, intensity_end, width
 
     def _set_minimum_step(self, workspace, axis):
         """Gets axes limits from workspace_provider and then sets the minimumStep dictionary with those values"""
@@ -238,6 +240,11 @@ class CutPresenter(PresenterUtility):
                 self._cut_view.populate_input_fields(saved_parameters)
         min_step = self._minimumStep[self._cut_view.get_cut_axis()]
         self._cut_view.set_minimum_step(min_step)
+        self._cut_view.update_integration_axis()
+
+
+    def _integration_axis_changed(self):
+        pass
 
     def set_workspace_provider(self, workspace_provider):
         self._cut_algorithm.set_workspace_provider(workspace_provider)

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -242,9 +242,5 @@ class CutPresenter(PresenterUtility):
         self._cut_view.set_minimum_step(min_step)
         self._cut_view.update_integration_axis()
 
-
-    def _integration_axis_changed(self):
-        pass
-
     def set_workspace_provider(self, workspace_provider):
         self._cut_plotter.set_workspace_provider(workspace_provider)

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -141,7 +141,7 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
 
     def workspace_selection_changed(self):
         workspace_selection = self._get_main_presenter().get_selected_workspaces()
-        if len(workspace_selection) != 1:
+        if len(workspace_selection) != 1 or not self._slice_plotter.is_sliceable(workspace_selection[0]):
             self._slice_view.clear_input_fields()
             self._slice_view.disable()
             return

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -155,14 +155,15 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
         self.populate_slice_params()
 
     def populate_slice_params(self):
-        workspace_selection = self._get_main_presenter().get_selected_workspaces()[0]
         try:
+            workspace_selection = self._get_main_presenter().get_selected_workspaces()[0]
             x_min, x_max, x_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_x_axis())
             y_min, y_max, y_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_y_axis())
-        except (KeyError, RuntimeError):
+        except (KeyError, RuntimeError, IndexError):
             self._slice_view.clear_input_fields()
             self._slice_view.disable()
             return
+        self._slice_view.enable()
         self._slice_view.populate_slice_x_params(*["%.5f" % x for x in (x_min, x_max, x_step)])
         self._slice_view.populate_slice_y_params(*["%.5f" % x for x in (y_min, y_max, y_step)])
 

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -84,7 +84,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         for workspace in selected_workspaces:
             self._workspace_provider.delete_workspace(workspace)
-        self.update_displayed_workspaces()
+            self.update_displayed_workspaces()
 
     def _rename_workspace(self):
         selected_workspaces = self._workspace_manager_view.get_workspace_selected()

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -111,6 +111,7 @@ class CutPresenterTest(unittest.TestCase):
         self.view.get_cut_axis_start = mock.Mock(return_value=axis.start)
         self.view.get_cut_axis_end = mock.Mock(return_value=axis.end)
         self.view.get_cut_axis.step = mock.Mock(return_value=axis.step)
+        self.view.get_integration_axis = mock.Mock(return_value=integrated_axis)
         self.view.get_integration_start = mock.Mock(return_value=integration_start)
         self.view.get_integration_end = mock.Mock(return_value=integration_end)
         self.view.get_intensity_start = mock.Mock(return_value=intensity_start)
@@ -218,12 +219,13 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
+        integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
 
         cut_presenter.notify(Command.Plot)
         self.cut_plotter.plot_cut.assert_called_with(selected_workspace=workspace, cut_axis=processed_axis,
-                                                     integration_start=integration_start, integration_end=integration_end,
+                                                     integration_axis=integration_axis,
                                                      norm_to_one=is_norm, intensity_start=intensity_start,
                                                      intensity_end=intensity_end, plot_over=False)
 
@@ -240,11 +242,12 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
+        integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         cut_presenter.notify(Command.PlotOver)
         self.cut_plotter.plot_cut.assert_called_with(selected_workspace=workspace, cut_axis=processed_axis,
-                                                     integration_start=integration_start, integration_end=integration_end,
+                                                     integration_axis=integration_axis,
                                                      norm_to_one=is_norm, intensity_start=None,
                                                      intensity_end=intensity_end, plot_over=True)
 
@@ -261,12 +264,12 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
+        integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=('x', 'y', 'e'))
         cut_presenter.notify(Command.SaveToWorkspace)
-        self.cut_plotter.save_cut.assert_called_with((workspace, processed_axis, integration_start,
-                                                      integration_end, is_norm))
+        self.cut_plotter.save_cut.assert_called_with((workspace, processed_axis, integration_axis, is_norm))
         self.cut_plotter.plot_cut.assert_not_called()
 
     def test_plot_multiple_cuts_with_width(self):
@@ -282,19 +285,22 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
+        integration_axis1 = Axis('integrated axis', 3, 5, 0)
+        integration_axis2 = Axis('integrated axis', 5, 7, 0)
+        integration_axis3 = Axis('integrated axis', 7, 8, 0)
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
 
         cut_presenter.notify(Command.Plot)
         call_list = [
-            call(selected_workspace=workspace, cut_axis=processed_axis,integration_start=3,
-                 integration_end=5,norm_to_one=is_norm,intensity_start=intensity_start,
+            call(selected_workspace=workspace, cut_axis=processed_axis, integration_axis=integration_axis1,
+                 norm_to_one=is_norm, intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=False),
-            call(selected_workspace=workspace, cut_axis=processed_axis,integration_start=5,
-                 integration_end=7,norm_to_one=is_norm,intensity_start=intensity_start,
+            call(selected_workspace=workspace, cut_axis=processed_axis, integration_axis=integration_axis2,
+                 norm_to_one=is_norm, intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=True),
-            call(selected_workspace=workspace, cut_axis=processed_axis,integration_start=7,
-                 integration_end=8,norm_to_one=is_norm,intensity_start=intensity_start,
+            call(selected_workspace=workspace, cut_axis=processed_axis, integration_axis=integration_axis3,
+                 norm_to_one=is_norm, intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=True)
         ]
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
@@ -312,18 +318,17 @@ class CutPresenterTest(unittest.TestCase):
         is_norm = True
         selected_workspaces = ["ws1", "ws2"]
         integrated_axis = 'integrated axis'
+        integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, selected_workspaces, integrated_axis)
         self.cut_algorithm.get_saved_cut_parameters = mock.Mock(return_value=(None, None))
         cut_presenter.notify(Command.Plot)
         call_list = [
             call(selected_workspace=selected_workspaces[0], cut_axis=processed_axis,
-                 integration_start=integration_start, integration_end=integration_end,
-                 norm_to_one=is_norm, intensity_start=intensity_start,
+                 integration_axis=integration_axis, norm_to_one=is_norm, intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=False),
             call(selected_workspace=selected_workspaces[1], cut_axis=processed_axis,
-                 integration_start=integration_start, integration_end=integration_end,
-                 norm_to_one=is_norm, intensity_start=intensity_start,
+                 integration_axis=integration_axis, norm_to_one=is_norm, intensity_start=intensity_start,
                  intensity_end=intensity_end, plot_over=True),
         ]
         self.cut_plotter.plot_cut.assert_has_calls(call_list)

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -182,7 +182,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_selected.assert_called_once_with()
         delete_calls = [call(workspace1), call(workspace2), call(workspace3)]
         self.workspace_provider.delete_workspace.assert_has_calls(delete_calls, any_order= True)
-        self.view.display_loaded_workspaces.assert_called_once()
+        self.view.display_loaded_workspaces.assert_called()
 
     def test_remove_workspace_non_selected_prompt_user(self):
         self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)

--- a/mslice/views/cut_view.py
+++ b/mslice/views/cut_view.py
@@ -16,6 +16,9 @@ class CutView:
     def get_cut_axis_step(self):
         pass
 
+    def get_integration_axis(self):
+        pass
+
     def get_integration_start(self):
         pass
 
@@ -38,6 +41,9 @@ class CutView:
         pass
 
     def get_presenter(self):
+        pass
+
+    def update_integration_axis(self):
         pass
 
     def set_cut_axis(self, axis_name):

--- a/mslice/widgets/cut/command.py
+++ b/mslice/widgets/cut/command.py
@@ -16,5 +16,6 @@ class Command(object):
     SaveToWorkspace = -997
     SaveToAscii = -996
     AxisChanged = -995
+    IntegrationAxisChanged = -992
     PlotFromWorkspace = -994
     PlotOverFromWorkspace = -993

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -46,7 +46,8 @@ class CutWidget(CutView, QWidget):
     def _btn_clicked(self):
         sender = self.sender()
         command = self._command_lookup[sender]
-        self._presenter.notify(command)
+        if self._step_edited():
+            self._presenter.notify(command)
 
     def _step_edited(self):
         """Checks that user inputted step size is not too small."""
@@ -59,7 +60,7 @@ class CutWidget(CutView, QWidget):
             if value == 0:
                 self.lneCutStep.setText('%.5f' % (self._minimumStep))
                 self._display_error('Setting step size to default.')
-            elif value < (self._minimumStep / 10000.):
+            elif value < (self._minimumStep / 100.):
                 self._display_error('Step size too small!')
                 return False
         return True

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -41,6 +41,7 @@ class CutWidget(CutView, QWidget):
         self.cmbCutAxis.currentIndexChanged.connect(self.axis_changed)
         self._minimumStep = None
         self.lneCutStep.editingFinished.connect(self._step_edited)
+        self.enable_integration_axis(False)
 
     def _btn_clicked(self):
         sender = self.sender()
@@ -69,6 +70,14 @@ class CutWidget(CutView, QWidget):
     def axis_changed(self, _changed_index):
         self._presenter.notify(Command.AxisChanged)
 
+    def enable_integration_axis(self, enabled):
+        if enabled:
+            self.integrationStack.setCurrentIndex(1)
+            self.label_250.show()
+        else:
+            self.integrationStack.setCurrentIndex(0)
+            self.label_250.hide()
+
     def get_presenter(self):
         return self._presenter
 
@@ -83,6 +92,9 @@ class CutWidget(CutView, QWidget):
 
     def get_cut_axis_end(self):
         return str(self.lneCutEnd.text())
+
+    def get_integration_axis(self):
+        return str(self.cmbIntegrationAxis.currentText())
 
     def get_integration_start(self):
         return str(self.lneCutIntegrationStart.text())
@@ -112,6 +124,14 @@ class CutWidget(CutView, QWidget):
             self.cmbCutAxis.setCurrentIndex(index[0])
             self.cmbCutAxis.blockSignals(False)
 
+    def update_integration_axis(self):
+        # For non-PSD mode only. Assumes that if we have 3 options for the cut axis we are in non-PSD mode
+        # (e.g. will have to change code for single crystal).
+        if self.cmbCutAxis.count() == 3:
+            # Assumes the axes are in order: ['|Q|', 'Degrees', 'DeltaE']
+            axis_name = ['|Q|', 'Degrees'] if self.cmbCutAxis.currentIndex() == 2 else ['DeltaE']
+            self.populate_integration_axis_options(axis_name)
+
     def set_minimum_step(self, value):
         self._minimumStep = value
 
@@ -124,6 +144,14 @@ class CutWidget(CutView, QWidget):
         for option in options:
             self.cmbCutAxis.addItem(option)
         self.cmbCutAxis.blockSignals(False)
+        self.update_integration_axis()
+
+    def populate_integration_axis_options(self, options):
+        self.cmbIntegrationAxis.blockSignals(True)
+        self.cmbIntegrationAxis.clear()
+        for option in options:
+            self.cmbIntegrationAxis.addItem(option)
+        self.cmbIntegrationAxis.blockSignals(False)
 
     def populate_cut_params(self, cut_start=None, cut_end=None, cut_step=None):
         if cut_start is not None:

--- a/mslice/widgets/cut/cut.ui
+++ b/mslice/widgets/cut/cut.ui
@@ -60,13 +60,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Integrating</string>
-       </property>
-      </widget>
-     </item>
      <item row="1" column="2">
       <widget class="QLabel" name="label_258">
        <property name="text">
@@ -173,6 +166,23 @@
       <widget class="QCheckBox" name="rdoCutNormToOne">
        <property name="text">
         <string>Norm to 1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QStackedWidget" name="integrationStack">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Integrating</string>
+        </property>
+       </widget>
+       <widget class="QComboBox" name="cmbIntegrationAxis"/>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_250">
+       <property name="text">
+        <string>over</string>
        </property>
       </widget>
      </item>

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -67,11 +67,12 @@ class SliceWidget(SlicePlotterView, QWidget):
 
     def _change_axes(self, axis, idx):
         """Makes sure u1 and u2 are always different, and updates default limits/steps values."""
-        num_items = self.cmbSliceXAxis.count()
-        if num_items < 2:
-            return
         curr_axis = axis - 1
         other_axis = axis % 2
+        axes_handle = [self.cmbSliceXAxis, self.cmbSliceYAxis]
+        num_items = axes_handle[other_axis].count()
+        if num_items < 2:
+            return
         axes = [self.cmbSliceXAxis.currentText(), self.cmbSliceYAxis.currentText()]
         index = [self.cmbSliceXAxis.currentIndex(), self.cmbSliceYAxis.currentIndex()]
         axes_set = [self.cmbSliceXAxis.setCurrentIndex, self.cmbSliceYAxis.setCurrentIndex]
@@ -85,8 +86,10 @@ class SliceWidget(SlicePlotterView, QWidget):
 
     def enable_units_choice(self, enabled):
         if enabled:
-            self.cmbSliceUnits.show()
-            self.label_16.show()
+            # TODO implement conversion from meV to cm-1
+            pass
+            #self.cmbSliceUnits.show()
+            #self.label_16.show()
         else:
             self.cmbSliceUnits.hide()
             self.label_16.hide()

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -60,7 +60,7 @@ class SliceWidget(SlicePlotterView, QWidget):
             if value == 0:
                 lineEdit.setText(str(self._minimumStep[idx]))
                 self._display_error('Setting step size to default.')
-            elif value < (self._minimumStep[idx] / 10000.):
+            elif value < (self._minimumStep[idx] / 100.):
                 self._display_error('Step size too small!')
                 return False
         return True

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -38,6 +38,7 @@ class SliceWidget(SlicePlotterView, QWidget):
         self._minimumStep = {}
         self.lneSliceXStep.editingFinished.connect(lambda: self._step_edited('x', self.lneSliceXStep))
         self.lneSliceYStep.editingFinished.connect(lambda: self._step_edited('y', self.lneSliceYStep))
+        self.enable_units_choice(False)
 
     def get_presenter(self):
         return self._presenter
@@ -64,6 +65,17 @@ class SliceWidget(SlicePlotterView, QWidget):
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
+
+    def enable_units_choice(self, enabled):
+        if enabled:
+            self.cmbSliceUnits.show()
+            self.label_16.show()
+        else:
+            self.cmbSliceUnits.hide()
+            self.label_16.hide()
+
+    def get_units(self):
+        return self.cmbSliceUnits.currentText()
 
     def get_slice_x_axis(self):
         return str(self.cmbSliceXAxis.currentText())

--- a/mslice/widgets/slice/slice.ui
+++ b/mslice/widgets/slice/slice.ui
@@ -169,6 +169,27 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_16">
+       <property name="text">
+        <string>e</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="cmbSliceUnits">
+       <item>
+        <property name="text">
+         <string>meV</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>cm-1</string>
+        </property>
+       </item>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -16,6 +16,7 @@ from .subtract_input_box import SubtractInputBox
 TAB_2D = 0
 TAB_EVENT = 1
 TAB_HISTO = 2
+TAB_NONPSD = 3
 
 class WorkspaceManagerWidget(WorkspaceView, QWidget):
     """A Widget that allows user to perform basic workspace save/load/rename/delete operations on workspaces"""
@@ -175,6 +176,11 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         return self._presenter
 
     def list_item_changed(self):
+        if self.sender() == self.listWorkspaces2D:
+            if all([self._presenter.get_workspace_provider().is_PSD(ws) for ws in self.get_workspace_selected()]):
+                self.tab_changed.emit(TAB_2D)
+            else:
+                self.tab_changed.emit(TAB_NONPSD)
         self._presenter.notify(Command.SelectionChanged)
 
     def error_unable_to_save(self):

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -24,6 +24,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
     error_occurred = Signal('QString')
     tab_changed = Signal(int)
     busy = Signal(bool)
+    nonpsd = Signal(bool)
 
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
@@ -179,8 +180,10 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         if self.sender() == self.listWorkspaces2D:
             if all([self._presenter.get_workspace_provider().is_PSD(ws) for ws in self.get_workspace_selected()]):
                 self.tab_changed.emit(TAB_2D)
+                self.nonpsd.emit(False)
             else:
                 self.tab_changed.emit(TAB_NONPSD)
+                self.nonpsd.emit(True)
         self._presenter.notify(Command.SelectionChanged)
 
     def error_unable_to_save(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ detailed-errors=1
 with-coverage=1
 cover-package=mslice.presenters,mslice.plotting.figuremanager
 cover-min-percentage=85
+cover-html=1
 #debug=nose.loader
 
 [bdist_rpm]


### PR DESCRIPTION
This PR adds a different workflow for non-PSD type data (from MARI or from other instruments using a `rings_map`). These data are defined by having detector lists in order sorted by `2theta` angles. The main characteristics is that there are few detectors in these data, and that centre-point rebinning (using  `ConvertToMD`) is not suitable. Until now, the work-around has been to use `SofQW3` to rebin the data into fine `|Q|` bins and then to convert to MD. However, this two step binning process overestimates the uncertainty (errors), because the first step involves partitioning bins. It would thus be better if the workflow includes only a single rebin.

This PR does this. Non-PSD data now do not need to go through a `Calculate Projection` step (i.e. conversion to `MDEventWorkspace`). `SofQW3` is used directly to rebin the data into a 2D slice in `|Q|` and `DeltaE` *and* also 1D cuts in these dimensions. For slices in `Degrees` (or `theta`), `ConvertSpectrumAxis` and `Rebin2D` is used (similar to the old workflow where `ConvertSpectrumAxis`, `ConvertToMD` and `BinMD` was used). 

**To test:**

Load a non-PSD input data file (e.g. `MAR21335_Ei60.00meV.nxs` or `MER30936_Ei10.00meV_rings.nxs`). Select the loaded workspace and check that the `Powder` tab is *disabled* and `Slice` and `Cut` *enabled*. Make slices and cuts as normal - check all supported features (recoil lines, powder lines, change intensity, interactive cuts, simultaneous cuts of multiple workspaces, cuts with integration widths) work as expected. 

Load a PSD input data file (e.g. `MER30936_Ei10.00meV_one2one.nxs`). Select the loaded workspace and check that `Powder` is *enabled* and `Slice` and `Cut` is *disabled*. Calculate projections and make cuts / slices / etc. and check everything works as before.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #254 .
