### PR TITLE
Fix cut window missing plot_handler

### DIFF
--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -12,7 +12,6 @@ class MatplotlibCutPlotter(CutPlotter):
     def __init__(self, cut_algorithm):
         self._cut_algorithm = cut_algorithm
         self.workspace_provider = None
-        self.background = None
         self.icut = None
 
     def plot_cut(self, selected_workspace, cut_axis, integration_axis, norm_to_one, intensity_start,

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -37,9 +37,9 @@ class MatplotlibCutPlotter(CutPlotter):
         if not plot_over:
             plt.gcf().canvas.set_window_title('Cut: ' + selected_workspace)
             plt.gcf().canvas.manager.update_grid()
-        if self.background is None:
+        if not plt.gcf().canvas.manager.has_plot_handler():
             self._create_cut(cut_ws_name if cut_ws_name is not None else selected_workspace)
-        plt.gcf().canvas.restore_region(self.background)
+        plt.gcf().canvas.restore_region(plt.gcf().canvas.manager.get_cut_background())
         try:
             plt.gca().draw_artist(plt.gcf().canvas.figure.get_children()[1])
             plt.gcf().canvas.blit(plt.gcf().canvas.figure.gca().clipbox)
@@ -47,16 +47,17 @@ class MatplotlibCutPlotter(CutPlotter):
             plt.gcf().canvas.draw()
 
     def _create_cut(self, workspace):
+        canvas = plt.gcf().canvas
+        canvas.manager.add_cut_plot(self, workspace)
         # don't include axis ticks in the saved background
-        plt.gcf().canvas.figure.gca().xaxis.set_visible(False)
-        plt.gcf().canvas.figure.gca().yaxis.set_visible(False)
-        plt.gcf().canvas.draw()
-        self.background = plt.gcf().canvas.copy_from_bbox(plt.gcf().canvas.figure.bbox)
+        canvas.figure.gca().xaxis.set_visible(False)
+        canvas.figure.gca().yaxis.set_visible(False)
+        canvas.draw()
+        canvas.manager.set_cut_background(canvas.copy_from_bbox(plt.gcf().canvas.figure.bbox))
 
-        plt.gcf().canvas.figure.gca().xaxis.set_visible(True)
-        plt.gcf().canvas.figure.gca().yaxis.set_visible(True)
-        plt.gcf().canvas.manager.add_cut_plot(self, workspace)
-        plt.gcf().canvas.draw()
+        canvas.figure.gca().xaxis.set_visible(True)
+        canvas.figure.gca().yaxis.set_visible(True)
+        canvas.draw()
 
     def set_icut(self, icut):
         if icut is not None:

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -92,6 +92,15 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
             self._plot_handler.disconnect(self)
         self._plot_handler = CutPlot(self, self.canvas, cut_plotter, workspace)
 
+    def has_plot_handler(self):
+        return self._plot_handler is not None
+
+    def set_cut_background(self, background):
+        self._plot_handler.background = background
+
+    def get_cut_background(self):
+        return self._plot_handler.background
+
     def is_icut(self, is_icut):
         if self._plot_handler is not None:
             self._plot_handler.is_icut(is_icut)


### PR DESCRIPTION
The plot background was stored on the `cut_plotter`, and its presence used to determine whether `create_cut` had been run yet. This is incorrect, as there is no one-to-one link between a `cut_plotter` object and the plot window.
This caused a bug where the `plot_handler` was not set, and some features could not be accessed.
The background is now accessed via methods on the `PlotFigureManager` and stored in the `plot_handler`.

**To test:**
- Plot a cut and hit keep
- Plot another cut
- Check the plot options can be accessed without error on both plots.

Fixes #281 
