### PR TITLE
Select and update loaded workspaces

### DIFF
--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -45,9 +45,9 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                 else:
                     self.check_efixed(ws_name, multi)
                     self._main_presenter.show_workspace_manager_tab()
+                    self._main_presenter.update_displayed_workspaces()
                     self._main_presenter.show_tab_for_workspace(self._workspace_provider.get_workspace_handle(ws_name))
         self._report_load_errors(ws_names, not_opened, not_loaded)
-        self._main_presenter.update_displayed_workspaces()
         self._view.busy.emit(False)
 
     def check_efixed(self, ws_name, multi=False):

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -30,6 +30,7 @@ class MainPresenter(MainPresenterInterface):
         elif isinstance(ws, IMDEventWorkspace):
             tab = 1
         self.change_ws_tab(tab)
+        self._workspace_presenter.set_selected_workspaces([ws])
 
     def set_selected_workspaces(self, workspace_list):
         self._workspace_presenter.set_selected_workspaces(workspace_list)


### PR DESCRIPTION
Avoids a bug by automatically selecting a workspace when it's loaded.

**To test:**
- Save a slice as 'slice1'
- Delete slice workspace
- Calculate projections from a different workspace and name this slice 'slice1' as well.
- Load original slice1 and overwrite.
- Slice1 should be automatically selected.
- Plot slice1 and check it displays correctly.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #235  
