### PR TITLE
Fix ylim not setting correctly

### DIFF
--- a/mslice/models/cut/cut_plotter.py
+++ b/mslice/models/cut/cut_plotter.py
@@ -12,5 +12,5 @@ class CutPlotter(object):
     def set_icut(self, icut):
         raise NotImplementedError('This class is an abstract interface')
 
-    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, out_ws_name, plot_over):
+    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, intensity_range, plot_over, out_ws_name, legend):
         raise NotImplementedError('This class is an abstract interface')

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -22,9 +22,12 @@ class MatplotlibCutPlotter(CutPlotter):
         output_ws_name = output_workspace_name(selected_workspace, integration_start, integration_end)
         integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis)
         legend = self._generate_legend(selected_workspace, integrated_dim, integration_start, integration_end)
-        self.plot_cut_from_xye(x, y, e, cut_axis.units, selected_workspace, (intensity_start, intensity_end), plot_over, output_ws_name, legend)
+        self.plot_cut_from_xye(x, y, e, cut_axis.units, selected_workspace, (intensity_start, intensity_end),
+                               plot_over, output_ws_name, legend)
 
-    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, intensity_range=None, plot_over=False, cut_ws_name=None, legend=None):
+    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, intensity_range=None, plot_over=False,
+                          cut_ws_name=None, legend=None):
+        
         legend = selected_workspace if legend is None else legend
         plt.errorbar(x, y, yerr=e, label=legend, hold=plot_over, marker='o', picker=picker)
         plt.ylim(*intensity_range) if intensity_range is not None else plt.autoscale()

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -27,7 +27,6 @@ class MatplotlibCutPlotter(CutPlotter):
 
     def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, intensity_range=None, plot_over=False,
                           cut_ws_name=None, legend=None):
-        
         legend = selected_workspace if legend is None else legend
         plt.errorbar(x, y, yerr=e, label=legend, hold=plot_over, marker='o', picker=picker)
         plt.ylim(*intensity_range) if intensity_range is not None else plt.autoscale()

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -22,17 +22,16 @@ class MatplotlibCutPlotter(CutPlotter):
         output_ws_name = output_workspace_name(selected_workspace, integration_start, integration_end)
         integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis)
         legend = self._generate_legend(selected_workspace, integrated_dim, integration_start, integration_end)
-        self.plot_cut_from_xye(x, y, e, cut_axis.units, selected_workspace, plot_over, output_ws_name, legend)
-        plt.ylim(intensity_start, intensity_end)
+        self.plot_cut_from_xye(x, y, e, cut_axis.units, selected_workspace, (intensity_start, intensity_end), plot_over, output_ws_name, legend)
 
-    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, plot_over, cut_ws_name=None, legend=None):
+    def plot_cut_from_xye(self, x, y, e, x_units, selected_workspace, intensity_range=None, plot_over=False, cut_ws_name=None, legend=None):
         legend = selected_workspace if legend is None else legend
         plt.errorbar(x, y, yerr=e, label=legend, hold=plot_over, marker='o', picker=picker)
+        plt.ylim(*intensity_range) if intensity_range is not None else plt.autoscale()
         leg = plt.legend(fontsize='medium')
         leg.draggable()
         plt.xlabel(self._getDisplayName(x_units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
         plt.ylabel(INTENSITY_LABEL, picker=picker)
-        plt.autoscale()
         if not plot_over:
             plt.gcf().canvas.manager.update_grid()
         if self.background is None:

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -93,7 +93,7 @@ class CutPresenter(PresenterUtility):
         selected_workspaces = self._main_presenter.get_selected_workspaces()
         for workspace in selected_workspaces:
             x, y, e, units = self._cut_algorithm.get_arrays_from_workspace(workspace)
-            self._cut_plotter.plot_cut_from_xye(x, y, e, units, workspace, plot_over)
+            self._cut_plotter.plot_cut_from_xye(x, y, e, units, workspace, plot_over=plot_over)
             plot_over = True  # plot over if multiple workspaces selected
 
     def _parse_step(self):


### PR DESCRIPTION
There was a bug which prevented the intensity range from being set when plotting a cut. This is to do with the order of calls in the `cut_plotter`. `ylim` must be set before drawing but after the line is plotted.

**To test:**
- Plot a cut inputting some range for the intensity values
- Ensure y axis on plot matches input intensity values
- Close plot and click plot again
- Check the intensity values are still correct (sometimes only saw the bug on second attempt.)

Fixes #271 
