### PR TITLE
Interactive cuts fixes

### DIFF
--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -72,7 +72,7 @@ class MatplotlibCutPlotter(CutPlotter):
         return self.icut
 
     def save_cut(self, params):
-        self._cut_algorithm.compute_cut(*params)
+        return self._cut_algorithm.compute_cut(*params)
 
     def _getDisplayName(self, axisUnits, comment=None):
         if 'DeltaE' in axisUnits:

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -66,6 +66,7 @@ class MatplotlibCutPlotter(CutPlotter):
                 plt.gcf().canvas.manager.is_icut(icut)
         else:
             self.icut = None
+            plt.gcf().canvas.manager.is_icut(False)
 
     def get_icut(self):
         return self.icut

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -51,8 +51,10 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         y_dim = workspace.getDimension(y_dim_id)
         xbinning = x_dim.getName() + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
         ybinning = y_dim.getName() + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
+        ws_name = self._workspace_provider.get_workspace_name(workspace)
         thisslice = BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
-                          OutputWorkspace='__' + self._workspace_provider.get_workspace_name(workspace))
+                          OutputWorkspace='__' + ws_name)
+        self._workspace_provider.propagate_properties(ws_name, '__' + ws_name)
         # perform number of events normalization
         with np.errstate(invalid='ignore'):
             if thisslice.displayNormalization() == MDNormalization.NoNormalization:

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -259,7 +259,8 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         save_as = save_name if save_name is not None else str(workspace) + extension
         full_path = os.path.join(str(path), save_as)
         workspace = self.get_workspace_handle(workspace)
-        if self.is_pixel_workspace(workspace) or (slice_nonpsd and not self.is_PSD(workspace)):
+        non_psd_slice = slice_nonpsd and not self.is_PSD(workspace) and isinstance(workspace, MatrixWorkspace)
+        if self.is_pixel_workspace(workspace) or non_psd_slice:
             slice = True
             workspace = self._get_slice_mdhisto(workspace, workspace.name())
         save_method(workspace, full_path, slice)
@@ -270,6 +271,7 @@ class MantidWorkspaceProvider(WorkspaceProvider):
             return self.get_workspace_handle('__' + ws_name)
         except KeyError:
             slice_alg = MantidSliceAlgorithm()
+            slice_alg.set_workspace_provider(self)
             ws_name = workspace.name()
             x_axis = self.get_axis_from_dimension(workspace, ws_name, 0)
             y_axis = self.get_axis_from_dimension(workspace, ws_name, 1)

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -28,6 +28,8 @@ class CutPlot(object):
         plot_figure.menuIntensity.setDisabled(True)
         plot_figure.menuInformation.setDisabled(True)
         plot_figure.actionSave_Cut.triggered.connect(self.save_icut)
+        plot_figure.actionFlip_Axis.setVisible(False)
+        plot_figure.actionFlip_Axis.triggered.connect(self.flip_icut)
 
     def disconnect(self, plot_figure):
         plot_figure.actionSave_Cut.triggered.disconnect()
@@ -43,11 +45,16 @@ class CutPlot(object):
         self.plot_figure.actionToggleLegends.setVisible(not is_icut)
         self.plot_figure.actionKeep.setVisible(not is_icut)
         self.plot_figure.actionMakeCurrent.setVisible(not is_icut)
+        self.plot_figure.actionFlip_Axis.setVisible(is_icut)
         self.plot_figure.show()
 
     def save_icut(self):
         icut = self._cut_plotter.get_icut()
         icut.save_cut()
+
+    def flip_icut(self):
+        icut = self._cut_plotter.get_icut()
+        icut.flip_axis()
 
     def object_clicked(self, target):
         if isinstance(target, Legend):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -33,6 +33,7 @@ class CutPlot(object):
 
     def disconnect(self, plot_figure):
         plot_figure.actionSave_Cut.triggered.disconnect()
+        plot_figure.actionFlip_Axis.triggered.disconnect()
 
     def plot_options(self):
         new_config = CutPlotOptionsPresenter(CutPlotOptions(), self).get_new_config()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -51,7 +51,7 @@ class CutPlot(object):
 
     def save_icut(self):
         icut = self._cut_plotter.get_icut()
-        icut.save_cut()
+        return icut.save_cut()
 
     def flip_icut(self):
         icut = self._cut_plotter.get_icut()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -75,6 +75,7 @@ class InteractiveCut(object):
 
     def set_workspace_provider(self, workspace_provider):
         self._cut_algorithm.set_workspace_provider(workspace_provider)
