### PR TITLE
Move common axis labelling code

### DIFF
--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -1,12 +1,10 @@
 from __future__ import (absolute_import, division, print_function)
 import mslice.plotting.pyplot as plt
-from mslice.util import MPL_COMPAT
 from .cut_plotter import CutPlotter
 from .mantid_cut_algorithm import output_workspace_name
+from ..labels import get_display_name, generate_legend, INTENSITY_LABEL
 
-INTENSITY_LABEL = 'Signal/#Events'
 picker=3
-
 
 class MatplotlibCutPlotter(CutPlotter):
     def __init__(self, cut_algorithm):
@@ -20,7 +18,7 @@ class MatplotlibCutPlotter(CutPlotter):
         output_ws_name = output_workspace_name(selected_workspace, integration_axis.start, integration_axis.end)
         integrated_dim = self._cut_algorithm.get_other_axis(selected_workspace, cut_axis) \
             if integration_axis.units == "" else  integration_axis.units
-        legend = self._generate_legend(selected_workspace, integrated_dim, integration_axis.start, integration_axis.end)
+        legend = generate_legend(selected_workspace, integrated_dim, integration_axis.start, integration_axis.end)
         self.plot_cut_from_xye(x, y, e, cut_axis.units, selected_workspace, (intensity_start, intensity_end),
                                plot_over, output_ws_name, legend)
 
@@ -31,7 +29,7 @@ class MatplotlibCutPlotter(CutPlotter):
         plt.ylim(*intensity_range) if intensity_range is not None else plt.autoscale()
         leg = plt.legend(fontsize='medium')
         leg.draggable()
