### PR TITLE
Add more tests around quick options and plots

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -68,6 +68,11 @@ class CutPlot(object):
         self._canvas.draw()
 
     def get_line_index(self, line):
+        '''
+        Checks if line index is cached, and if not finds the index by iterating over the axes' containers.
+        :param line: Line to find the index of
+        :return: Index of line
+        '''
         try:
             container = self._lines[line]
         except KeyError:
@@ -182,10 +187,10 @@ class CutPlot(object):
         return v
 
     def line_containers(self):
+        '''build dictionary of lines and their containers'''
         line_containers = {}
         containers = self._canvas.figure.gca().containers
-        for index in range(len(containers)):
-            container = containers[index]
+        for container in containers:
             line = container.get_children()[0]
             line_containers[line] = container
         return line_containers

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -1,8 +1,8 @@
-from mock import MagicMock
+from mock import MagicMock, patch, ANY
 import numpy as np
 import unittest
 
-
+from matplotlib.lines import Line2D
 from mslice.plotting.plot_window.cut_plot import CutPlot
 
 
@@ -29,8 +29,8 @@ class CutPlotTest(unittest.TestCase):
         self.cut_plot.change_axis_scale(xy_config)
         self.axes.set_xscale.assert_called_once_with('linear')
         self.axes.set_yscale.assert_called_once_with('linear')
-        self.assertEqual(self.cut_plot.x_range, (0,10))
-        self.assertEqual(self.cut_plot.y_range, (1,7))
+        self.assertEqual(self.cut_plot.x_range, (0, 10))
+        self.assertEqual(self.cut_plot.y_range, (1, 7))
 
     def test_change_scale_log(self):
         self.axes.set_xscale = MagicMock()
@@ -38,12 +38,41 @@ class CutPlotTest(unittest.TestCase):
         line = MagicMock()
         line.get_ydata = MagicMock(return_value=np.array([1, 5, 10]))
         line.get_xdata = MagicMock(return_value=np.array([20, 60, 12]))
-        self.axes.get_lines = MagicMock(return_value = [line])
-        self.canvas.figure.gca = MagicMock(return_value = self.axes)
+        self.axes.get_lines = MagicMock(return_value=[line])
+        self.canvas.figure.gca = MagicMock(return_value=self.axes)
         xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
 
         self.cut_plot.change_axis_scale(xy_config)
         self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
         self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
-        self.assertEqual(self.cut_plot.x_range, (12,20))
-        self.assertEqual(self.cut_plot.y_range, (1,7))
+        self.assertEqual(self.cut_plot.x_range, (12, 20))
+        self.assertEqual(self.cut_plot.y_range, (1, 7))
+
+    @patch('mslice.plotting.plot_window.cut_plot.quick_options')
+    def test_line_clicked(self, quick_options_mock):
+        line = Line2D([], [])
+        self.cut_plot.get_line_index = MagicMock(return_value=2)
+        self.cut_plot.update_legend = MagicMock()
+        self.cut_plot.object_clicked(line)
+        self.cut_plot.get_line_index.assert_called_once_with(line)
+        quick_options_mock.assert_called_once_with(2, self.cut_plot)
+        self.cut_plot.update_legend.assert_called_once()
+        self.cut_plot._canvas.draw.assert_called_once()
+
+    @patch('mslice.plotting.plot_window.cut_plot.quick_options')
+    def test_object_clicked(self, quick_options_mock):
+        text = "some_label"
+        self.cut_plot.get_line_index = MagicMock(return_value=2)
+        self.cut_plot.update_legend = MagicMock()
+        self.cut_plot.object_clicked(text)
+        self.cut_plot.get_line_index.assert_not_called()
+        quick_options_mock.assert_called_once_with(text, self.cut_plot)
+        self.cut_plot.update_legend.assert_called_once()
+        self.cut_plot._canvas.draw.assert_called_once()
+
+    def test_update_legend(self):
+        line = Line2D([], [])
+        self.axes.get_legend_handles_labels = MagicMock(return_value=([line], ['some_label']))
+        self.cut_plot.update_legend()
+        self.assertTrue(self.cut_plot._legends_visible[0])
+        self.axes.legend.assert_called_with([line], ['some_label'], fontsize=ANY)

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -54,11 +54,11 @@ class QuickOptionsTest(unittest.TestCase):
         assert type(self.presenter) is QuickLinePresenter
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': None, 'color': 'red', 'label': unicode('label1'), 'style': '-', 'width': '3',
+            {'shown': None, 'color': 'red', 'label': u'label1', 'style': '-', 'width': '3',
              'marker': 'o', 'legend': None})
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_data(target),
-                             {'shown': None, 'color': 'blue', 'label': unicode('label2'),
+                             {'shown': None, 'color': 'blue', 'label': u'label2',
                               'style': '--', 'width': '5', 'marker': '.', 'legend': None})
 
     @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
