### PR TITLE
Fix intensity off-by-one broadcasting error 

### DIFF
--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -1,9 +1,10 @@
 from six import string_types
+import numpy as np
 
 class AlgWorkspaceOps(object):
 
     def _get_number_of_steps(self, axis):
-        return int(max(1, (axis.end - axis.start)/axis.step))
+        return int(np.ceil(max(1, (axis.end - axis.start)/axis.step)))
 
     def get_axis_range(self, workspace, dimension_name):
         return tuple(self._workspace_provider.get_limits(workspace, dimension_name))


### PR DESCRIPTION
`_get_number_of_steps` rounded down, whereas the slice plotter rounds up. Now they both round up so they are consistent.

**To test:**
- Try changing the intensity option for different workspaces (e.g. `MAR22017_Ei10.00meV` was broken before) and check there are no errors.

Fixes #282
