### PR TITLE
Dataloader usability fixes

### DIFF
--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -5,7 +5,7 @@ import os
 from functools import partial
 
 from mslice.util.qt.QtWidgets import QWidget, QFileSystemModel, QAbstractItemView, QMessageBox
-from mslice.util.qt.QtCore import Signal, QDir
+from mslice.util.qt.QtCore import Signal, QDir, Qt
 
 from mslice.presenters.data_loader_presenter import DataLoaderPresenter
 from mslice.util.qt import load_ui
@@ -48,6 +48,12 @@ class DataLoaderWidget(QWidget): # and some view interface
         self.btnhome.clicked.connect(self.go_to_home)
         self.btnload.clicked.connect(partial(self.load, False))
         self.btnmerge.clicked.connect(partial(self.load, True))
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Backspace:
+            self.back()
+        else:
+            event.accept()
 
     def doubleClicked(self, file_clicked):
         file_clicked = file_clicked.sibling(file_clicked.row(), 0) # so clicking anywhere on row gives filename

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -11,6 +11,7 @@ from mslice.presenters.data_loader_presenter import DataLoaderPresenter
 from mslice.util.qt import load_ui
 from .inputdialog import EfInputDialog
 
+MSLICE_EXTENSIONS = ['*.nxs', '*.nxspe', '*.txt', '*.xye']
 
 class DataLoaderWidget(QWidget): # and some view interface
 
@@ -25,6 +26,8 @@ class DataLoaderWidget(QWidget): # and some view interface
         self.directory = QDir(os.path.expanduser('~'))
         path = self.directory.absolutePath()
         self.file_system.setRootPath(path)
+        self.file_system.setNameFilters(MSLICE_EXTENSIONS)
+        self.file_system.setNameFilterDisables(False)
         self.table_view.setModel(self.file_system)
         self.table_view.setRootIndex(self.file_system.index(path))
         self.txtpath.setText(path)

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -39,8 +39,7 @@ class DataLoaderWidget(QWidget): # and some view interface
         self.btnload.setEnabled(False)
         self.btnmerge.setEnabled(False)
 
-        self.table_view.doubleClicked.connect(self.doubleClicked)
-        self.table_view.activated.connect(self.doubleClicked)
+        self.table_view.activated.connect(self.activated)
         self.table_view.clicked.connect(self.validate_selection)
         self.txtpath.editingFinished.connect(self.refresh)
         self.btnback.clicked.connect(self.back)
@@ -55,7 +54,7 @@ class DataLoaderWidget(QWidget): # and some view interface
         else:
             event.accept()
 
-    def doubleClicked(self, file_clicked):
+    def activated(self, file_clicked):
         file_clicked = file_clicked.sibling(file_clicked.row(), 0) # so clicking anywhere on row gives filename
         if self.file_system.isDir(file_clicked):
             self.enter_dir(self.file_system.fileName(file_clicked))

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -39,7 +39,8 @@ class DataLoaderWidget(QWidget): # and some view interface
         self.btnload.setEnabled(False)
         self.btnmerge.setEnabled(False)
 
-        self.table_view.doubleClicked.connect(self.enter_dir)
+        self.table_view.doubleClicked.connect(self.doubleClicked)
+        self.table_view.activated.connect(self.doubleClicked)
         self.table_view.clicked.connect(self.validate_selection)
         self.txtpath.editingFinished.connect(self.refresh)
         self.btnback.clicked.connect(self.back)
@@ -48,9 +49,15 @@ class DataLoaderWidget(QWidget): # and some view interface
         self.btnload.clicked.connect(partial(self.load, False))
         self.btnmerge.clicked.connect(partial(self.load, True))
 
-    def enter_dir(self, file_clicked):
+    def doubleClicked(self, file_clicked):
         file_clicked = file_clicked.sibling(file_clicked.row(), 0) # so clicking anywhere on row gives filename
-        self.directory.cd(self.file_system.fileName(file_clicked))
+        if self.file_system.isDir(file_clicked):
+            self.enter_dir(self.file_system.fileName(file_clicked))
+        else:
+            self.load(False)
+
+    def enter_dir(self, directory):
+        self.directory.cd(directory)
         self._update_from_path()
 
     def refresh(self):


### PR DESCRIPTION
Adds various small features to the `DataLoader` widget:

* Only files loadable by MSlice (`nxs`, `nxspe`, `txt`, `xye`) are shown.
* Double clicking a file now loads it. (Double clicking a folder opens it as before).
* Pressing `Enter` on a file loads it, on a folder opens it.
* Pressing `Backspace` moves up a folder.

**To test:**

Code review.

Run MSlice and check the above functionality works as expected.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #273.