@@ -79,11 +79,11 @@ class QuickOptionsTest(unittest.TestCase):
         assert type(self.presenter) is QuickLinePresenter
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': True, 'color': 'red', 'label': unicode('label1'), 'style': '-', 'width': '3',
+            {'shown': True, 'color': 'red', 'label': u'label1', 'style': '-', 'width': '3',
              'marker': 'o', 'legend': True})
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_data(model.get_line_index(target)),
-                             {'shown': True, 'color': 'blue', 'label': unicode('label2'),
+                             {'shown': True, 'color': 'blue', 'label': u'label2',
                               'style': '--', 'width': '5', 'marker': '.', 'legend': True})
 
     @patch.object(QuickAxisOptions, '__init__', lambda v, w, x, y, z: None)

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -1,8 +1,27 @@
 from mock import MagicMock, PropertyMock, Mock, patch
 import unittest
 
-from mslice.presenters.quick_options_presenter import quick_options, QuickLinePresenter, QuickAxisPresenter, QuickLabelPresenter
+from matplotlib import text
+from matplotlib.lines import Line2D
+from matplotlib.container import Container
+from mslice.plotting.plot_window.slice_plot import SlicePlot
+from mslice.plotting.plot_window.cut_plot import CutPlot
+from mslice.presenters.quick_options_presenter import (quick_options, QuickLinePresenter, QuickAxisPresenter,
+                                                       QuickLabelPresenter)
 from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLabelOptions, QuickLineOptions
+
+
+def setup_line_values(qlo_mock):
+    quick_line_options = MagicMock()
+    qlo_mock.return_value = quick_line_options
+    type(quick_line_options).marker = PropertyMock(return_value='.')
+    type(quick_line_options).color = PropertyMock(return_value='blue')
+    type(quick_line_options).style = PropertyMock(return_value='--')
+    type(quick_line_options).width = PropertyMock(return_value='5')
+    type(quick_line_options).label = PropertyMock(return_value='label2')
+    target = Line2D([], [], 3, '-', 'red', 'o', label='label1')
+    return qlo_mock, target
+
 
 class QuickOptionsTest(unittest.TestCase):
 
@@ -12,7 +31,6 @@ class QuickOptionsTest(unittest.TestCase):
     @patch.object(QuickLabelOptions, '__init__', lambda x, y: None)
     @patch.object(QuickLabelOptions, 'exec_', lambda x: None)
     def test_label(self):
-        from matplotlib import text
         self.target = Mock(spec=text.Text)
         self.presenter = quick_options(self.target, self.model)
         assert type(self.presenter) is QuickLabelPresenter
@@ -23,6 +41,50 @@ class QuickOptionsTest(unittest.TestCase):
         self.target = 1
         self.presenter = quick_options(self.target, self.model)
         assert type(self.presenter) is QuickLinePresenter
+
+    @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
+    def test_line_slice(self, qlo_mock):
+        plot_figure = MagicMock()
+        canvas = MagicMock()
+        slice_plotter = MagicMock()
+        model = SlicePlot(plot_figure, canvas, slice_plotter, 'workspace')
+        qlo_mock, target = setup_line_values(qlo_mock)
+
+        self.presenter = quick_options(target, model)
+        assert type(self.presenter) is QuickLinePresenter
+        # check view is called with existing line parameters
+        qlo_mock.assert_called_with(
+            {'shown': None, 'color': 'red', 'label': unicode('label1'), 'style': '-', 'width': '3',
+             'marker': 'o', 'legend': None})
+        # check model is updated with parameters from view
+        self.assertDictEqual(model.get_line_data(target),
+                             {'shown': None, 'color': 'blue', 'label': unicode('label2'),
+                              'style': '--', 'width': '5', 'marker': '.', 'legend': None})
+
+    @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
+    def test_line_cut(self, qlo_mock):
+        plot_figure = MagicMock()
+        canvas = MagicMock()
+        cut_plotter = MagicMock()
+        model = CutPlot(plot_figure, canvas, cut_plotter, 'workspace')
+        qlo_mock, target = setup_line_values(qlo_mock)
+
+        container = Container([target], label='label1')
+        model._lines[target] = container
+        container_mock = MagicMock()
+        container_mock.containers = [container]
+        canvas.figure.gca = MagicMock(return_value=container_mock)
+
+        self.presenter = quick_options(model.get_line_index(target), model)
+        assert type(self.presenter) is QuickLinePresenter
+        # check view is called with existing line parameters
+        qlo_mock.assert_called_with(
+            {'shown': True, 'color': 'red', 'label': unicode('label1'), 'style': '-', 'width': '3',
+             'marker': 'o', 'legend': True})
+        # check model is updated with parameters from view
+        self.assertDictEqual(model.get_line_data(model.get_line_index(target)),
+                             {'shown': True, 'color': 'blue', 'label': unicode('label2'),
+                              'style': '--', 'width': '5', 'marker': '.', 'legend': True})
 
     @patch.object(QuickAxisOptions, '__init__', lambda v, w, x, y, z: None)
     @patch.object(QuickAxisOptions, 'exec_', lambda x: True)
@@ -61,7 +123,7 @@ class QuickAxisTest(unittest.TestCase):
     def test_accept(self):
         self.view.exec_ = MagicMock(return_value=True)
         QuickAxisPresenter(self.view, 'x_range', self.model, False, None)