-        plt.xlabel(self._getDisplayName(x_units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
+        plt.xlabel(get_display_name(x_units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
         plt.ylabel(INTENSITY_LABEL, picker=picker)
         if not plot_over:
             plt.gcf().canvas.set_window_title('Cut: ' + selected_workspace)
@@ -75,28 +73,6 @@ class MatplotlibCutPlotter(CutPlotter):
     def save_cut(self, params):
         return self._cut_algorithm.compute_cut(*params)
 
-    def _getDisplayName(self, axisUnits, comment=None):
-        if 'DeltaE' in axisUnits:
-            # Matplotlib 1.3 doesn't handle LaTeX very well. Sometimes no legend appears if we use LaTeX
-            if MPL_COMPAT:
-                return 'Energy Transfer ' + ('(cm-1)' if (comment and 'wavenumber' in comment) else '(meV)')
-            else:
-                return 'Energy Transfer ' + ('(cm$^{-1}$)' if (comment and 'wavenumber' in comment) else '(meV)')
-        elif 'MomentumTransfer' in axisUnits or '|Q|' in axisUnits:
-            return '|Q| (recip. Ang.)' if MPL_COMPAT else '$|Q|$ ($\mathrm{\AA}^{-1}$)'
-        elif 'Degrees' in axisUnits:
-            return 'Scattering Angle (degrees)' if MPL_COMPAT else r'Scattering Angle 2$\theta$ ($^{\circ}$)'
-        else:
-            return axisUnits
-
-    def _generate_legend(self, workspace_name, integrated_dim, integration_start, integration_end):
-        if MPL_COMPAT:
-            mappings = {'DeltaE':'E', 'MomentumTransfer':'|Q|', 'Degrees':r'2Theta'}
-        else:
-            mappings = {'DeltaE':'E', 'MomentumTransfer':'|Q|', 'Degrees':r'2$\theta$'}
-        integrated_dim = mappings[integrated_dim] if integrated_dim in mappings else integrated_dim
-        return workspace_name + " " + "%.2f" % integration_start + "<" + integrated_dim + "<" + \
-            "%.2f" % integration_end
 
     def set_workspace_provider(self, workspace_provider):
         self.workspace_provider = workspace_provider

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import mslice.plotting.pyplot as plt
 from .cut_plotter import CutPlotter
 from .mantid_cut_algorithm import output_workspace_name
-from ..labels import get_display_name, generate_legend, INTENSITY_LABEL
+from ..labels import get_display_name, generate_legend, CUT_INTENSITY_LABEL
 
 picker=3
 
@@ -30,7 +30,7 @@ class MatplotlibCutPlotter(CutPlotter):
         leg = plt.legend(fontsize='medium')
         leg.draggable()
         plt.xlabel(get_display_name(x_units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
-        plt.ylabel(INTENSITY_LABEL, picker=picker)
+        plt.ylabel(CUT_INTENSITY_LABEL, picker=picker)
         if not plot_over:
             plt.gcf().canvas.set_window_title('Cut: ' + selected_workspace)
             plt.gcf().canvas.manager.update_grid()

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -30,4 +30,3 @@ def generate_legend(workspace_name, integrated_dim, integration_start, integrati
     integrated_dim = mappings[integrated_dim] if integrated_dim in mappings else integrated_dim
     return workspace_name + " " + "%.2f" % integration_start + "<" + integrated_dim + "<" + \
         "%.2f" % integration_end
-

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -3,7 +3,7 @@
 from __future__ import (absolute_import, division, print_function)
 from mslice.util import MPL_COMPAT
 
-INTENSITY_LABEL = 'Signal/#Events'
+CUT_INTENSITY_LABEL = 'Signal/#Events'
 recoil_labels={1:'Hydrogen', 2:'Deuterium', 4:'Helium'}
 
 

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -1,0 +1,33 @@
+'''Module to create axis and legend labels'''
+
+from __future__ import (absolute_import, division, print_function)
+from mslice.util import MPL_COMPAT
+
+INTENSITY_LABEL = 'Signal/#Events'
+recoil_labels={1:'Hydrogen', 2:'Deuterium', 4:'Helium'}
+
+
+def get_display_name(axisUnits, comment=None):
+    if 'DeltaE' in axisUnits:
+        # Matplotlib 1.3 doesn't handle LaTeX very well. Sometimes no legend appears if we use LaTeX
+        if MPL_COMPAT:
+            return 'Energy Transfer ' + ('(cm-1)' if (comment and 'wavenumber' in comment) else '(meV)')
+        else:
+            return 'Energy Transfer ' + ('(cm$^{-1}$)' if (comment and 'wavenumber' in comment) else '(meV)')
+    elif 'MomentumTransfer' in axisUnits or '|Q|' in axisUnits:
+        return '|Q| (recip. Ang.)' if MPL_COMPAT else '$|Q|$ ($\mathrm{\AA}^{-1}$)'
+    elif 'Degrees' in axisUnits:
+        return 'Scattering Angle (degrees)' if MPL_COMPAT else r'Scattering Angle 2$\theta$ ($^{\circ}$)'
+    else:
+        return axisUnits
+
+
+def generate_legend(workspace_name, integrated_dim, integration_start, integration_end):
+    if MPL_COMPAT:
+        mappings = {'DeltaE':'E', 'MomentumTransfer':'|Q|', 'Degrees':r'2Theta'}
+    else:
+        mappings = {'DeltaE':'E', 'MomentumTransfer':'|Q|', 'Degrees':r'2$\theta$'}
+    integrated_dim = mappings[integrated_dim] if integrated_dim in mappings else integrated_dim
+    return workspace_name + " " + "%.2f" % integration_start + "<" + integrated_dim + "<" + \
+        "%.2f" % integration_end
+

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -3,8 +3,8 @@ from matplotlib.colors import Normalize
 from .slice_plotter import SlicePlotter
 import mslice.plotting.pyplot as plt
 from mslice.util import MPL_COMPAT
+from ..labels import get_display_name, recoil_labels
 
-recoil_labels={1:'Hydrogen', 2:'Deuterium', 4:'Helium'}
 overplot_colors={1:'b', 2:'g', 4:'r', 'Aluminium': 'g', 'Copper':'m', 'Niobium':'y', 'Tantalum':'b'}
 picker=5
 
@@ -49,21 +49,6 @@ class MatplotlibSlicePlotter(SlicePlotter):
             self.slice_cache[ws]['energy_axis'] = x_axis
             self.slice_cache[ws]['rotated'] = True
 
-
-    def _getDisplayName(self, axisUnits, comment=None):
-        if 'DeltaE' in axisUnits:
-            # Matplotlib 1.3 doesn't handle LaTeX very well. Sometimes no legend appears if we use LaTeX
-            if MPL_COMPAT:
-                return 'Energy Transfer ' + ('(cm-1)' if (comment and 'wavenumber' in comment) else '(meV)')
-            else:
-                return 'Energy Transfer ' + ('(cm$^{-1}$)' if (comment and 'wavenumber' in comment) else '(meV)')
-        elif 'MomentumTransfer' in axisUnits or '|Q|' in axisUnits:
-            return '|Q| (recip. Ang.)' if MPL_COMPAT else '$|Q|$ ($\mathrm{\AA}^{-1}$)'
-        elif 'Degrees' in axisUnits:
-            return 'Scattering Angle (degrees)' if MPL_COMPAT else r'Scattering Angle 2$\theta$ ($^{\circ}$)'
-        else:
-            return axisUnits
-
     def _show_plot(self, workspace_name, plot_data, extent, colourmap, norm, momentum_axis, energy_axis):
         plt.imshow(plot_data, extent=extent, cmap=colourmap, aspect='auto', norm=norm,
                    interpolation='none', hold=False)
@@ -75,8 +60,8 @@ class MatplotlibSlicePlotter(SlicePlotter):
             x_axis = momentum_axis
             y_axis = energy_axis
         comment = self._slice_algorithm.getComment(str(workspace_name))
-        plt.xlabel(self._getDisplayName(x_axis.units, comment), picker=picker)
-        plt.ylabel(self._getDisplayName(y_axis.units, comment), picker=picker)
+        plt.xlabel(get_display_name(x_axis.units, comment), picker=picker)
+        plt.ylabel(get_display_name(y_axis.units, comment), picker=picker)
         plt.xlim(x_axis.start)
         plt.ylim(y_axis.start)
         plt.gcf().get_axes()[1].set_ylabel('Intensity (arb. units)', labelpad=20, rotation=270, picker=picker)


### PR DESCRIPTION
Moves axis labels and latex code into new `labels` module.

**To test:**

- check axis labels are still displayed correctly (on slices and cuts)

Fixes #293 
