### PR TITLE
Move check_mpl call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
 matrix:
     include:
         - python: "2.7_with_system_site_packages"
-          env: PY=2.7 PYTHONPATH=$PYTHONPATH:/opt/mantidnightly/bin
+          env: PY=2.7 PYTHONPATH=$PYTHONPATH:/opt/mantidnightly/bin QT_API=pyqt
         - python: "3.4_with_system_site_packages"
           env: PY=3.4 PYTHONPATH=$PYTHONPATH:/opt/mantidnightly-python3/bin
 

--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -7,17 +7,6 @@ from mslice.util.qt.QtWidgets import QApplication
 
 # Module-level reference to keep main window alive after show_gui has returned
 MAIN_WINDOW = None
-MPL_COMPAT = False
-
-def check_mpl():
-    from distutils.version import LooseVersion
-    import matplotlib
-    if LooseVersion(matplotlib.__version__) < LooseVersion("1.5.0"):
-        import warnings
-        warnings.warn('A version of Matplotlib older than 1.5.0 has been detected.')
-        warnings.warn('Some features of MSlice may not work correctly.')
-        global MPL_COMPAT
-        MPL_COMPAT = True
 
 def main():
     """Start the application.
@@ -31,7 +20,6 @@ def show_gui():
     If this is the first call then an instance of the Windows is cached to ensure it
     survives for the duration of the application
     """
-    check_mpl()
     global MAIN_WINDOW
     if MAIN_WINDOW is None:
         from mslice.app.mainwindow import MainWindow

--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -22,7 +22,6 @@ def check_mpl():
 def main():
     """Start the application.
     """
-    check_mpl()
     qapp_ref = QApplication([])
     show_gui()
     return qapp_ref.exec_()
@@ -32,6 +31,7 @@ def show_gui():
     If this is the first call then an instance of the Windows is cached to ensure it
     survives for the duration of the application
     """
+    check_mpl()
     global MAIN_WINDOW
     if MAIN_WINDOW is None:
         from mslice.app.mainwindow import MainWindow

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import mslice.plotting.pyplot as plt
-from mslice.app import MPL_COMPAT
+from mslice.util import MPL_COMPAT
 from .cut_plotter import CutPlotter
 from .mantid_cut_algorithm import output_workspace_name
 

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 from matplotlib.colors import Normalize
 from .slice_plotter import SlicePlotter
 import mslice.plotting.pyplot as plt
-from mslice.app import MPL_COMPAT
+from mslice.util import MPL_COMPAT
 
 recoil_labels={1:'Hydrogen', 2:'Deuterium', 4:'Helium'}
 overplot_colors={1:'b', 2:'g', 4:'r', 'Aluminium': 'g', 'Copper':'m', 'Niobium':'y', 'Tantalum':'b'}

--- a/mslice/plotting/pyplot.py
+++ b/mslice/plotting/pyplot.py
@@ -6,7 +6,7 @@ from six import string_types
 from .figuremanager import FigureManager, activate_category
 from .script_generation import script_log
 from ._pyplot_decorators import draw_colorbar
-from mslice.app import MPL_COMPAT
+from mslice.util import MPL_COMPAT
 
 # imports from matplotlit.pyplot
 import matplotlib

--- a/mslice/util/__init__.py
+++ b/mslice/util/__init__.py
@@ -1,8 +1,9 @@
+from distutils.version import LooseVersion
+import matplotlib
+
 MPL_COMPAT = False
 
 # check matplotlib version
-from distutils.version import LooseVersion
-import matplotlib
 if LooseVersion(matplotlib.__version__) < LooseVersion("1.5.0"):
     import warnings
     warnings.warn('A version of Matplotlib older than 1.5.0 has been detected.')

--- a/mslice/util/__init__.py
+++ b/mslice/util/__init__.py
@@ -1,0 +1,11 @@
+MPL_COMPAT = False
+
+# check matplotlib version
+from distutils.version import LooseVersion
+import matplotlib
+if LooseVersion(matplotlib.__version__) < LooseVersion("1.5.0"):
+    import warnings
+    warnings.warn('A version of Matplotlib older than 1.5.0 has been detected.')
+    warnings.warn('Some features of MSlice may not work correctly.')
+    global MPL_COMPAT
+    MPL_COMPAT = True

--- a/mslice/util/__init__.py
+++ b/mslice/util/__init__.py
@@ -8,5 +8,4 @@ if LooseVersion(matplotlib.__version__) < LooseVersion("1.5.0"):
     import warnings
     warnings.warn('A version of Matplotlib older than 1.5.0 has been detected.')
     warnings.warn('Some features of MSlice may not work correctly.')
-    global MPL_COMPAT
     MPL_COMPAT = True


### PR DESCRIPTION
Moves `check_mpl()` inside `show_gui` so it is always called to prevent errors on old matplotlib versions.

Fixes #291