-        self.assertEquals(self.model.x_range, (5,10))
+        self.assertEquals(self.model.x_range, (5, 10))
         self.assertEquals(self.model.x_grid, True)
 
     def test_reject(self):
@@ -140,7 +202,7 @@ class QuickLineTest(unittest.TestCase):
         type(self.view).legend = legend
         self.view.exec_ = MagicMock(return_value=True)
         QuickLinePresenter(self.view, self.target, self.model)
-        values = {'color': 1, 'style': 2,'width': 3, 'marker':4, 'label':5, 'shown':False, 'legend':False}
+        values = {'color': 1, 'style': 2, 'width': 3, 'marker': 4, 'label': 5, 'shown': False, 'legend': False}
         self.model.set_line_data.assert_called_once_with(self.target, values)
 
     def test_reject(self):

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -1,7 +1,9 @@
-from mock import MagicMock, PropertyMock
+from mock import MagicMock, patch, PropertyMock, ANY
 import unittest
 
-import matplotlib.colors as colors
+from matplotlib import colors
+from matplotlib.lines import Line2D
+from matplotlib.text import Text
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 
 
@@ -17,7 +19,7 @@ class SlicePlotTest(unittest.TestCase):
 
     def test_change_logarithmic(self):
         image = MagicMock()
-        norm = PropertyMock(return_value = colors.Normalize)
+        norm = PropertyMock(return_value=colors.Normalize)
         type(image).norm = norm
         self.axes.get_images = MagicMock(return_value=[image])
         self.slice_plot.change_axis_scale((0, 10), True)
@@ -45,7 +47,7 @@ class SlicePlotTest(unittest.TestCase):
         line1 = MagicMock()
         line2 = MagicMock()
         line1.get_linestyle = MagicMock(return_value='None')
-        line2.get_linestyle = MagicMock(return_value = '-')
+        line2.get_linestyle = MagicMock(return_value='-')
         self.slice_plotter.overplot_lines.__getitem__ = MagicMock(return_value={0: line1, 1: line2})
         self.slice_plotter.get_recoil_label = MagicMock()
         self.slice_plotter.get_recoil_label.side_effect = ['0', '1']
@@ -63,3 +65,43 @@ class SlicePlotTest(unittest.TestCase):
 
         self.assertTrue(new_slice_plot.plot_figure.actionHelium.checked)
         self.slice_plotter.add_overplot_line.assert_any_call('workspace', 4, True, '')
+
+    @patch('mslice.plotting.plot_window.slice_plot.QtWidgets.QInputDialog.getInt')
+    def test_arbitrary_recoil_line(self, qt_get_int_mock):
+        qt_get_int_mock.return_value = (5, True)
+        self.slice_plotter.add_overplot_line.reset_mock()
+        self.plot_figure.actionArbitrary_nuclei.isChecked = MagicMock(return_value=True)
+
+        self.slice_plot.arbitrary_recoil_line()
+        self.slice_plotter.add_overplot_line.assert_called_once_with('workspace', 5, True, None)
+
+    @patch('mslice.plotting.plot_window.slice_plot.QtWidgets.QInputDialog.getInt')
+    def test_arbitrary_recoil_line_cancelled(self, qt_get_int_mock):
+        qt_get_int_mock.return_value = (5, False)
+        self.slice_plotter.add_overplot_line.reset_mock()
+        self.plot_figure.actionArbitrary_nuclei.isChecked = MagicMock(return_value=True)
+
+        self.slice_plot.arbitrary_recoil_line()
+        self.slice_plotter.add_overplot_line.assert_not_called()
+
+    def test_update_legend(self):
+        line1 = Line2D([], [],label='line1')
+        line2 = Line2D([], [], label='line2')
+        line3 = Line2D([], [], label='line_not_to_show1')
+        line4 = Line2D([], [], label='')
+        line3.set_linestyle('None')
+        line1_text = Text('line1')
+        line2_text = Text('line2')
+
+        get_legend_mock = MagicMock()
+        get_legend_mock.get_lines = MagicMock(return_value=[line1, line2])
+        get_legend_mock.get_texts = MagicMock(return_value=[line1_text, line2_text])
+        self.axes.get_children = MagicMock(return_value=[line1, line2, line3, line4, "nonsense", 4])
+        self.axes.legend = MagicMock(return_value=get_legend_mock)
+
+        self.slice_plot.update_legend()
+        self.axes.legend.assert_called_with([line1, line2], ['line1', 'line2'], fontsize=ANY)
+        self.assertEqual(self.slice_plot._legend_dict[line1], line1)
+        self.assertEqual(self.slice_plot._legend_dict[line2], line2)
+        self.assertEqual(self.slice_plot._legend_dict[line1_text], line1)
+        self.assertEqual(self.slice_plot._legend_dict[line2_text], line2)


### PR DESCRIPTION
Some quick_options tests were very basic because `plot_figure` could not be instantiated in the tests, but the `SlicePlot` and `CutPlot` objects bypass this requirement. 
Also adds some other tests to those related classes.

Fixes #224 
