### PR TITLE
Pre-beta release bug fixes and improvements

### DIFF
--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -35,6 +35,7 @@ class MatplotlibCutPlotter(CutPlotter):
         plt.xlabel(self._getDisplayName(x_units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
         plt.ylabel(INTENSITY_LABEL, picker=picker)
         if not plot_over:
+            plt.gcf().canvas.set_window_title('Cut: ' + selected_workspace)
             plt.gcf().canvas.manager.update_grid()
         if self.background is None:
             self._create_cut(cut_ws_name if cut_ws_name is not None else selected_workspace)

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -91,11 +91,11 @@ class MantidWorkspaceProvider(WorkspaceProvider):
         ws_name = workspace if isinstance(workspace, string_types) else self.get_workspace_name(workspace)
         ws_h = self.get_workspace_handle(workspace)
         # For cases, e.g. indirect, where EFixed has not been set yet, return calculate later.
-        if ws_name not in self._limits:
-            self._limits[ws_name] = {}
         efix = self.get_EFixed(ws_h)
         if efix is None:
             return
+        if ws_name not in self._limits:
+            self._limits[ws_name] = {}
         if isinstance(ws_h, IMDEventWorkspace):
             self.process_limits_event(ws_h, ws_name, efix)
         elif isinstance(ws_h, MatrixWorkspace):

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -7,7 +7,7 @@ from matplotlib.figure import Figure
 import six
 from mslice.util.qt import QT_VERSION
 from mslice.util.qt.QtCore import Qt
-from mslice.util.qt import QtWidgets
+from mslice.util.qt import QtWidgets, QtGui
 import qtawesome as qta
 
 from mslice.plotting.plot_window.slice_plot import SlicePlot
@@ -135,10 +135,10 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         printer.setOrientation(QtWidgets.QPrinter.Landscape) #  landscape by default
         print_dialog = QtWidgets.QPrintDialog(printer)
         if print_dialog.exec_():
-            pixmap_image = QtWidgets.QPixmap.grabWidget(self.canvas)
+            pixmap_image = QtGui.QPixmap.grabWidget(self.canvas)
             page_size = printer.pageRect()
             pixmap_image = pixmap_image.scaled(page_size.width(), page_size.height(), Qt.KeepAspectRatio)
-            painter = QtWidgets.QPainter(printer)
+            painter = QtGui.QPainter(printer)
             painter.drawPixmap(0,0,pixmap_image)
             painter.end()
 

--- a/mslice/tests/data_loader_test.py
+++ b/mslice/tests/data_loader_test.py
@@ -35,7 +35,7 @@ class DataLoaderTest(unittest.TestCase):
 
         self.presenter.load_workspace([path_to_nexus])
         self.workspace_provider.load.assert_called_with(filename=path_to_nexus, output_workspace=workspace_name)
-        self.view.get_workspace_efixed.assert_called_with(workspace_name, False)
+        self.view.get_workspace_efixed.assert_called_with(workspace_name, False, None)
         self.workspace_provider.set_efixed.assert_called_once_with(workspace_name, 1.845)
         self.main_presenter.show_workspace_manager_tab.assert_called_once()
         self.main_presenter.show_tab_for_workspace.assert_called_once()

--- a/mslice/util/qt/QtGui.py
+++ b/mslice/util/qt/QtGui.py
@@ -1,0 +1,4 @@
+try:
+    from qtpy.QtGui import * # noqa: F401
+except (ImportError, ValueError):
+    from PyQt4.QtGui import * # noqa: F401

--- a/mslice/util/qt/QtWidgets.py
+++ b/mslice/util/qt/QtWidgets.py
@@ -1,4 +1,5 @@
 try:
     from qtpy.QtWidgets import * # noqa: F401
+    from qtpy.QtPrintSupport import * # noqa: F401
 except (ImportError, ValueError):
     from PyQt4.QtGui import * # noqa: F401

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -111,8 +111,8 @@ class DataLoaderWidget(QWidget): # and some view interface
             selected[i] = str(os.path.join(self.directory.absolutePath(), self.file_system.fileName(selected[i])))
         return selected
 
-    def get_workspace_efixed(self, workspace, hasMultipleWS=False):
-        Ef, applyToAll, success = EfInputDialog.getEf(workspace, hasMultipleWS, None)
+    def get_workspace_efixed(self, workspace, hasMultipleWS=False, default_value=None):
+        Ef, applyToAll, success = EfInputDialog.getEf(workspace, hasMultipleWS, default_value)
         if not success:
             raise ValueError('Fixed final energy not given')
         return Ef, applyToAll

--- a/mslice/widgets/dataloader/inputdialog.py
+++ b/mslice/widgets/dataloader/inputdialog.py
@@ -25,10 +25,12 @@ class EfInputDialog(QDialog):
         return self.efspin.value(), self.allchk.isChecked()
 
     @staticmethod
-    def getEf(workspace, hasMultipleWS=False, parent = None):
+    def getEf(workspace, hasMultipleWS=False, default_value = None, parent = None):
         """Static method to get an Ef"""
         dialog = EfInputDialog(parent)
         dialog.text.setText('Input Fixed Final Energy in meV for %s:' % (workspace))
+        if default_value:
+            dialog.efspin.setValue(default_value)
         if hasMultipleWS:
             dialog.showCheck()
         result = dialog.exec_()


### PR DESCRIPTION
A series of small bug fixes and improvements in advance of the beta release. Including:

* Fixes `pyqt` shim to handle `QPrinter` and `QPixmap` correctly for both `PyQt4` and `qtpy`.
* Add a title to cut windows.
* Now caches `Ef` for indirect `nxspe` files where we need to ask the user; also the "Apply to all" check box now works.
* Fixes an issue with setting the limits for `nxspe` indirect file, where it needs the `Ef` but is first run before this is asked from the user, meaning the limits dict entry is left blank.

**To test:**

* Load an indirect nxspe file, put 1.84 meV as Ef if using IRIS data (as in the zip below), and check you can plot slices / cuts / etc.
* Load another indirect nxspe and check that the Ef dialog comes up again with 1.84 meV this time.
* Load multiple indirect files and check the "Apply to all" checkbox. Check that the dialog does not appear again, and then that the data looks like what it did when it was loaded individually.
* From any slice or cut window, on a system with `qtpy`, check that you can print using the print icon.

Attached zip has some files for testing.
[indirect_nxspe.zip](https://github.com/mantidproject/mslice/files/1814449/indirect_nxspe.zip)


<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #279 .