+        self._cut_plotter.set_workspace_provider(workspace_provider)
 
     def clear(self):
         self._cut_plotter.set_icut(None)

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -29,7 +29,8 @@ class InteractiveCut(object):
     def plot_cut(self, x1, x2, y1, y2):
         if x2 > x1 and y2 > y1:
             ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
-            integration_axis = Axis('', integration_start, integration_end, 0)
+            other_axis = self._cut_algorithm.get_other_axis(str(self._ws_title), ax)
+            integration_axis = Axis(other_axis, integration_start, integration_end, 0)
             self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False)
 
     def get_cut_parameters(self, pos1, pos2):

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -36,8 +36,9 @@ class InteractiveCut(object):
     def plot_cut(self, x1, x2, y1, y2):
         if x2 > x1 and y2 > y1:
             ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
-            other_axis = self._cut_algorithm.get_other_axis(str(self._ws_title), ax)
-            integration_axis = Axis(other_axis, integration_start, integration_end, 0)
+            units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
+                self._canvas.figure.gca().get_xaxis().units
+            integration_axis = Axis(units, integration_start, integration_end, 0)
             self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False)
 
     def get_cut_parameters(self, pos1, pos2):

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -21,7 +21,7 @@ class InteractiveCut(object):
         self._canvas.draw()
 
     def plot_from_mouse_event(self, eclick, erelease):
-        self.horizontal = abs(erelease.x - eclick.x) > abs(erelease.y - erelease.y)
+        self.horizontal = abs(erelease.x - eclick.x) > abs(erelease.y - eclick.y)
         self.plot_cut(eclick.xdata, erelease.xdata, eclick.ydata, erelease.ydata)
         self._cut_plotter.set_icut(self)
         self.connect_event[2] = self._canvas.mpl_connect('button_press_event', self.clicked)

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -67,8 +67,9 @@ class InteractiveCut(object):
         units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
             self._canvas.figure.gca().get_xaxis().units
         integration_axis = Axis(units, integration_start, integration_end, 0)
-        self._cut_plotter.save_cut((str(self._ws_title), ax, integration_axis, False))
+        output_ws = self._cut_plotter.save_cut((str(self._ws_title), ax, integration_axis, False))
         self.update_workspaces()
+        return self.slice_plot.workspace_provider().get_workspace_name(output_ws)
 
     def update_workspaces(self):
         self.slice_plot.update_workspaces()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -64,7 +64,10 @@ class InteractiveCut(object):
     def save_cut(self):
         x1, x2, y1, y2 = self.rect.extents
         ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
-        self._cut_plotter.save_cut((str(self._ws_title), ax, integration_start, integration_end, False))
+        units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
+            self._canvas.figure.gca().get_xaxis().units
+        integration_axis = Axis(units, integration_start, integration_end, 0)
+        self._cut_plotter.save_cut((str(self._ws_title), ax, integration_axis, False))
         self.update_workspaces()
 
     def update_workspaces(self):

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -36,10 +36,9 @@ class InteractiveCut(object):
     def get_cut_parameters(self, pos1, pos2):
         start = pos1[not self.horizontal]
         end = pos2[not self.horizontal]
-        # hard code step for now. When sliceMD is fixed, can get minimum step with cut_algorithm.get_axis_range()
-        step = 0.02
         units = self._canvas.figure.gca().get_xaxis().units if self.horizontal else \
             self._canvas.figure.gca().get_yaxis().units
+        step = self.slice_plot.workspace_provider().get_limits(self._ws_title, units)[2]
         ax = Axis(units, start, end, step)
         integration_start = pos1[self.horizontal]
         integration_end = pos2[self.horizontal]

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -78,3 +78,7 @@ class InteractiveCut(object):
         for event in self.connect_event:
             self._canvas.mpl_disconnect(event)
         self._canvas.draw()
+
+    def flip_axis(self):
+        self.horizontal = not self.horizontal
+        self.plot_cut(*self.rect.extents)

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -154,6 +154,9 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
                 pass
             else:
                 raise RuntimeError(e)
+        except KeyError:   # Could be case of interactive cuts when the workspace has not been saved yet
+            workspace = self._plot_handler.save_icut()
+            self._plot_handler.workspace_provider().save_workspaces([workspace], file_path, save_name, ext)
 
     def save_image(self, path):
         self.canvas.figure.savefig(path)

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -164,6 +164,7 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         self.actionZoom_In.setIcon(qta.icon('fa.search-plus'))
         self.actionZoom_Out.setIcon(qta.icon('fa.search-minus'))
         self.actionPlotOptions.setIcon(qta.icon('fa.cog'))
