### PR TITLE
Fix MDHistoWorkspace errors

### DIFF
--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -12,7 +12,7 @@ from six import string_types
 from mantid.simpleapi import (AnalysisDataService, DeleteWorkspace, Load, Scale,
                               RenameWorkspace, MergeMD, MergeRuns, Minus)
 
-from mantid.api import IMDEventWorkspace, Workspace
+from mantid.api import IMDEventWorkspace, MatrixWorkspace, Workspace
 from .file_io import save_ascii, save_matlab, save_nexus
 import numpy as np
 from scipy import constants
@@ -89,7 +89,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             return
         if isinstance(ws_h, IMDEventWorkspace):
             self.process_limits_event(ws_h, ws_name, efix)
-        else:
+        elif isinstance(ws_h, MatrixWorkspace):
             self.process_limits(ws_h, ws_name, efix)
 
     def process_limits(self, ws, ws_name, efix):

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -290,7 +290,10 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             except AttributeError:
                 if ws_handle.getExperimentInfo(0).run().hasProperty('Ei'):
                     efix = ws_handle.getExperimentInfo(0).run().getProperty('Ei').value
-        return efix if not np.isnan(efix) else None
+        if efix is not None and not np.isnan(efix):  # error if none is passed to isnan
+            return efix
+        else:
+            return None
 
     def _get_ws_EFixed(self, ws_handle):
         try:

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -63,7 +63,7 @@ class InteractiveCut(object):
         self.slice_plot.update_workspaces()
 
     def clear(self):
-        self._cut_plotter.set_icut(False)
+        self._cut_plotter.set_icut(None)
         self.rect.set_active(False)
         for event in self.connect_event:
             self._canvas.mpl_disconnect(event)


### PR DESCRIPTION
Fixes some MDHisto related bugs.

**To test:**

 1. 
- Load a cut.
- Check there are no errors and that it loaded correctly.

 2.
- Plot a slice and create an interactive cut.
- Click 'save cut'.
- Go to `MDHisto` tab.
- Should be able to select and plot the cut without errors.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #265 