+        self.actionFlip_Axis.setIcon(qta.icon('fa.retweet'))
 
     def error_box(self, message):
         error_box = QtWidgets.QMessageBox(self)

--- a/mslice/plotting/plot_window/plot_window.ui
+++ b/mslice/plotting/plot_window/plot_window.ui
@@ -89,6 +89,7 @@
    <addaction name="actionPlotOptions"/>
    <addaction name="actionInteractive_Cuts"/>
    <addaction name="actionSave_Cut"/>
+   <addaction name="actionFlip_Axis"/>
   </widget>
   <action name="action_save_image">
    <property name="text">
@@ -307,6 +308,11 @@
   <action name="actionSave_Cut">
    <property name="text">
     <string>Save Cut</string>
+   </property>
+  </action>
+  <action name="actionFlip_Axis">
+   <property name="text">
+    <string>Flip Integration Axis</string>
    </property>
   </action>
  </widget>

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -35,6 +35,8 @@ class SlicePlot(object):
         plot_figure.actionInteractive_Cuts.setVisible(True)
         plot_figure.actionInteractive_Cuts.triggered.connect(self.interactive_cuts)
         plot_figure.actionSave_Cut.triggered.connect(self.save_icut)
+        plot_figure.actionFlip_Axis.setVisible(False)
+        plot_figure.actionFlip_Axis.triggered.connect(self.flip_icut)
 
         plot_figure.actionS_Q_E.triggered.connect(partial(self.show_intensity_plot, plot_figure.actionS_Q_E,
                                                           self._slice_plotter.show_scattering_function, False))
@@ -313,6 +315,7 @@ class SlicePlot(object):
             self.plot_figure.actionKeep.setEnabled(False)
             self.plot_figure.actionMakeCurrent.setEnabled(False)
             self.plot_figure.actionSave_Cut.setVisible(True)
+            self.plot_figure.actionFlip_Axis.setVisible(True)
             self._canvas.setCursor(Qt.CrossCursor)
         else:
             self.plot_figure.actionZoom_In.setEnabled(True)
@@ -320,6 +323,7 @@ class SlicePlot(object):
             self.plot_figure.actionKeep.setEnabled(True)
             self.plot_figure.actionMakeCurrent.setEnabled(True)
             self.plot_figure.actionSave_Cut.setVisible(False)
+            self.plot_figure.actionFlip_Axis.setVisible(False)
             self._canvas.setCursor(Qt.ArrowCursor)
         self.toggle_icut()
 
@@ -333,6 +337,9 @@ class SlicePlot(object):
 
     def save_icut(self):
         self.icut.save_cut()
+
+    def flip_icut(self):
+        self.icut.flip_axis()
 
     def update_workspaces(self):
         self._slice_plotter.update_displayed_workspaces()

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -350,6 +350,7 @@ class SlicePlot(object):
     def disconnect(self, plot_figure):
         plot_figure.actionInteractive_Cuts.triggered.disconnect()
         plot_figure.actionSave_Cut.triggered.disconnect()
+        plot_figure.actionFlip_Axis.triggered.disconnect()
         plot_figure.actionS_Q_E.triggered.disconnect()
         plot_figure.actionChi_Q_E.triggered.disconnect()
         plot_figure.actionChi_Q_E_magnetic.triggered.disconnect()


### PR DESCRIPTION
Fixes a few small issues with interactive cuts:

* Cuts can now be made along the vertical as well as horizontal direction. This is determined by the shape of the initial rectangle. If it is "tall" (`x_width <= y_width`), a vertical cut is made. If it is "wide" (`x_width > y_width`), a horizontal cut is made.
* The step sizes along the cut direction is obtained from the parent workspace instead of being hard coded in.
* In non-PSD mode, it now detects correctly the axes to be integrated over for cuts along `DeltaE`.

In addition, a new feature - a `Flip Axis` button has been added which is only visible when in interactive cut mode. This allows the user to change the integration axis regardless of the original shape of the rectangle (e.g. plot a horizontal cut for a "tall" rectangle and vice versa).

**To test:**

Load a PSD and non-PSD workspace and plot slices for different axes (E-|Q| and E-2theta) and check that interactive cuts work for all cases. Click the flip (`retweet`) button and check it flips the integration axis. 

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #276.
