### PR TITLE
Use workspace wrappers for caching parameters

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -44,12 +44,6 @@ class MainWindow(MainView, QMainWindow):
         self._presenter = MainPresenter(self, self.workspace_presenter, dataloader_presenter,
                                         slice_presenter, powder_presenter, self.cut_presenter)
 
-        workspace_provider = self.workspace_presenter.get_workspace_provider()
-        dataloader_presenter.set_workspace_provider(workspace_provider)
-        powder_presenter.set_workspace_provider(workspace_provider)
-        slice_presenter.set_workspace_provider(workspace_provider)
-        self.cut_presenter.set_workspace_provider(workspace_provider)
-
         self.wgtWorkspacemanager.tab_changed.connect(self.ws_tab_changed)
         self.setup_save()
         self.btnSave.clicked.connect(self.button_save)

--- a/mslice/cli/_mslice_commmands.py
+++ b/mslice/cli/_mslice_commmands.py
@@ -12,7 +12,7 @@ from mantid.kernel.funcinspect import lhs_info as _lhs_info
 from mantid.simpleapi import mtd, Load, ConvertUnits, RenameWorkspace # noqa: F401
 
 # Helper tools
-from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider as _MantidWorkspaceProvider
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
 from mslice.presenters.slice_plotter_presenter import Axis as _Axis
 # Projections
 from mslice.models.projection.powder.mantid_projection_calculator import MantidProjectionCalculator as _MantidProjectionCalculator
@@ -27,7 +27,6 @@ from mslice.models.cut.matplotlib_cut_plotter import MatplotlibCutPlotter
 # Module constants
 # -----------------------------------------------------------------------------
 
-_WORKSPACE_PROVIDER = _MantidWorkspaceProvider()
 _POWDER_PROJECTION_MODEL = _MantidProjectionCalculator()
 _SLICE_ALGORITHM = _MantidSliceAlgorithm()
 _SLICE_MODEL = _MatplotlibSlicePlotter(_SLICE_ALGORITHM)
@@ -118,7 +117,7 @@ def get_slice(input_workspace, x=None, y=None, ret_val='both', normalize=False):
     normalize -- if set to True the slice will be normalize to one.
 
     """
-    input_workspace = _WORKSPACE_PROVIDER.get_workspace_handle(input_workspace)
+    input_workspace = get_workspace_handle(input_workspace)
     assert isinstance(input_workspace, _IMDWorkspace)
     x_axis = _process_axis(x, 0, input_workspace)
     y_axis = _process_axis(y, 1, input_workspace)
@@ -157,7 +156,7 @@ def plot_slice(input_workspace, x=None, y=None, colormap='viridis', intensity_mi
 
     """
 
-    input_workspace = _WORKSPACE_PROVIDER.get_workspace_handle(input_workspace)
+    input_workspace = get_workspace_handle(input_workspace)
     assert isinstance(input_workspace, _IMDWorkspace)
 
     x_axis = _process_axis(x, 0, input_workspace)

--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -1,6 +1,6 @@
 from six import string_types
 import numpy as np
-from mslice.models.workspacemanager.mantid_workspace_provider import getComment
+from mslice.models.workspacemanager.mantid_workspace_provider import getComment, get_workspace_handle
 
 class AlgWorkspaceOps(object):
 
@@ -8,6 +8,7 @@ class AlgWorkspaceOps(object):
         return int(np.ceil(max(1, (axis.end - axis.start)/axis.step)))
 
     def get_axis_range(self, workspace, dimension_name):
+        workspace = get_workspace_handle(workspace)
         return tuple(workspace.limits[dimension_name])
 
     def getComment(self, workspace):
@@ -27,6 +28,7 @@ class AlgWorkspaceOps(object):
             axis.step = (axis.end - axis.start)/100
 
     def get_available_axis(self, workspace):
+        workspace = get_workspace_handle(workspace)
         if not workspace.is_PSD:
             return ['|Q|', 'Degrees', 'DeltaE']
         dim_names = []

--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -1,5 +1,5 @@
 import numpy as np
-from mslice.models.workspacemanager.mantid_workspace_provider import getComment, get_workspace_handle
+from mslice.models.workspacemanager.mantid_workspace_provider import get_comment, get_workspace_handle
 
 class AlgWorkspaceOps(object):
 
@@ -10,8 +10,8 @@ class AlgWorkspaceOps(object):
         workspace = get_workspace_handle(workspace)
         return tuple(workspace.limits[dimension_name])
 
-    def getComment(self, workspace):
-        return getComment(workspace)
+    def get_comment(self, workspace):
+        return get_comment(workspace)
 
     def _fill_in_missing_input(self,axis,workspace):
         dim = workspace.getDimensionIndexByName(axis.units)

--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -7,7 +7,7 @@ class AlgWorkspaceOps(object):
         return int(np.ceil(max(1, (axis.end - axis.start)/axis.step)))
 
     def get_axis_range(self, workspace, dimension_name):
-        return tuple(self._workspace_provider.get_limits(workspace, dimension_name))
+        return tuple(workspace.limits[dimension_name])
 
     def set_workspace_provider(self, workspace_provider):
         self._workspace_provider = workspace_provider
@@ -32,11 +32,9 @@ class AlgWorkspaceOps(object):
             axis.step = (axis.end - axis.start)/100
 
     def get_available_axis(self, workspace):
-        if not self._workspace_provider.is_PSD(workspace):
+        if not workspace.is_PSD:
             return ['|Q|', 'Degrees', 'DeltaE']
         dim_names = []
-        if isinstance(workspace, string_types):
-            workspace = self._workspace_provider.get_workspace_handle(workspace)
-        for i in range(workspace.getNumDims()):
-            dim_names.append(workspace.getDimension(i).getName())
+        for i in range(workspace.raw_ws.getNumDims()):
+            dim_names.append(workspace.raw_ws.getDimension(i).getName())
         return dim_names

--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -1,5 +1,6 @@
 from six import string_types
 import numpy as np
+from mslice.models.workspacemanager.mantid_workspace_provider import getComment
 
 class AlgWorkspaceOps(object):
 
@@ -9,14 +10,8 @@ class AlgWorkspaceOps(object):
     def get_axis_range(self, workspace, dimension_name):
         return tuple(workspace.limits[dimension_name])
 
-    def set_workspace_provider(self, workspace_provider):
-        self._workspace_provider = workspace_provider
-
-    def get_workspace_provider(self):
-        return self._workspace_provider
-
     def getComment(self, workspace):
-        return self._workspace_provider.getComment(workspace)
+        return getComment(workspace)
 
     def _fill_in_missing_input(self,axis,workspace):
         dim = workspace.getDimensionIndexByName(axis.units)

--- a/mslice/models/alg_workspace_ops.py
+++ b/mslice/models/alg_workspace_ops.py
@@ -1,4 +1,3 @@
-from six import string_types
 import numpy as np
 from mslice.models.workspacemanager.mantid_workspace_provider import getComment, get_workspace_handle
 

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -24,9 +24,6 @@ class CutAlgorithm(object):
     def get_axis_range(self, workspace, dimension_name):
         pass
 
-    def set_workspace_provider(self, workspace_provider):
-        pass
-
     def set_saved_cut_parameters(self, workspace, axis, parameters):
         pass
 

--- a/mslice/models/cut/cut_plotter.py
+++ b/mslice/models/cut/cut_plotter.py
@@ -1,6 +1,5 @@
 class CutPlotter(object):
     def __init__(self, _cut_algorithm):
-        self.workspace_provider = None
         raise Exception('This class is an interface')
 
     def plot_cut(self, selected_workspace, cut_axis, integration_axis, norm_to_one, intensity_start,

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -98,7 +98,7 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
             self._converted_nonpsd = None
         if cut_axis.units == '|Q|':
             ws_out = SofQW3(selected_workspace.raw_ws, OutputWorkspace=out_ws_name, EMode=emode,
-                   QAxisBinning=cut_binning, EAxisBinning=int_binning)
+                            QAxisBinning=cut_binning, EAxisBinning=int_binning)
             idx = 1
             unit = 'MomentumTransfer'
             name = '|Q|'
@@ -113,7 +113,7 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
             name = 'Theta'
         elif integration_units == '|Q|':
             ws_out = SofQW3(selected_workspace.raw_ws, OutputWorkspace=out_ws_name, EMode=emode,
-                   QAxisBinning=int_binning, EAxisBinning=cut_binning)
+                            QAxisBinning=int_binning, EAxisBinning=cut_binning)
             idx = 0
             unit = 'DeltaE'
             name = 'EnergyTransfer'
@@ -133,7 +133,7 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         return wrap_workspace(cut)
 
     def get_arrays_from_workspace(self, workspace):
-        mantid_ws = get_workspace_handle(workspace)
+        mantid_ws = get_workspace_handle(workspace).raw_ws
         dim = mantid_ws.getDimension(0)
         x = np.linspace(dim.getMinimum(), dim.getMaximum(), dim.getNBins())
         with np.errstate(invalid='ignore'):

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -7,6 +7,7 @@ from mantid.api import MDNormalization, IMDEventWorkspace, IMDHistoWorkspace, Wo
 
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
+from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
 
 
 def output_workspace_name(selected_workspace, integration_start, integration_end):
@@ -151,7 +152,7 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         return all_axis[0]
 
     def is_cuttable(self, workspace):
-        workspace = self._workspace_provider.get_workspace_handle(workspace)
+        workspace = loaded_workspaces[workspace]
         try:
             is2D = workspace.getNumDims() == 2
         except AttributeError:

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -2,12 +2,12 @@ from __future__ import (absolute_import, division, print_function)
 import numpy as np
 
 from mantid.simpleapi import BinMD, SofQW3, Rebin2D, ConvertSpectrumAxis, CreateMDHistoWorkspace
-from mantid.api import MDNormalization, IMDHistoWorkspace, WorkspaceUnitValidator
+from mantid.api import MDNormalization, WorkspaceUnitValidator
 
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
 from mslice.models.workspacemanager.mantid_workspace_provider import (get_workspace_handle, delete_workspace,
-                                                                      wrap_workspace)
+                                                                      wrap_workspace, workspace_exists)
 
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.workspace import Workspace as Workspace2D
@@ -169,12 +169,16 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
             return isinstance(workspace, Workspace2D) and validator.isValid(workspace.raw_ws) == ''
 
     def set_saved_cut_parameters(self, workspace, axis, parameters):
-        workspace = get_workspace_handle(workspace)
-        workspace.set_cut_params(axis, parameters)
+        if workspace_exists(workspace):
+            workspace = get_workspace_handle(workspace)
+            workspace.set_cut_params(axis, parameters)
 
-    def get_saved_cut_parameters(self, workspace, axis='previous_axis'):
+    def get_saved_cut_parameters(self, workspace, axis=None):
         try:
-            return get_workspace_handle(workspace).cut_params[axis], axis
+            workspace = get_workspace_handle(workspace)
+            if axis is None:
+                axis = workspace.cut_params['previous_axis']
+            return workspace.cut_params[axis], axis
         except KeyError:
             return None, None
 

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -1,13 +1,12 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 
-from mantid.simpleapi import BinMD, SofQW3, Rebin2D, ConvertSpectrumAxis, CreateMDHistoWorkspace
 from mantid.api import MDNormalization, WorkspaceUnitValidator
 
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
 from mslice.models.workspacemanager.mantid_workspace_provider import (get_workspace_handle, delete_workspace,
-                                                                      wrap_workspace, workspace_exists)
+                                                                      wrap_workspace, workspace_exists, run_alg)
 
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.workspace import Workspace as Workspace2D
@@ -85,9 +84,8 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         cut_binning = " ,".join(map(str, (cut_axis.units, cut_axis.start, cut_axis.end, n_steps)))
         integration_binning = integration_axis + "," + str(integration_start) + "," + str(integration_end) + ",1"
 
-        cut = BinMD(selected_workspace, OutputWorkspace=out_ws_name, AxisAligned="1",
-                    AlignedDim1=integration_binning, AlignedDim0=cut_binning, StoreInADS=False)
-        return wrap_workspace(cut, out_ws_name)
+        return run_alg('BinMD', output_name=out_ws_name, InputWorkspace=selected_workspace, AxisAligned="1",
+                    AlignedDim1=integration_binning, AlignedDim0=cut_binning)
 
     def _compute_cut_nonPSD(self, input_workspace_name, out_ws_name, selected_workspace, cut_axis,
                             integration_start, integration_end, integration_units):
@@ -97,43 +95,45 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         if self._converted_nonpsd and self._converted_nonpsd[0] != input_workspace_name:
             self._converted_nonpsd = None
         if cut_axis.units == '|Q|':
-            ws_out = SofQW3(selected_workspace.raw_ws, OutputWorkspace=out_ws_name, EMode=emode,
-                            QAxisBinning=cut_binning, EAxisBinning=int_binning, StoreInADS=False)
+            ws_out = run_alg('SofQW3', output_name=out_ws_name, store=False, InputWorkspace=selected_workspace,
+                             OutputWorkspace=out_ws_name, EMode=emode, QAxisBinning=cut_binning,
+                             EAxisBinning=int_binning)
             idx = 1
             unit = 'MomentumTransfer'
             name = '|Q|'
         elif cut_axis.units == 'Degrees':
             if not self._converted_nonpsd:
                 self._converted_nonpsd = (input_workspace_name,
-                                          ConvertSpectrumAxis(selected_workspace.raw_ws, Target='theta',
-                                                              OutputWorkspace='__convToTheta', StoreInADS=False))
-            ws_out = Rebin2D(self._converted_nonpsd[1], OutputWorkspace=out_ws_name, Axis1Binning=int_binning,
-                             Axis2Binning=cut_binning, StoreInADS=False)
+                                          run_alg('ConvertSpectrumAxis', output_name='__convToTheta', store=False,
+                                                  InputWorkspace=selected_workspace, Target='theta'))
+            ws_out = run_alg('Rebin2D', output_name=out_ws_name, store=False, InputWorkspace=self._converted_nonpsd[1],
+                             Axis1Binning=int_binning, Axis2Binning=cut_binning)
             idx = 1
             unit = 'Degrees'
             name = 'Theta'
         elif integration_units == '|Q|':
-            ws_out = SofQW3(selected_workspace.raw_ws, OutputWorkspace=out_ws_name, EMode=emode,
-                            QAxisBinning=int_binning, EAxisBinning=cut_binning, StoreInADS=False)
+            ws_out = run_alg('SofQW3', output_name=out_ws_name, store=False, InputWorkspace=selected_workspace,
+                             OutputWorkspace=out_ws_name, EMode=emode,QAxisBinning=int_binning,
+                             EAxisBinning=cut_binning)
             idx = 0
             unit = 'DeltaE'
             name = 'EnergyTransfer'
         else:
             if not self._converted_nonpsd:
                 self._converted_nonpsd = (input_workspace_name,
-                                          ConvertSpectrumAxis(selected_workspace.raw_ws, Target='theta',
-                                                              OutputWorkspace='__convToTheta', StoreInADS=False))
-            ws_out = Rebin2D(self._converted_nonpsd[1], OutputWorkspace=out_ws_name, Axis1Binning=cut_binning,
-                             Axis2Binning=int_binning, StoreInADS=False)
+                                          run_alg('ConvertSpectrumAxis', output_name='__convToTheta', store=False,
+                                                  InputWorkspace=selected_workspace, Target='theta',
+                                                  OutputWorkspace='__convToTheta'))
+            ws_out = run_alg('Rebin2D', output_name=out_ws_name, InputWorkspace=self._converted_nonpsd[1],
+                             Axis1Binning=cut_binning, Axis2Binning=int_binning)
             idx = 0
             unit = 'DeltaE'
             name = 'EnergyTransfer'
         xdim = ws_out.getDimension(idx)
         extents = " ,".join(map(str, (xdim.getMinimum(), xdim.getMaximum())))
-        cut = CreateMDHistoWorkspace(OutputWorkspace=out_ws_name, SignalInput=ws_out.extractY(),
+        return run_alg('CreateMDHistoWorkspace', output_name=out_ws_name, SignalInput=ws_out.extractY(),
                                      ErrorInput=ws_out.extractE(), Dimensionality=1, Extents=extents,
-                                     NumberOfBins=xdim.getNBins(), Names=name, Units=unit, StoreInADS=False)
-        return wrap_workspace(cut, out_ws_name)
+                                     NumberOfBins=xdim.getNBins(), Names=name, Units=unit)
 
     def get_arrays_from_workspace(self, workspace):
         mantid_ws = get_workspace_handle(workspace).raw_ws

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -7,7 +7,6 @@ from mantid.api import MDNormalization, IMDEventWorkspace, IMDHistoWorkspace, Wo
 
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
-from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 
 def output_workspace_name(selected_workspace, integration_start, integration_end):
@@ -17,7 +16,6 @@ def output_workspace_name(selected_workspace, integration_start, integration_end
 
 class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
     def __init__(self):
-        self._workspace_provider = MantidWorkspaceProvider()
         self._converted_nonpsd = None   # Cache for ConvertSpectrumAxis for non-PSD data.
 
     def compute_cut_xye(self, selected_workspace, cut_axis, integration_axis, is_norm):

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -7,7 +7,7 @@ from mantid.api import MDNormalization, IMDEventWorkspace, IMDHistoWorkspace, Wo
 
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
-from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
 
 
 def output_workspace_name(selected_workspace, integration_start, integration_end):
@@ -152,7 +152,7 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         return all_axis[0]
 
     def is_cuttable(self, workspace):
-        workspace = loaded_workspaces[workspace]
+        workspace = get_workspace_handle(workspace)
         try:
             is2D = workspace.getNumDims() == 2
         except AttributeError:

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -232,6 +232,3 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         errors = workspace.get_variance() / (average_event_range**2)
         workspace.raw_ws.setErrorSquaredArray(errors)
         workspace.raw_ws.setComment("Normalized By MSlice")
-
-    def _was_previously_normalized(self, workspace):
-        return workspace.getComment() == "Normalized By MSlice"

--- a/mslice/models/cut/mantid_cut_algorithm.py
+++ b/mslice/models/cut/mantid_cut_algorithm.py
@@ -6,7 +6,7 @@ from mantid.api import MDNormalization, WorkspaceUnitValidator
 from .cut_algorithm import CutAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
 from mslice.models.workspacemanager.mantid_workspace_provider import (get_workspace_handle, delete_workspace,
-                                                                      wrap_workspace, workspace_exists, run_alg)
+                                                                      workspace_exists, run_alg)
 
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.workspace import Workspace as Workspace2D
@@ -85,7 +85,7 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         integration_binning = integration_axis + "," + str(integration_start) + "," + str(integration_end) + ",1"
 
         return run_alg('BinMD', output_name=out_ws_name, InputWorkspace=selected_workspace, AxisAligned="1",
-                    AlignedDim1=integration_binning, AlignedDim0=cut_binning)
+                       AlignedDim1=integration_binning, AlignedDim0=cut_binning)
 
     def _compute_cut_nonPSD(self, input_workspace_name, out_ws_name, selected_workspace, cut_axis,
                             integration_start, integration_end, integration_units):
@@ -132,8 +132,8 @@ class MantidCutAlgorithm(AlgWorkspaceOps, CutAlgorithm):
         xdim = ws_out.getDimension(idx)
         extents = " ,".join(map(str, (xdim.getMinimum(), xdim.getMaximum())))
         return run_alg('CreateMDHistoWorkspace', output_name=out_ws_name, SignalInput=ws_out.extractY(),
-                                     ErrorInput=ws_out.extractE(), Dimensionality=1, Extents=extents,
-                                     NumberOfBins=xdim.getNBins(), Names=name, Units=unit)
+                       ErrorInput=ws_out.extractE(), Dimensionality=1, Extents=extents,
+                       NumberOfBins=xdim.getNBins(), Names=name, Units=unit)
 
     def get_arrays_from_workspace(self, workspace):
         mantid_ws = get_workspace_handle(workspace).raw_ws

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -9,7 +9,6 @@ picker=3
 class MatplotlibCutPlotter(CutPlotter):
     def __init__(self, cut_algorithm):
         self._cut_algorithm = cut_algorithm
-        self.workspace_provider = None
         self.icut = None
 
     def plot_cut(self, selected_workspace, cut_axis, integration_axis, norm_to_one, intensity_start,
@@ -72,8 +71,3 @@ class MatplotlibCutPlotter(CutPlotter):
 
     def save_cut(self, params):
         return self._cut_algorithm.compute_cut(*params)
-
-
-    def set_workspace_provider(self, workspace_provider):
-        self.workspace_provider = workspace_provider
-        self._cut_algorithm.set_workspace_provider(workspace_provider)

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import mslice.plotting.pyplot as plt
 from .cut_plotter import CutPlotter
 from .mantid_cut_algorithm import output_workspace_name
+from mslice.models.workspacemanager.mantid_workspace_provider import get_comment
 from ..labels import get_display_name, generate_legend, CUT_INTENSITY_LABEL
 
 picker=3
@@ -28,7 +29,7 @@ class MatplotlibCutPlotter(CutPlotter):
         plt.ylim(*intensity_range) if intensity_range is not None else plt.autoscale()
         leg = plt.legend(fontsize='medium')
         leg.draggable()
-        plt.xlabel(get_display_name(x_units, self._cut_algorithm.getComment(selected_workspace)), picker=picker)
+        plt.xlabel(get_display_name(x_units, get_comment(selected_workspace)), picker=picker)
         plt.ylabel(CUT_INTENSITY_LABEL, picker=picker)
         if not plot_over:
             plt.gcf().canvas.set_window_title('Cut: ' + selected_workspace)

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -30,7 +30,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
         dim1 = dim1.getName() + ',' + str(dim1.getMinimum()) + ',' +\
             str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
         return run_alg('SliceMD', output_name=output_workspace, store=False, InputWorkspace=output_workspace,
-                       AlignedDim0=dim0, AlignedDim1=dim1, StoreInADS=False)
+                       AlignedDim0=dim0, AlignedDim1=dim1)
 
     def _getDetWS(self, input_workspace):
         """ Precalculates the detector workspace for ConvertToMD - workaround for bug for indirect geometry """

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -4,7 +4,6 @@ from mantid.simpleapi import ConvertToMD, SliceMD, TransformMD, ConvertSpectrumA
 from mantid.simpleapi import RenameWorkspace, DeleteWorkspace, SofQW3
 
 from mslice.models.projection.powder.projection_calculator import ProjectionCalculator
-from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 # unit labels
 MOD_Q_LABEL = '|Q|'
@@ -14,8 +13,6 @@ MEV_LABEL = 'meV'
 WAVENUMBER_LABEL = 'cm-1'
 
 class MantidProjectionCalculator(ProjectionCalculator):
-    def __init__(self):
-        self._workspace_provider = MantidWorkspaceProvider()
 
     def available_axes(self):
         return [MOD_Q_LABEL, THETA_LABEL, DELTA_E_LABEL]

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -42,11 +42,11 @@ class MantidProjectionCalculator(ProjectionCalculator):
     def _calcQEproj(self, input_workspace_name, emode, axis1, axis2):
         """ Carries out either the Q-E or E-Q projections """
         input_workspace = get_workspace_handle(input_workspace_name)
-        output_workspace = input_workspace + ('_QE' if axis1 == MOD_Q_LABEL else '_EQ')
+        output_workspace = input_workspace_name + ('_QE' if axis1 == MOD_Q_LABEL else '_EQ')
         # For indirect geometry and large datafiles (likely to be using a 1-to-1 mapping use ConvertToMD('|Q|')
         numSpectra = input_workspace.raw_ws.getNumberHistograms()
         if emode == 'Indirect' or numSpectra > 1000:
-            retval = ConvertToMD(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
+            retval = ConvertToMD(InputWorkspace=input_workspace.raw_ws, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
                                  PreprocDetectorsWS='-', dEAnalysisMode=emode)
             if axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
                 retval = self._flip_axes(output_workspace)
@@ -54,7 +54,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
         else:
             limits = input_workspace.limits['Momentum Transfer']
             limits = ','.join([str(limits[i]) for i in [0, 2, 1]])
-            SofQW3(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, QAxisBinning=limits, Emode=emode)
+            SofQW3(InputWorkspace=input_workspace.raw_ws, OutputWorkspace=output_workspace, QAxisBinning=limits, Emode=emode)
             retval = ConvertToMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, QDimensions='CopyToMD',
                                  PreprocDetectorsWS='-', dEAnalysisMode=emode)
             if axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL:
@@ -65,7 +65,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
         """ Carries out either the 2Theta-E or E-2Theta projections """
         input_workspace = get_workspace_handle(input_workspace_name)
         output_workspace = input_workspace_name + ('_ThE' if axis1 == THETA_LABEL else '_ETh')
-        ConvertSpectrumAxis(InputWorkspace=input_workspace, OutputWorkspace=output_workspace, Target='Theta')
+        ConvertSpectrumAxis(InputWorkspace=input_workspace.raw_ws, OutputWorkspace=output_workspace, Target='Theta')
         # Work-around for a bug in ConvertToMD.
         wsdet = self._getDetWS(input_workspace) if emode == 'Indirect' else '-'
         retval = ConvertToMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, QDimensions='CopyToMD',
@@ -84,22 +84,21 @@ class MantidProjectionCalculator(ProjectionCalculator):
         emode = input_workspace.e_mode
         # Calculates the projection - can have Q-E or 2theta-E or their transpose.
         if (axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL) or (axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL):
-            retval, output_workspace = self._calcQEproj(input_workspace_name, emode, axis1, axis2)
+            new_ws, output_workspace = self._calcQEproj(input_workspace_name, emode, axis1, axis2)
         elif (axis1 == THETA_LABEL and axis2 == DELTA_E_LABEL) or (axis1 == DELTA_E_LABEL and axis2 == THETA_LABEL):
-            retval, output_workspace = self._calcThetaEproj(input_workspace_name, emode, axis1, axis2)
+            new_ws, output_workspace = self._calcThetaEproj(input_workspace_name, emode, axis1, axis2)
         else:
             raise NotImplementedError("Not implemented axis1 = %s and axis2 = %s" % (axis1, axis2))
         # Now scale the energy axis if required - ConvertToMD always gives DeltaE in meV
         if units == WAVENUMBER_LABEL:
             scale = [1, 8.06554] if axis2 == DELTA_E_LABEL else [8.06544, 1]
-            retval = TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
-            retval = RenameWorkspace(InputWorkspace=output_workspace, OutputWorkspace=output_workspace+'_cm')
-            retval.setComment('MSlice_in_wavenumber')
+            new_ws = TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale)
+            new_ws = RenameWorkspace(InputWorkspace=output_workspace, OutputWorkspace=output_workspace+'_cm')
+            new_ws.setComment('MSlice_in_wavenumber')
             output_workspace += '_cm'
         elif units != MEV_LABEL:
             raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))
-        propagate_properties(input_workspace, output_workspace)
-        return retval
+        return propagate_properties(input_workspace, new_ws)
 
     def validate_workspace(self, ws):
         workspace = get_workspace_handle(ws)

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -1,8 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 import uuid
-from mantid.simpleapi import ConvertToMD, SliceMD, TransformMD, ConvertSpectrumAxis, PreprocessDetectorsToMD
-from mantid.simpleapi import RenameWorkspace, DeleteWorkspace, SofQW3
-from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle, propagate_properties
+from mantid.simpleapi import DeleteWorkspace
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle, propagate_properties, run_alg
 from mslice.models.projection.powder.projection_calculator import ProjectionCalculator
 
 # unit labels
@@ -30,13 +29,13 @@ class MantidProjectionCalculator(ProjectionCalculator):
             str(dim0.getMaximum()) + ',' + str(dim0.getNBins())
         dim1 = dim1.getName() + ',' + str(dim1.getMinimum()) + ',' +\
             str(dim1.getMaximum()) + ',' + str(dim1.getNBins())
-        return SliceMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, AlignedDim0=dim0,
-                       AlignedDim1=dim1, StoreInADS=False)
+        return run_alg('SliceMD', output_name=output_workspace, store=False, InputWorkspace=output_workspace,
+                       AlignedDim0=dim0, AlignedDim1=dim1, StoreInADS=False)
 
     def _getDetWS(self, input_workspace):
         """ Precalculates the detector workspace for ConvertToMD - workaround for bug for indirect geometry """
         wsdet = str(uuid.uuid4().hex)
-        PreprocessDetectorsToMD(InputWorkspace=input_workspace, OutputWorkspace=wsdet)
+        wsdet = run_alg('PreprocessDetectorsToMD', output_name=wsdet, store=False, InputWorkspace=input_workspace)
         return wsdet
 
     def _calcQEproj(self, input_workspace_name, emode, axis1, axis2):
@@ -46,18 +45,18 @@ class MantidProjectionCalculator(ProjectionCalculator):
         # For indirect geometry and large datafiles (likely to be using a 1-to-1 mapping use ConvertToMD('|Q|')
         numSpectra = input_workspace.raw_ws.getNumberHistograms()
         if emode == 'Indirect' or numSpectra > 1000:
-            retval = ConvertToMD(InputWorkspace=input_workspace.raw_ws, OutputWorkspace=output_workspace, QDimensions=MOD_Q_LABEL,
-                                 PreprocDetectorsWS='-', dEAnalysisMode=emode, StoreInADS=False)
+            retval = run_alg('ConvertToMD', output_name=output_workspace, InputWorkspace=input_workspace,
+                             QDimensions=MOD_Q_LABEL, PreprocDetectorsWS='-', dEAnalysisMode=emode)
             if axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
                 retval = self._flip_axes(output_workspace)
         # Otherwise first run SofQW3 to rebin it in |Q| properly before calling ConvertToMD with CopyToMD
         else:
             limits = input_workspace.limits['Momentum Transfer']
             limits = ','.join([str(limits[i]) for i in [0, 2, 1]])
-            SofQW3(InputWorkspace=input_workspace.raw_ws, OutputWorkspace=output_workspace, QAxisBinning=limits,
-                   Emode=emode, StoreInADS=False)
-            retval = ConvertToMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, QDimensions='CopyToMD',
-                                 PreprocDetectorsWS='-', dEAnalysisMode=emode, StoreInADS=False)
+            retval = run_alg('SofQW3', output_name=output_workspace, store=False, InputWorkspace=input_workspace.raw_ws,
+                             QAxisBinning=limits, Emode=emode)
+            retval = run_alg('ConvertToMD', output_name=output_workspace, InputWorkspace=retval, QDimensions='CopyToMD',
+                                 PreprocDetectorsWS='-', dEAnalysisMode=emode)
             if axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL:
                 retval = self._flip_axes(retval)
         return retval, output_workspace
@@ -66,12 +65,12 @@ class MantidProjectionCalculator(ProjectionCalculator):
         """ Carries out either the 2Theta-E or E-2Theta projections """
         input_workspace = get_workspace_handle(input_workspace_name)
         output_workspace = input_workspace_name + ('_ThE' if axis1 == THETA_LABEL else '_ETh')
-        ConvertSpectrumAxis(InputWorkspace=input_workspace.raw_ws, OutputWorkspace=output_workspace,
-                            Target='Theta', StoreInADS=False)
+        retval = run_alg('ConvertSpectrumAxis', output_name=output_workspace, store=False,
+                         InputWorkspace=input_workspace, Target='Theta')
         # Work-around for a bug in ConvertToMD.
         wsdet = self._getDetWS(input_workspace) if emode == 'Indirect' else '-'
-        retval = ConvertToMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, QDimensions='CopyToMD',
-                             PreprocDetectorsWS=wsdet, dEAnalysisMode=emode, StoreInADS=False)
+        retval = run_alg('ConvertToMD', output_name=output_workspace, InputWorkspace=output_workspace,
+                         QDimensions='CopyToMD', PreprocDetectorsWS=wsdet, dEAnalysisMode=emode)
         if emode == 'Indirect':
             DeleteWorkspace(wsdet)
         if axis1 == THETA_LABEL and axis2 == DELTA_E_LABEL:
@@ -94,12 +93,13 @@ class MantidProjectionCalculator(ProjectionCalculator):
         # Now scale the energy axis if required - ConvertToMD always gives DeltaE in meV
         if units == WAVENUMBER_LABEL:
             scale = [1, 8.06554] if axis2 == DELTA_E_LABEL else [8.06544, 1]
-            new_ws = TransformMD(InputWorkspace=output_workspace, OutputWorkspace=output_workspace, Scaling=scale, StoreInADS=False)
+            new_ws = run_alg('TransformMD', output_name=output_workspace, InputWorkspace=new_ws, Scaling=scale)
             new_ws.setComment('MSlice_in_wavenumber')
             output_workspace += '_cm'
         elif units != MEV_LABEL:
             raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))
-        return propagate_properties(input_workspace, new_ws, output_workspace)
+        propagate_properties(input_workspace, new_ws)
+        return new_ws
 
     def validate_workspace(self, ws):
         workspace = get_workspace_handle(ws)

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -56,7 +56,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
             retval = run_alg('SofQW3', output_name=output_workspace, store=False, InputWorkspace=input_workspace.raw_ws,
                              QAxisBinning=limits, Emode=emode)
             retval = run_alg('ConvertToMD', output_name=output_workspace, InputWorkspace=retval, QDimensions='CopyToMD',
-                                 PreprocDetectorsWS='-', dEAnalysisMode=emode)
+                             PreprocDetectorsWS='-', dEAnalysisMode=emode)
             if axis1 == MOD_Q_LABEL and axis2 == DELTA_E_LABEL:
                 retval = self._flip_axes(retval)
         return retval, output_workspace

--- a/mslice/models/projection/powder/projection_calculator.py
+++ b/mslice/models/projection/powder/projection_calculator.py
@@ -13,6 +13,3 @@ class ProjectionCalculator(object):
     @abc.abstractmethod
     def calculate_projection(self, input_workspace, axis1, axis2, units):
         pass
-
-    def set_workspace_provider(self, workspace_provider):
-        raise NotImplementedError("This method must be implemented in a concrete view before being called")

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -4,12 +4,14 @@ import numpy as np
 
 from mantid.simpleapi import BinMD, LoadCIF, SofQW3, ConvertSpectrumAxis, Rebin2D
 from mantid.api import IMDEventWorkspace, MDNormalization, WorkspaceUnitValidator
-from mantid.dataobjects import Workspace2D
 from mantid.geometry import CrystalStructure, ReflectionGenerator, ReflectionConditionFilter
 from scipy import constants
 
 from .slice_algorithm import SliceAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
+from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
+from mslice.workspace.pixel_workspace import PixelWorkspace
+from mslice.workspace.workspace import Workspace
 
 KB_MEV = constants.value('Boltzmann constant in eV/K') * 1000
 E_TO_K = np.sqrt(2 * constants.neutron_mass * constants.elementary_charge / 1000) / constants.hbar
@@ -285,9 +287,9 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         return (data - np.nanmin(data))/data_range
 
     def is_sliceable(self, workspace):
-        workspace = self._workspace_provider.get_workspace_handle(workspace)
-        if isinstance(workspace, IMDEventWorkspace):
+        ws = loaded_workspaces[workspace]
+        if isinstance(ws, PixelWorkspace):
             return True
         else:
             validator = WorkspaceUnitValidator('DeltaE')
-            return isinstance(workspace, Workspace2D) and validator.isValid(workspace) == ''
+            return isinstance(ws, Workspace) and validator.isValid(ws.raw_ws) == ''

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -10,7 +10,6 @@ from scipy import constants
 
 from .slice_algorithm import SliceAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
-from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 
 KB_MEV = constants.value('Boltzmann constant in eV/K') * 1000
 E_TO_K = np.sqrt(2 * constants.neutron_mass * constants.elementary_charge / 1000) / constants.hbar
@@ -22,8 +21,6 @@ crystal_structure = {'Copper': ['3.6149 3.6149 3.6149', 'F m -3 m', 'Cu 0 0 0 1.
 
 
 class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
-    def __init__(self):
-        self._workspace_provider = MantidWorkspaceProvider()
 
     def compute_slice(self, selected_workspace, x_axis, y_axis, norm_to_one):
         workspace = self._workspace_provider.get_workspace_handle(selected_workspace)

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -261,7 +261,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
 
     def _crystal_structure(self, ws_name, element, cif_file):
         if cif_file:
-            ws = get_workspace_handle(ws_name)
+            ws = get_workspace_handle(ws_name).raw_ws
             LoadCIF(ws, cif_file)
             return ws.sample().getCrystalStructure()
         else:

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -55,6 +55,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         thisslice = run_alg('BinMD', output_name='__' + ws_name, InputWorkspace=raw_ws, AxisAligned="1",
                             AlignedDim0=xbinning, AlignedDim1=ybinning)
         propagate_properties(workspace, thisslice)
+        thisslice = thisslice.raw_ws
         # perform number of events normalization
         with np.errstate(invalid='ignore'):
             if thisslice.displayNormalization() == MDNormalization.NoNormalization:

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -9,7 +9,7 @@ from scipy import constants
 
 from .slice_algorithm import SliceAlgorithm
 from mslice.models.alg_workspace_ops import AlgWorkspaceOps
-from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.workspace import Workspace
 
@@ -287,7 +287,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         return (data - np.nanmin(data))/data_range
 
     def is_sliceable(self, workspace):
-        ws = loaded_workspaces[workspace]
+        ws = get_workspace_handle(workspace)
         if isinstance(ws, PixelWorkspace):
             return True
         else:

--- a/mslice/models/slice/mantid_slice_algorithm.py
+++ b/mslice/models/slice/mantid_slice_algorithm.py
@@ -190,7 +190,7 @@ class MantidSliceAlgorithm(AlgWorkspaceOps, SliceAlgorithm):
         return gdos
 
     def sample_temperature(self, ws_name, sample_temp_fields):
-        ws = get_workspace_handle(ws_name)
+        ws = get_workspace_handle(ws_name).raw_ws
         sample_temp = None
         for field_name in sample_temp_fields:
             try:

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -20,7 +20,6 @@ class MatplotlibSlicePlotter(SlicePlotter):
         self.slice_cache = {}
         self._sample_temp_fields = []
         self.overplot_lines = {}
-        self.workspace_provider = None
 
     def plot_slice(self, selected_ws, x_axis, y_axis, smoothing, intensity_start, intensity_end, norm_to_one,
                    colourmap):
@@ -209,10 +208,3 @@ class MatplotlibSlicePlotter(SlicePlotter):
 
     def update_displayed_workspaces(self):
         self.listener.update_workspaces()
-
-    def set_workspace_provider(self, workspace_provider):
-        self.workspace_provider = workspace_provider
-        self._slice_algorithm.set_workspace_provider(workspace_provider)
-
-    def get_workspace_provider(self):
-        return self._slice_algorithm.get_workspace_provider()

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -3,6 +3,7 @@ from matplotlib.colors import Normalize
 from .slice_plotter import SlicePlotter
 import mslice.plotting.pyplot as plt
 from mslice.util import MPL_COMPAT
+from mslice.models.workspacemanager.mantid_workspace_provider import get_comment
 from ..labels import get_display_name, recoil_labels
 
 overplot_colors={1:'b', 2:'g', 4:'r', 'Aluminium': 'g', 'Copper':'m', 'Niobium':'y', 'Tantalum':'b'}
@@ -58,7 +59,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
         else:
             x_axis = momentum_axis
             y_axis = energy_axis
-        comment = self._slice_algorithm.getComment(str(workspace_name))
+        comment = get_comment(str(workspace_name))
         plt.xlabel(get_display_name(x_axis.units, comment), picker=picker)
         plt.ylabel(get_display_name(y_axis.units, comment), picker=picker)
         plt.xlim(x_axis.start)

--- a/mslice/models/slice/matplotlib_slice_plotter.py
+++ b/mslice/models/slice/matplotlib_slice_plotter.py
@@ -90,7 +90,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
 
     def show_d2sigma(self, workspace):
         cached_slice = self.slice_cache[workspace]
-        if cached_slice['plot_data'][2] is None:
+        if cached_slice['plot_data'][3] is None:
             self.compute_d2sigma(workspace)
         self._show_plot(workspace, cached_slice['plot_data'][3], cached_slice['boundaries'], cached_slice['colourmap'],
                         cached_slice['norm'], cached_slice['momentum_axis'], cached_slice['energy_axis'])
@@ -110,7 +110,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
                         cached_slice['norm'], cached_slice['momentum_axis'], cached_slice['energy_axis'])
 
     def add_overplot_line(self, workspace, key, recoil, extra_info):
-        if recoil: # key is relative mass
+        if recoil:  # key is relative mass
             label = recoil_labels[key] if key in recoil_labels else \
                 'Relative mass ' + str(key)
         else:  # key is element name
@@ -119,7 +119,7 @@ class MatplotlibSlicePlotter(SlicePlotter):
             line = self.overplot_lines[workspace][key]
             line.set_linestyle('-')  # make visible
             line.set_label(label)  # add to legend
-            line.set_markersize(6) # show markers - 6.0 is default size
+            line.set_markersize(6)  # show markers - 6.0 is default size
             if line not in plt.gca().get_children():
                 plt.gca().add_artist(line)
         else:

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -8,6 +8,3 @@ class SliceAlgorithm(object):
 
     def get_available_axis(self, workspace):
         pass
-
-    def set_workspace_provider(self, workspace_provider):
-        pass

--- a/mslice/models/slice/slice_plotter.py
+++ b/mslice/models/slice/slice_plotter.py
@@ -13,9 +13,6 @@ class SlicePlotter():
     def get_axis_range(self, workspace, dimension_name):
         pass
 
-    def set_workspace_provider(self, workspace_provider):
-        pass
-
     def sample_temperature(self, ws_name):
         pass
 

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import os.path
-from mantid.api import IMDHistoWorkspace, MDNormalization
+from mantid.api import MDNormalization
 from mantid.simpleapi import CreateMDHistoWorkspace, SaveMD, SaveNexus, SaveAscii
 from mslice.util.qt.QtWidgets import QFileDialog
 from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -3,6 +3,8 @@ import os.path
 from mantid.api import IMDHistoWorkspace, MDNormalization
 from mantid.simpleapi import CreateMDHistoWorkspace, SaveMD, SaveNexus, SaveAscii
 from mslice.util.qt.QtWidgets import QFileDialog
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
+from mslice.workspace.histogram_workspace import HistogramWorkspace
 
 import numpy as np
 from scipy.io import savemat
@@ -42,40 +44,40 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
 
 
 def save_nexus(workspace, path, is_slice):
-    if isinstance(workspace, IMDHistoWorkspace):
+    if isinstance(workspace, HistogramWorkspace):
         if is_slice:
-            SaveMD(InputWorkspace=workspace.name()[2:], Filename=path)
+            SaveMD(InputWorkspace=get_workspace_handle(workspace.raw_ws.name()[2:]), Filename=path)
         else:
-            SaveMD(InputWorkspace=workspace.name(), Filename=path)
+            SaveMD(InputWorkspace=workspace.raw_ws, Filename=path)
     else:
-        SaveNexus(InputWorkspace=workspace.name(), Filename=path)
+        SaveNexus(InputWorkspace=workspace.raw_ws, Filename=path)
 
 
 def save_ascii(workspace, path, is_slice):
-    if isinstance(workspace, IMDHistoWorkspace):
+    if isinstance(workspace, HistogramWorkspace):
         if is_slice:
-            _save_slice_to_ascii(workspace, path)
+            _save_slice_to_ascii(workspace.raw_ws, path)
         else:
-            _save_cut_to_ascii(workspace, workspace.name(), path)
+            _save_cut_to_ascii(workspace.raw_ws, workspace.raw_ws.name(), path)
     else:
-        SaveAscii(InputWorkspace=workspace, Filename=path)
+        SaveAscii(InputWorkspace=workspace.raw_ws, Filename=path)
 
 
 def save_matlab(workspace, path, is_slice):
-    if isinstance(workspace, IMDHistoWorkspace):
+    if isinstance(workspace, HistogramWorkspace):
         if is_slice:
-            x, y, e = _get_slice_mdhisto_xye(workspace)
+            x, y, e = _get_slice_mdhisto_xye(workspace.raw_ws)
         else:
-            x, y, e = _get_md_histo_xye(workspace)
+            x, y, e = _get_md_histo_xye(workspace.raw_ws)
     else:
         if is_slice:
             x = []
-            for dim in [workspace.getDimension(i) for i in range(2)]:
+            for dim in [workspace.raw_ws.getDimension(i) for i in range(2)]:
                 x.append(np.linspace(dim.getMinimum(), dim.getMaximum(), dim.getNBins()))
         else:
-            x = workspace.extractX()
-        y = workspace.extractY()
-        e = workspace.extractE()
+            x = workspace.raw_ws.extractX()
+        y = workspace.raw_ws.extractY()
+        e = workspace.raw_ws.extractE()
     mdict = {'x': x, 'y': y, 'e': e}
     savemat(path, mdict=mdict)
 
@@ -87,19 +89,19 @@ def _save_cut_to_ascii(workspace, ws_name, output_path):
     int_end = int_ranges[int_ranges.find(',')+1:-1]
     ws_name = ws_name[:ws_name.find('_cut')]
 
-    dim = workspace.getDimension(0)
+    dim = workspace.raw_ws.getDimension(0)
     units = dim.getUnits()
 
-    x, y, e = _get_md_histo_xye(workspace)
+    x, y, e = _get_md_histo_xye(workspace.raw_ws)
     header = 'MSlice Cut of workspace "%s" along "%s" between %s and %s' % (ws_name, units, int_start, int_end)
     out_data = np.c_[x, y, e]
     _output_data_to_ascii(output_path, out_data, header)
 
 
 def _save_slice_to_ascii(workspace, output_path):
-    header = 'MSlice Slice of workspace "%s"' % (workspace.name())
-    x, y, e = _get_slice_mdhisto_xye(workspace)
-    dim_sz = [workspace.getDimension(i).getNBins() for i in range(workspace.getNumDims())]
+    header = 'MSlice Slice of workspace "%s"' % (workspace.raw_ws.name())
+    x, y, e = _get_slice_mdhisto_xye(workspace.raw_ws)
+    dim_sz = [workspace.raw_ws.getDimension(i).getNBins() for i in range(workspace.raw_ws.getNumDims())]
     nbins = np.prod(dim_sz)
     x = [np.reshape(x0, nbins) for x0 in np.broadcast_arrays(*x)]
     y = np.reshape(y, nbins)

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -1,9 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 import os.path
 from mantid.api import MDNormalization
-from mantid.simpleapi import CreateMDHistoWorkspace, SaveMD, SaveNexus, SaveAscii
 from mslice.util.qt.QtWidgets import QFileDialog
-from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle, run_alg
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 
 import numpy as np
@@ -46,21 +45,21 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
 def save_nexus(workspace, path, is_slice):
     if isinstance(workspace, HistogramWorkspace):
         if is_slice:
-            SaveMD(InputWorkspace=get_workspace_handle(workspace.raw_ws.name()[2:]), Filename=path)
+            run_alg('SaveMD', InputWorkspace=get_workspace_handle(workspace.name[2:]), Filename=path)
         else:
-            SaveMD(InputWorkspace=workspace.raw_ws, Filename=path)
+            run_alg('SaveMD', InputWorkspace=workspace, Filename=path)
     else:
-        SaveNexus(InputWorkspace=workspace.raw_ws, Filename=path)
+        run_alg('SaveNexus', InputWorkspace=workspace, Filename=path)
 
 
 def save_ascii(workspace, path, is_slice):
     if isinstance(workspace, HistogramWorkspace):
         if is_slice:
-            _save_slice_to_ascii(workspace.raw_ws, path)
+            _save_slice_to_ascii(workspace, path)
         else:
-            _save_cut_to_ascii(workspace.raw_ws, workspace.raw_ws.name(), path)
+            _save_cut_to_ascii(workspace, workspace.name, path)
     else:
-        SaveAscii(InputWorkspace=workspace.raw_ws, Filename=path)
+        run_alg('SaveAscii', InputWorkspace=workspace, Filename=path)
 
 
 def save_matlab(workspace, path, is_slice):
@@ -99,7 +98,7 @@ def _save_cut_to_ascii(workspace, ws_name, output_path):
 
 
 def _save_slice_to_ascii(workspace, output_path):
-    header = 'MSlice Slice of workspace "%s"' % (workspace.raw_ws.name())
+    header = 'MSlice Slice of workspace "%s"' % (workspace.name)
     x, y, e = _get_slice_mdhisto_xye(workspace.raw_ws)
     dim_sz = [workspace.raw_ws.getDimension(i).getNBins() for i in range(workspace.raw_ws.getNumDims())]
     nbins = np.prod(dim_sz)
@@ -119,8 +118,8 @@ def load_from_ascii(file_path, ws_name):
     extents = str(np.min(x)) + ',' + str(np.max(x))
     nbins = len(x)
     units = header[header.find('along "'):header.find('" between')]
-    CreateMDHistoWorkspace(SignalInput=y, ErrorInput=e, Dimensionality=1, Extents=extents, NumberOfBins=nbins,
-                           Names='Dim1', Units=units, OutputWorkspace=ws_name, StoreInADS=False)
+    run_alg('CreateMDHistoWorkspace', output_name=ws_name, SignalInput=y, ErrorInput=e, Dimensionality=1,
+            Extents=extents, NumberOfBins=nbins, Names='Dim1', Units=units)
 
 
 def _get_md_histo_xye(histo_ws):

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -8,12 +8,16 @@ It uses mantid to perform the workspace operations
 from __future__ import (absolute_import, division, print_function)
 import os.path
 from six import string_types
+from mantid.api import IMDEventWorkspace, IMDHistoWorkspace
 
 from mantid.simpleapi import (AnalysisDataService, DeleteWorkspace, Load, Scale,
                               RenameWorkspace, MergeMD, MergeRuns, Minus)
 
 from mslice.presenters.slice_plotter_presenter import Axis
-from mantid.api import IMDEventWorkspace, MatrixWorkspace, Workspace
+from mslice.workspace.base import WorkspaceBase as Workspace
+from mslice.workspace.workspace import Workspace as MatrixWorkspace
+from mslice.workspace.pixel_workspace import PixelWorkspace
+from mslice.workspace.histogram_workspace import HistogramWorkspace
 from .file_io import save_ascii, save_matlab, save_nexus
 import numpy as np
 from scipy import constants
@@ -29,375 +33,375 @@ E2q = 2. * constants.m_n / (constants.hbar ** 2)  # Energy to (neutron momentum)
 meV2J = constants.e / 1000.  # meV to Joules
 m2A = 1.e10  # metres to Angstrom
 
+loaded_workspaces = {}
 
-class MantidWorkspaceProvider(WorkspaceProvider):
-    def __init__(self):
-        # Stores various parameters of workspaces not stored by Mantid
-        self._EfDefined = {}
-        self._limits = {}
-        self._cutParameters = {}
-        self._isPSD = {}
 
-    def get_workspace_handle(self, workspace_name):
-        """"Return handle to workspace given workspace_name_as_string"""
-        # if passed a workspace handle return the handle
-        if isinstance(workspace_name, Workspace):
-            return workspace_name
-        return AnalysisDataService[str(workspace_name)]
+def get_workspace_handle(self, workspace_name):
+    """"Return handle to workspace given workspace_name_as_string"""
+    # if passed a workspace handle return the handle
+    if isinstance(workspace_name, Workspace):
+        return workspace_name
+    return loaded_workspaces[workspace_name]
 
-    def get_workspace_names(self):
-        return AnalysisDataService.getObjectNames()
+def get_workspace_names(self):
+    return loaded_workspaces.keys()
 
-    def delete_workspace(self, workspace):
-        ws = DeleteWorkspace(Workspace=workspace)
-        if workspace in self._EfDefined:
-            del self._EfDefined[workspace]
-        if workspace in self._limits:
-            del self._limits[workspace]
-        if workspace in self._isPSD:
-            del self._isPSD[workspace]
-        return ws
+def delete_workspace(self, workspace):
+    ws = DeleteWorkspace(Workspace=workspace)
+    if workspace in _EfDefined:
+        del _EfDefined[workspace]
+    if workspace in _limits:
+        del _limits[workspace]
+    if workspace in _isPSD:
+        del _isPSD[workspace]
+    return ws
 
-    def get_limits(self, workspace, axis):
-        if workspace not in self._limits:
-            self._processLoadedWSLimits(workspace)
-        if axis in self._limits[workspace]:
-            return self._limits[workspace][axis]
-        else:
-            # If we cannot get the step size from the data, use the old 1/100 steps.
-            ws_h = self.get_workspace_handle(workspace)
-            dim = ws_h.getDimension(ws_h.getDimensionIndexByName(axis))
-            minimum = dim.getMinimum()
-            maximum = dim.getMaximum()
-            step = (maximum - minimum) / 100
-            return minimum, maximum, step
+def get_limits(self, workspace, axis):
+    if workspace.limits is None:
+        _processLoadedWSLimits(workspace)
+    if axis in workspace.limits:
+        return workspace.limits[axis]
+    else:
+        # If we cannot get the step size from the data, use the old 1/100 steps.
+        ws_h = get_workspace_handle(workspace)
+        dim = ws_h.getDimension(ws_h.getDimensionIndexByName(axis))
+        minimum = dim.getMinimum()
+        maximum = dim.getMaximum()
+        step = (maximum - minimum) / 100
+        return minimum, maximum, step
 
-    def is_PSD(self, workspace):
-        ws_name = workspace if isinstance(workspace, string_types) else self.get_workspace_name(workspace)
-        return self._isPSD[ws_name] if (ws_name in self._isPSD) else None
+def is_PSD(self, workspace):
+    ws_name = workspace if isinstance(workspace, string_types) else get_workspace_name(workspace)
+    return _isPSD[ws_name] if (ws_name in _isPSD) else None
 
-    def _processEfixed(self, workspace):
-        """Checks whether the fixed energy is defined for this workspace"""
-        ws_name = workspace if isinstance(workspace, string_types) else self.get_workspace_name(workspace)
-        ws_h = self.get_workspace_handle(ws_name)
-        try:
-            self._get_ws_EFixed(ws_h)
-            self._EfDefined[ws_name] = True
-        except RuntimeError:
-            self._EfDefined[ws_name] = False
+def _processEfixed(self, workspace):
+    """Checks whether the fixed energy is defined for this workspace"""
+    try:
+        _get_ws_EFixed(workspace.raw_ws)
+        workspace.ef_defined = True
+    except RuntimeError:
+        workspace.ef_defined = False
 
-    def _processLoadedWSLimits(self, workspace):
-        """ Processes an (angle-deltaE) workspace to get the limits and step size in angle, energy and |Q| """
-        ws_name = workspace if isinstance(workspace, string_types) else self.get_workspace_name(workspace)
-        ws_h = self.get_workspace_handle(workspace)
-        # For cases, e.g. indirect, where EFixed has not been set yet, return calculate later.
-        efix = self.get_EFixed(ws_h)
-        if efix is None:
-            return
-        if ws_name not in self._limits:
-            self._limits[ws_name] = {}
-        if isinstance(ws_h, IMDEventWorkspace):
-            self.process_limits_event(ws_h, ws_name, efix)
-        elif isinstance(ws_h, MatrixWorkspace):
-            self.process_limits(ws_h, ws_name, efix)
+def _processLoadedWSLimits(self, workspace):
+    """ Processes an (angle-deltaE) workspace to get the limits and step size in angle, energy and |Q| """
+    # For cases, e.g. indirect, where EFixed has not been set yet, return calculate later.
+    efix = get_EFixed(workspace.raw_ws)
+    if efix is None:
+        return
+    if isinstance(workspace, PixelWorkspace):
+        process_limits_event(workspace, efix)
+    elif isinstance(workspace, MatrixWorkspace):
+        process_limits(workspace, efix)
 
-    def process_limits(self, ws, ws_name, efix):
-        en = ws.getAxis(0).extractValues()
-        theta = self._get_theta_for_limits(ws)
-        # Use minimum energy (Direct geometry) or maximum energy (Indirect) to get qmax
-        emax = -np.min(en) if (str(ws.getEMode()) == 'Direct') else np.max(en)
-        qmin, qmax, qstep = self.get_q_limits(theta, emax, efix)
-        self.set_limits(ws_name, qmin, qmax, qstep, theta, np.min(en), np.max(en), np.mean(np.diff(en)))
+def process_limits(self, ws, efix):
+    en = ws.raw_ws.getAxis(0).extractValues()
+    theta = _get_theta_for_limits(ws)
+    # Use minimum energy (Direct geometry) or maximum energy (Indirect) to get qmax
+    emax = -np.min(en) if (str(ws.getEMode()) == 'Direct') else np.max(en)
+    qmin, qmax, qstep = get_q_limits(theta, emax, efix)
+    set_limits(ws, qmin, qmax, qstep, theta, np.min(en), np.max(en), np.mean(np.diff(en)))
 
-    def process_limits_event(self, ws, ws_name, efix):
-        e_dim = ws.getDimension(ws.getDimensionIndexByName('DeltaE'))
-        emin  = e_dim.getMinimum()
-        emax = e_dim.getMaximum()
-        theta = self._get_theta_for_limits_event(ws)
-        estep = self._original_step_size(ws)
-        emax_1 = -emin if (str(self.get_EMode(ws)) == 'Direct') else emax
-        qmin, qmax, qstep = self.get_q_limits(theta, emax_1, efix)
-        self.set_limits(ws_name, qmin, qmax, qstep, theta, emin, emax, estep)
+def process_limits_event(self, ws, efix):
+    e_dim = ws.raw_ws.getDimension(ws.raw_ws.getDimensionIndexByName('DeltaE'))
+    emin  = e_dim.getMinimum()
+    emax = e_dim.getMaximum()
+    theta = _get_theta_for_limits_event(ws)
+    estep = _original_step_size(ws)
+    emax_1 = -emin if (str(ws.e_mode == 'Direct')) else emax
+    qmin, qmax, qstep = get_q_limits(theta, emax_1, efix)
+    set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep)
 
-    def _original_step_size(self, workspace):
-        rebin_history = self._get_algorithm_history("Rebin", workspace.getHistory())
-        params_history = self._get_property_from_history("Params", rebin_history)
-        return float(params_history.value().split(',')[1])
+def _original_step_size(self, workspace):
+    rebin_history = _get_algorithm_history("Rebin", workspace.raw_ws.getHistory())
+    params_history = _get_property_from_history("Params", rebin_history)
+    return float(params_history.value().split(',')[1])
 
-    def _get_algorithm_history(self, name, workspace_history):
-        histories = workspace_history.getAlgorithmHistories()
+def _get_algorithm_history(self, name, workspace_history):
+    histories = workspace_history.getAlgorithmHistories()
 
-        for history in reversed(histories):
-            if history.name() == name:
-                return history
-        return None
+    for history in reversed(histories):
+        if history.name() == name:
+            return history
+    return None
 
-    def _get_property_from_history(self, name, history):
-        for property in history.getProperties():
-            if property.name() == name:
-                return property
-        return None
+def _get_property_from_history(self, name, history):
+    for property in history.getProperties():
+        if property.name() == name:
+            return property
+    return None
 
-    def get_q_limits(self, theta, emax, efix):
-        qmin, qmax, qstep = tuple(np.sqrt(E2q * 2 * efix * (1 - np.cos(theta)) * meV2J) / m2A)
-        qmax = np.sqrt(E2q * (2 * efix + emax - 2 * np.sqrt(efix * (efix + emax)) * np.cos(theta[1])) * meV2J) / m2A
-        return qmin, qmax, qstep
+def get_q_limits(self, theta, emax, efix):
+    qmin, qmax, qstep = tuple(np.sqrt(E2q * 2 * efix * (1 - np.cos(theta)) * meV2J) / m2A)
+    qmax = np.sqrt(E2q * (2 * efix + emax - 2 * np.sqrt(efix * (efix + emax)) * np.cos(theta[1])) * meV2J) / m2A
+    return qmin, qmax, qstep
 
-    def set_limits(self, ws_name, qmin, qmax, qstep, theta, emin, emax, estep):
-        # Use a step size a bit smaller than angular spacing ( / 3) so user can rebin if they want...
-        self._limits[ws_name]['MomentumTransfer'] = [qmin - qstep, qmax + qstep, qstep / 3]
-        self._limits[ws_name]['|Q|'] = self._limits[ws_name]['MomentumTransfer']  # ConvertToMD renames it(!)
-        self._limits[ws_name]['Degrees'] = theta * 180 / np.pi
-        self._limits[ws_name]['DeltaE'] = [emin, emax, estep]
+def set_limits(self, ws, qmin, qmax, qstep, theta, emin, emax, estep):
+    # Use a step size a bit smaller than angular spacing ( / 3) so user can rebin if they want...
+    ws.limits['MomentumTransfer'] = [qmin - qstep, qmax + qstep, qstep / 3]
+    ws.limits['|Q|'] = ws.limits['MomentumTransfer']  # ConvertToMD renames it(!)
+    ws.limits['Degrees'] = theta * 180 / np.pi
+    ws.limits['DeltaE'] = [emin, emax, estep]
 
-    def _get_theta_for_limits(self, ws_handle):
-        # Don't parse all spectra in cases where there are a lot to save time.
-        num_hist = ws_handle.getNumberHistograms()
-        if num_hist > 1000:
-            n_segments = 5
-            interval = int(num_hist / n_segments)
-            theta = []
-            for segment in range(n_segments):
-                i0 = segment * interval
-                theta.append([ws_handle.detectorTwoTheta(ws_handle.getDetector(i))
-                              for i in range(i0, i0+200)])
-            round_fac = 573
-        else:
-            theta = [ws_handle.detectorTwoTheta(ws_handle.getDetector(i)) for i in range(num_hist)]
-            round_fac = 100
-        self._isPSD[self.get_workspace_name(ws_handle)] = not all(x < y for x, y in zip(theta, theta[1:]))
-        # Rounds the differences to avoid pixels with same 2theta. Implies min limit of ~0.5 degrees
-        thdiff = np.diff(np.round(np.sort(theta)*round_fac)/round_fac)
-        return np.array([np.min(theta), np.max(theta), np.min(thdiff[np.where(thdiff>0)])])
-
-    def _get_theta_for_limits_event(self, ws):
-        spectrum_info = ws.getExperimentInfo(0).spectrumInfo()
+def _get_theta_for_limits(self, ws):
+    # Don't parse all spectra in cases where there are a lot to save time.
+    num_hist = ws.raw_ws.getNumberHistograms()
+    if num_hist > 1000:
+        n_segments = 5
+        interval = int(num_hist / n_segments)
         theta = []
-        i = 0
-        while True:
-            try:
-                if not spectrum_info.isMonitor(i):
-                    theta.append(spectrum_info.twoTheta(i))
-                i += 1
-            except IndexError:
-                break
-        theta = np.unique(theta)
+        for segment in range(n_segments):
+            i0 = segment * interval
+            theta.append([ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i))
+                          for i in range(i0, i0+200)])
+        round_fac = 573
+    else:
+        theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_hist)]
         round_fac = 100
-        thdiff = np.diff(np.round(np.sort(theta) * round_fac) / round_fac)
-        return np.array([np.min(theta), np.max(theta), np.min(thdiff[np.where(thdiff > 0)])])
+    ws.is_PSD = not all(x < y for x, y in zip(theta, theta[1:]))
+    # Rounds the differences to avoid pixels with same 2theta. Implies min limit of ~0.5 degrees
+    thdiff = np.diff(np.round(np.sort(theta)*round_fac)/round_fac)
+    return np.array([np.min(theta), np.max(theta), np.min(thdiff[np.where(thdiff>0)])])
 
-    def load(self, filename, output_workspace):
-        ws = Load(Filename=filename, OutputWorkspace=output_workspace)
-        if self.get_EMode(output_workspace) == 'Indirect':
-            self._processEfixed(output_workspace)
-        self._processLoadedWSLimits(output_workspace)
-        return ws
-
-    def rename_workspace(self, selected_workspace, new_name):
-        ws = RenameWorkspace(InputWorkspace=selected_workspace, OutputWorkspace=new_name)
-        if selected_workspace in self._limits:
-            self._limits[new_name] = self._limits.pop(selected_workspace)
-        if selected_workspace in self._isPSD:
-            self._isPSD[new_name] = self._isPSD.pop(selected_workspace)
-        if selected_workspace in self._EfDefined:
-            self._EfDefined[new_name] = self._EfDefined.pop(selected_workspace)
-        if selected_workspace in self._cutParameters:
-            self._cutParameters[new_name] = self._cutParameters.pop(selected_workspace)
-        return ws
-
-    def combine_workspace(self, selected_workspaces, new_name):
-        ws = MergeMD(InputWorkspaces=selected_workspaces, OutputWorkspace=new_name)
-        # Use precalculated step size, otherwise get limits directly from workspace
-        ax1 = ws.getDimension(0)
-        ax2 = ws.getDimension(1)
-        step1 = []
-        step2 = []
-        for input_workspace in selected_workspaces:
-            step1.append(self.get_limits(input_workspace, ax1.name)[2])
-            step2.append(self.get_limits(input_workspace, ax2.name)[2])
-        if new_name not in self._limits.keys():
-            self._limits[new_name] = {}
-        self._limits[new_name][ax1.name] = [ax1.getMinimum(), ax1.getMaximum(), np.max(step1)]
-        self._limits[new_name][ax2.name] = [ax2.getMinimum(), ax2.getMaximum(), np.max(step2)]
-        return ws
-
-    def add_workspace_runs(self, selected_ws):
-        MergeRuns(InputWorkspaces=selected_ws, OutputWorkspace=selected_ws[0] + '_sum')
-
-    def subtract(self, workspaces, background_ws, ssf):
-        bg_ws = self.get_workspace_handle(str(background_ws))
-        scaled_bg_ws = Scale(bg_ws, ssf)
+def _get_theta_for_limits_event(self, ws):
+    spectrum_info = ws.raw_ws.getExperimentInfo(0).spectrumInfo()
+    theta = []
+    i = 0
+    while True:
         try:
-            for ws_name in workspaces:
-                ws = self.get_workspace_handle(ws_name)
-                Minus(LHSWorkspace=ws, RHSWorkspace=scaled_bg_ws, OutputWorkspace=ws_name + '_subtracted')
-        except ValueError as e:
-            raise ValueError(e)
-        finally:
-            self.delete_workspace(scaled_bg_ws)
+            if not spectrum_info.isMonitor(i):
+                theta.append(spectrum_info.twoTheta(i))
+            i += 1
+        except IndexError:
+            break
+    theta = np.unique(theta)
+    round_fac = 100
+    thdiff = np.diff(np.round(np.sort(theta) * round_fac) / round_fac)
+    return np.array([np.min(theta), np.max(theta), np.min(thdiff[np.where(thdiff > 0)])])
 
-    def save_workspaces(self, workspaces, path, save_name, extension, slice_nonpsd=False):
-        '''
-        :param workspaces: list of workspaces to save
-        :param path: directory to save to
-        :param save_name: name to save the file as (plus file extension). Pass none to use workspace name
-        :param extension: file extension (such as .txt)
-        '''
-        if extension == '.nxs':
-            save_method = save_nexus
-        elif extension == '.txt':
-            save_method = save_ascii
-        elif extension == '.mat':
-            save_method = save_matlab
-        else:
-            raise RuntimeError("unrecognised file extension")
-        for workspace in workspaces:
-            self._save_single_ws(workspace, save_name, save_method, path, extension, slice_nonpsd)
+def load(self, filename, output_workspace):
+    ws = Load(Filename=filename, OutputWorkspace=output_workspace)
+    wrapped = wrap_workspace(ws)
+    wrapped.e_mode = get_EMode(ws)
+    if wrapped.e_mode == 'Indirect':
+        _processEfixed(wrapped)
+    _processLoadedWSLimits(wrapped)
+    loaded_workspaces[output_workspace] = wrapped
+    return wrapped
 
-    def _save_single_ws(self, workspace, save_name, save_method, path, extension, slice_nonpsd):
-        slice = False
-        save_as = save_name if save_name is not None else str(workspace) + extension
-        full_path = os.path.join(str(path), save_as)
-        workspace = self.get_workspace_handle(workspace)
-        non_psd_slice = slice_nonpsd and not self.is_PSD(workspace) and isinstance(workspace, MatrixWorkspace)
-        if self.is_pixel_workspace(workspace) or non_psd_slice:
-            slice = True
-            workspace = self._get_slice_mdhisto(workspace, workspace.name())
-        save_method(workspace, full_path, slice)
+def wrap_workspace(self, raw_ws):
+    if isinstance(raw_ws, IMDEventWorkspace):
+        return PixelWorkspace(raw_ws)
+    elif isinstance(raw_ws, IMDHistoWorkspace):
+        return HistogramWorkspace(raw_ws)
+    else:
+        return MatrixWorkspace(raw_ws)
 
-    def _get_slice_mdhisto(self, workspace, ws_name):
-        from mslice.models.slice.mantid_slice_algorithm import MantidSliceAlgorithm
+
+def rename_workspace(self, selected_workspace, new_name):
+    ws = RenameWorkspace(InputWorkspace=selected_workspace, OutputWorkspace=new_name)
+    if selected_workspace in _limits:
+        _limits[new_name] = _limits.pop(selected_workspace)
+    if selected_workspace in _isPSD:
+        _isPSD[new_name] = _isPSD.pop(selected_workspace)
+    if selected_workspace in _EfDefined:
+        _EfDefined[new_name] = _EfDefined.pop(selected_workspace)
+    if selected_workspace in _cutParameters:
+        _cutParameters[new_name] = _cutParameters.pop(selected_workspace)
+    return ws
+
+def combine_workspace(self, selected_workspaces, new_name):
+    ws = MergeMD(InputWorkspaces=selected_workspaces, OutputWorkspace=new_name)
+    # Use precalculated step size, otherwise get limits directly from workspace
+    ax1 = ws.getDimension(0)
+    ax2 = ws.getDimension(1)
+    step1 = []
+    step2 = []
+    for input_workspace in selected_workspaces:
+        step1.append(get_limits(input_workspace, ax1.name)[2])
+        step2.append(get_limits(input_workspace, ax2.name)[2])
+    if new_name not in _limits.keys():
+        _limits[new_name] = {}
+    _limits[new_name][ax1.name] = [ax1.getMinimum(), ax1.getMaximum(), np.max(step1)]
+    _limits[new_name][ax2.name] = [ax2.getMinimum(), ax2.getMaximum(), np.max(step2)]
+    return ws
+
+def add_workspace_runs(self, selected_ws):
+    MergeRuns(InputWorkspaces=selected_ws, OutputWorkspace=selected_ws[0] + '_sum')
+
+def subtract(self, workspaces, background_ws, ssf):
+    bg_ws = get_workspace_handle(str(background_ws))
+    scaled_bg_ws = Scale(bg_ws, ssf)
+    try:
+        for ws_name in workspaces:
+            ws = get_workspace_handle(ws_name)
+            Minus(LHSWorkspace=ws, RHSWorkspace=scaled_bg_ws, OutputWorkspace=ws_name + '_subtracted')
+    except ValueError as e:
+        raise ValueError(e)
+    finally:
+        delete_workspace(scaled_bg_ws)
+
+def save_workspaces(self, workspaces, path, save_name, extension, slice_nonpsd=False):
+    '''
+    :param workspaces: list of workspaces to save
+    :param path: directory to save to
+    :param save_name: name to save the file as (plus file extension). Pass none to use workspace name
+    :param extension: file extension (such as .txt)
+    '''
+    if extension == '.nxs':
+        save_method = save_nexus
+    elif extension == '.txt':
+        save_method = save_ascii
+    elif extension == '.mat':
+        save_method = save_matlab
+    else:
+        raise RuntimeError("unrecognised file extension")
+    for workspace in workspaces:
+        _save_single_ws(workspace, save_name, save_method, path, extension, slice_nonpsd)
+
+def _save_single_ws(self, workspace, save_name, save_method, path, extension, slice_nonpsd):
+    slice = False
+    save_as = save_name if save_name is not None else str(workspace) + extension
+    full_path = os.path.join(str(path), save_as)
+    workspace = get_workspace_handle(workspace)
+    non_psd_slice = slice_nonpsd and not is_PSD(workspace) and isinstance(workspace, MatrixWorkspace)
+    if is_pixel_workspace(workspace) or non_psd_slice:
+        slice = True
+        workspace = _get_slice_mdhisto(workspace, workspace.name())
+    save_method(workspace, full_path, slice)
+
+def _get_slice_mdhisto(self, workspace, ws_name):
+    from mslice.models.slice.mantid_slice_algorithm import MantidSliceAlgorithm
+    try:
+        return get_workspace_handle('__' + ws_name)
+    except KeyError:
+        slice_alg = MantidSliceAlgorithm()
+        slice_alg.set_workspace_provider(self)
+        ws_name = workspace.name()
+        x_axis = get_axis_from_dimension(workspace, ws_name, 0)
+        y_axis = get_axis_from_dimension(workspace, ws_name, 1)
+        slice_alg.compute_slice(ws_name, x_axis, y_axis, False)
+        return get_workspace_handle('__' + ws_name)
+
+def get_axis_from_dimension(self, workspace, ws_name, id):
+    dim = workspace.getDimension(id).getName()
+    min, max, step = _limits[ws_name][dim]
+    return Axis(dim, min, max, step)
+
+
+def is_pixel_workspace(self, workspace_name):
+    workspace = get_workspace_handle(workspace_name)
+    return isinstance(workspace, IMDEventWorkspace)
+
+def get_workspace_name(self, workspace):
+    """Returns the name of a workspace given the workspace handle"""
+    if isinstance(workspace, string_types):
+        return workspace
+    return workspace.name()
+
+def get_EMode(self, workspace):
+    """Returns the energy analysis mode (direct or indirect of a workspace)"""
+    workspace_handle = get_workspace_handle(workspace)
+    emode = str(_get_ws_EMode(workspace_handle))
+    if emode == 'Elastic':
+        # Work-around for older versions of Mantid which does not set instrument name
+        # in NXSPE files, so LoadNXSPE does not know if it is direct or indirect data
+        ei_log = workspace_handle.run().getProperty('Ei').value
+        emode = 'Indirect' if np.isnan(ei_log) else 'Direct'
+    return emode
+
+def _get_ws_EMode(self, ws_handle):
+    try:
+        emode = ws_handle.getEMode()
+    except AttributeError: # workspace is not matrix workspace
         try:
-            return self.get_workspace_handle('__' + ws_name)
-        except KeyError:
-            slice_alg = MantidSliceAlgorithm()
-            slice_alg.set_workspace_provider(self)
-            ws_name = workspace.name()
-            x_axis = self.get_axis_from_dimension(workspace, ws_name, 0)
-            y_axis = self.get_axis_from_dimension(workspace, ws_name, 1)
-            slice_alg.compute_slice(ws_name, x_axis, y_axis, False)
-            return self.get_workspace_handle('__' + ws_name)
+            emode = _get_exp_info_using(ws_handle, lambda e: ws_handle.getExperimentInfo(e).getEMode())
+        except ValueError:
+            raise ValueError("Workspace contains different EModes")
+    return emode
 
-    def get_axis_from_dimension(self, workspace, ws_name, id):
-        dim = workspace.getDimension(id).getName()
-        min, max, step = self._limits[ws_name][dim]
-        return Axis(dim, min, max, step)
-
-
-    def is_pixel_workspace(self, workspace_name):
-        workspace = self.get_workspace_handle(workspace_name)
-        return isinstance(workspace, IMDEventWorkspace)
-
-    def get_workspace_name(self, workspace):
-        """Returns the name of a workspace given the workspace handle"""
-        if isinstance(workspace, string_types):
-            return workspace
-        return workspace.name()
-
-    def get_EMode(self, workspace):
-        """Returns the energy analysis mode (direct or indirect of a workspace)"""
-        workspace_handle = self.get_workspace_handle(workspace)
-        emode = str(self._get_ws_EMode(workspace_handle))
-        if emode == 'Elastic':
-            # Work-around for older versions of Mantid which does not set instrument name
-            # in NXSPE files, so LoadNXSPE does not know if it is direct or indirect data
-            ei_log = workspace_handle.run().getProperty('Ei').value
-            emode = 'Indirect' if np.isnan(ei_log) else 'Direct'
-        return emode
-
-    def _get_ws_EMode(self, ws_handle):
+def get_EFixed(self, ws_handle):
+    efix = np.nan
+    try:
+        efix = _get_ws_EFixed(ws_handle)
+    except RuntimeError:  # Efixed not defined
+        # This could occur for malformed NXSPE without the instrument name set.
+        # LoadNXSPE then sets EMode to 'Elastic' and getEFixed fails.
         try:
-            emode = ws_handle.getEMode()
-        except AttributeError: # workspace is not matrix workspace
-            try:
-                emode = self._get_exp_info_using(ws_handle, lambda e: ws_handle.getExperimentInfo(e).getEMode())
-            except ValueError:
-                raise ValueError("Workspace contains different EModes")
-        return emode
+            if ws_handle.run().hasProperty('Ei'):
+                efix = ws_handle.run().getProperty('Ei').value
+        except AttributeError:
+            if ws_handle.getExperimentInfo(0).run().hasProperty('Ei'):
+                efix = ws_handle.getExperimentInfo(0).run().getProperty('Ei').value
+    if efix is not None and not np.isnan(efix):  # error if none is passed to isnan
+        return efix
+    else:
+        return None
 
-    def get_EFixed(self, ws_handle):
-        efix = np.nan
+def _get_ws_EFixed(self, ws_handle):
+    try:
+        efixed = ws_handle.getEFixed(ws_handle.getDetector(0).getID())
+    except AttributeError: # workspace is not matrix workspace
         try:
-            efix = self._get_ws_EFixed(ws_handle)
-        except RuntimeError:  # Efixed not defined
-            # This could occur for malformed NXSPE without the instrument name set.
-            # LoadNXSPE then sets EMode to 'Elastic' and getEFixed fails.
-            try:
-                if ws_handle.run().hasProperty('Ei'):
-                    efix = ws_handle.run().getProperty('Ei').value
-            except AttributeError:
-                if ws_handle.getExperimentInfo(0).run().hasProperty('Ei'):
-                    efix = ws_handle.getExperimentInfo(0).run().getProperty('Ei').value
-        if efix is not None and not np.isnan(efix):  # error if none is passed to isnan
-            return efix
-        else:
-            return None
+            efixed = _get_exp_info_using(ws_handle, lambda e: ws_handle.getExperimentInfo(e).getEFixed(1))
+        except ValueError:
+            raise ValueError("Workspace contains different EFixed values")
+    return efixed
 
-    def _get_ws_EFixed(self, ws_handle):
-        try:
-            efixed = ws_handle.getEFixed(ws_handle.getDetector(0).getID())
-        except AttributeError: # workspace is not matrix workspace
-            try:
-                efixed = self._get_exp_info_using(ws_handle, lambda e: ws_handle.getExperimentInfo(e).getEFixed(1))
-            except ValueError:
-                raise ValueError("Workspace contains different EFixed values")
-        return efixed
+def _get_exp_info_using(self, ws_handle, get_exp_info):
+    """get data from MultipleExperimentInfo. Returns None if ExperimentInfo is not found"""
+    prev = None
+    for exp in range(ws_handle.getNumExperimentInfo()):
+        exp_value = get_exp_info(exp)
+        if prev is not None:
+            if exp_value != prev:
+                raise ValueError
+        prev = exp_value
+    return prev
 
-    def _get_exp_info_using(self, ws_handle, get_exp_info):
-        """get data from MultipleExperimentInfo. Returns None if ExperimentInfo is not found"""
-        prev = None
-        for exp in range(ws_handle.getNumExperimentInfo()):
-            exp_value = get_exp_info(exp)
-            if prev is not None:
-                if exp_value != prev:
-                    raise ValueError
-            prev = exp_value
-        return prev
+def has_efixed(self, workspace):
+    return _EfDefined[workspace if isinstance(workspace, string_types) else get_workspace_name(workspace)]
 
-    def has_efixed(self, workspace):
-        return self._EfDefined[workspace if isinstance(workspace, string_types) else self.get_workspace_name(workspace)]
+def set_efixed(self, workspace, Ef):
+    """Sets (overides) the fixed energy for all detectors (spectra) of this workspace"""
+    ws_name = workspace if isinstance(workspace, string_types) else get_workspace_name(workspace)
+    ws_handle = get_workspace_handle(ws_name)
+    for idx in range(ws_handle.getNumberHistograms()):
+        ws_handle.setEFixed(ws_handle.getDetector(idx).getID(), Ef)
 
-    def set_efixed(self, workspace, Ef):
-        """Sets (overides) the fixed energy for all detectors (spectra) of this workspace"""
-        ws_name = workspace if isinstance(workspace, string_types) else self.get_workspace_name(workspace)
-        ws_handle = self.get_workspace_handle(ws_name)
-        for idx in range(ws_handle.getNumberHistograms()):
-            ws_handle.setEFixed(ws_handle.getDetector(idx).getID(), Ef)
+def propagate_properties(self, old_workspace, new_workspace):
+    """Propagates MSlice only properties of workspaces, e.g. limits"""
+    if old_workspace in _EfDefined:
+        _EfDefined[new_workspace] = _EfDefined[old_workspace]
+    if old_workspace in _limits:
+        _limits[new_workspace] = _limits[old_workspace]
+    if old_workspace in _isPSD:
+        _isPSD[new_workspace] = _isPSD[old_workspace]
 
-    def propagate_properties(self, old_workspace, new_workspace):
-        """Propagates MSlice only properties of workspaces, e.g. limits"""
-        if old_workspace in self._EfDefined:
-            self._EfDefined[new_workspace] = self._EfDefined[old_workspace]
-        if old_workspace in self._limits:
-            self._limits[new_workspace] = self._limits[old_workspace]
-        if old_workspace in self._isPSD:
-            self._isPSD[new_workspace] = self._isPSD[old_workspace]
+def getComment(self, workspace):
+    if hasattr(workspace, 'getComment'):
+        return workspace.getComment()
+    ws_handle = get_workspace_handle(workspace)
+    return ws_handle.getComment()
 
-    def getComment(self, workspace):
-        if hasattr(workspace, 'getComment'):
-            return workspace.getComment()
-        ws_handle = self.get_workspace_handle(workspace)
-        return ws_handle.getComment()
+def setCutParameters(self, workspace, axis, parameters):
+    if workspace not in _cutParameters:
+        _cutParameters[workspace] = dict()
+    _cutParameters[workspace][axis] = parameters
+    _cutParameters[workspace]['previous_axis'] = axis
 
-    def setCutParameters(self, workspace, axis, parameters):
-        if workspace not in self._cutParameters:
-            self._cutParameters[workspace] = dict()
-        self._cutParameters[workspace][axis] = parameters
-        self._cutParameters[workspace]['previous_axis'] = axis
-
-    def getCutParameters(self, workspace, axis=None):
-        if workspace in self._cutParameters:
-            if axis is not None:
-                if axis in self._cutParameters[workspace]:
-                    return self._cutParameters[workspace][axis], axis
-                else:
-                    return None, None
+def getCutParameters(self, workspace, axis=None):
+    if workspace in _cutParameters:
+        if axis is not None:
+            if axis in _cutParameters[workspace]:
+                return _cutParameters[workspace][axis], axis
             else:
-                prev_axis = self._cutParameters[workspace]['previous_axis']
-                return self._cutParameters[workspace][prev_axis], prev_axis
-        return None, None
+                return None, None
+        else:
+            prev_axis = _cutParameters[workspace]['previous_axis']
+            return _cutParameters[workspace][prev_axis], prev_axis
+    return None, None
 
-    def isAxisSaved(self, workspace, axis):
-        if workspace in self._cutParameters:
-            return True if axis in self._cutParameters[workspace] else False
-        return False
+def isAxisSaved(self, workspace, axis):
+    if workspace in _cutParameters:
+        return True if axis in _cutParameters[workspace] else False
+    return False

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -79,13 +79,14 @@ def workspace_exists(ws_name):
 
 
 def get_limits(workspace, axis):
-    if workspace.limits is None:
+    workspace = get_workspace_handle(workspace)
+    if workspace.limits is None or len(workspace.limits) == 0:
         _processLoadedWSLimits(workspace)
     if axis in workspace.limits:
         return workspace.limits[axis]
     else:
         # If we cannot get the step size from the data, use the old 1/100 steps.
-        ws_h = get_workspace_handle(workspace).raw_ws
+        ws_h = workspace.raw_ws
         dim = ws_h.getDimension(ws_h.getDimensionIndexByName(axis))
         minimum = dim.getMinimum()
         maximum = dim.getMaximum()
@@ -237,14 +238,14 @@ def rename_workspace(selected_workspace, new_name):
 
 
 def combine_workspace(selected_workspaces, new_name):
-    ws = MergeMD(InputWorkspaces=selected_workspaces, OutputWorkspace=new_name)
+    workspaces = [get_workspace_handle(ws).raw_ws for ws in selected_workspaces]
+    ws = MergeMD(InputWorkspaces=workspaces, OutputWorkspace=new_name)
     # Use precalculated step size, otherwise get limits directly from workspace
     ax1 = ws.getDimension(0)
     ax2 = ws.getDimension(1)
     step1 = []
     step2 = []
-    for input_workspace in selected_workspaces:
-        in_ws = get_workspace_handle(input_workspace)
+    for in_ws in selected_workspaces:
         step1.append(get_limits(in_ws, ax1.name)[2])
         step2.append(get_limits(in_ws, ax2.name)[2])
     ws = wrap_workspace(ws)

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -287,7 +287,6 @@ def _get_slice_mdhisto(workspace, ws_name):
         return get_workspace_handle('__' + ws_name)
     except KeyError:
         slice_alg = MantidSliceAlgorithm()
-        slice_alg.set_workspace_provider(self)
         ws_name = workspace.name()
         x_axis = get_axis_from_dimension(workspace, ws_name, 0)
         y_axis = get_axis_from_dimension(workspace, ws_name, 1)

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -252,8 +252,8 @@ def combine_workspace(selected_workspaces, new_name):
     workspaces = [get_workspace_handle(ws).raw_ws for ws in selected_workspaces]
     ws = run_alg('MergeMD', output_name=new_name, InputWorkspaces=workspaces)
     # Use precalculated step size, otherwise get limits directly from workspace
-    ax1 = ws.getDimension(0)
-    ax2 = ws.getDimension(1)
+    ax1 = ws.raw_ws.getDimension(0)
+    ax2 = ws.raw_ws.getDimension(1)
     step1 = []
     step2 = []
     for in_ws in selected_workspaces:
@@ -272,7 +272,7 @@ def add_workspace_runs(selected_ws):
 
 def subtract(workspaces, background_ws, ssf):
     bg_ws = get_workspace_handle(str(background_ws)).raw_ws
-    scaled_bg_ws = run_alg('Scale', output_name='scaled_bg_ws', Store=False, InputWorkspace=bg_ws, Factor=ssf,
+    scaled_bg_ws = run_alg('Scale', output_name='scaled_bg_ws', store=False, InputWorkspace=bg_ws, Factor=ssf,
                            StoreInADS=False)
     try:
         for ws_name in workspaces:

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -13,7 +13,6 @@ from mantid.api import IMDEventWorkspace, IMDHistoWorkspace
 from mantid.simpleapi import (DeleteWorkspace, Load, Scale, RenameWorkspace, 
                               MergeMD, MergeRuns, Minus)
 
-from mslice.presenters.slice_plotter_presenter import Axis
 from mslice.workspace.base import WorkspaceBase as Workspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
 from mslice.workspace.pixel_workspace import PixelWorkspace
@@ -33,6 +32,21 @@ m2A = 1.e10  # metres to Angstrom
 
 loaded_workspaces = {}
 
+class Axis(object):
+    def __init__(self, units, start, end, step):
+        self.units = units
+        self.start = start
+        self.end = end
+        self.step = step
+
+    def __eq__(self, other):
+        # This is required for Unit testing
+        return self.units == other.units and self.start == other.start and self.end == other.end \
+            and self.step == other.step and isinstance(other, Axis)
+
+    def __repr__(self):
+        info = (self.units, self.start, self.end, self.step)
+        return "Axis(" + " ,".join(map(repr, info)) + ")"
 
 def get_workspace_handle(workspace_name):
     """"Return handle to workspace given workspace_name_as_string"""

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -12,6 +12,7 @@ from mantid.api import IMDEventWorkspace, IMDHistoWorkspace
 
 from mantid.simpleapi import (Load, Scale, RenameWorkspace,
                               MergeMD, MergeRuns, Minus)
+import mantid.simpleapi as mantid_algs
 
 from mslice.workspace.base import WorkspaceBase as Workspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
@@ -55,6 +56,13 @@ def get_workspace_handle(workspace_name):
     if isinstance(workspace_name, Workspace):
         return workspace_name
     return _loaded_workspaces[workspace_name]
+
+
+def run_alg(alg_name, output_name, store=True, **kwargs):
+    ws = getattr(mantid_algs, alg_name)(**kwargs)
+    if store:
+        ws = wrap_workspace(ws, output_name)
+    return ws
 
 
 def get_workspace_names():
@@ -209,8 +217,8 @@ def _get_theta_for_limits_event(ws):
 
 
 def load(filename, output_workspace):
-    ws = Load(Filename=filename, OutputWorkspace=output_workspace)
-    wrapped = wrap_workspace(ws)
+    wrapped = run_alg('Load', output_name=output_workspace, Filename=filename, OutputWorkspace=output_workspace)
+    # wrapped = wrap_workspace(ws)
     wrapped.e_mode = get_EMode(ws)
     if wrapped.e_mode == 'Indirect':
         _processEfixed(wrapped)
@@ -393,12 +401,10 @@ def _get_exp_info_using(raw_ws, get_exp_info):
 
 def propagate_properties(old_workspace, new_workspace):
     """Propagates MSlice only properties of workspaces, e.g. limits"""
-    new_ws = wrap_workspace(new_workspace)
-    new_ws.ef_defined = old_workspace.ef_defined
-    new_ws.e_mode = old_workspace.e_mode
-    new_ws.limits = old_workspace.limits
-    new_ws.is_PSD = old_workspace.is_PSD
-    return new_ws
+    new_workspace.ef_defined = old_workspace.ef_defined
+    new_workspace.e_mode = old_workspace.e_mode
+    new_workspace.limits = old_workspace.limits
+    new_workspace.is_PSD = old_workspace.is_PSD
 
 
 def getComment(workspace):

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -59,14 +59,9 @@ def get_workspace_names():
     return _loaded_workspaces.keys()
 
 def delete_workspace(workspace):
-    ws = DeleteWorkspace(Workspace=workspace)
-    if workspace in _EfDefined:
-        del _EfDefined[workspace]
-    if workspace in _limits:
-        del _limits[workspace]
-    if workspace in _isPSD:
-        del _isPSD[workspace]
-    return ws
+    workspace = get_workspace_handle(workspace)
+    del _loaded_workspaces[get_workspace_name(workspace)]
+    del workspace
 
 def get_limits(workspace, axis):
     if workspace.limits is None:
@@ -393,26 +388,3 @@ def getComment(workspace):
         return workspace.getComment()
     ws_handle = get_workspace_handle(workspace)
     return ws_handle.raw_ws.getComment()
-
-def setCutParameters(workspace, axis, parameters):
-    if workspace not in _cutParameters:
-        _cutParameters[workspace] = dict()
-    _cutParameters[workspace][axis] = parameters
-    _cutParameters[workspace]['previous_axis'] = axis
-
-def getCutParameters(workspace, axis=None):
-    if workspace in _cutParameters:
-        if axis is not None:
-            if axis in _cutParameters[workspace]:
-                return _cutParameters[workspace][axis], axis
-            else:
-                return None, None
-        else:
-            prev_axis = _cutParameters[workspace]['previous_axis']
-            return _cutParameters[workspace][prev_axis], prev_axis
-    return None, None
-
-def isAxisSaved(workspace, axis):
-    if workspace in _cutParameters:
-        return True if axis in _cutParameters[workspace] else False
-    return False

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -197,16 +197,17 @@ def load(filename, output_workspace):
     if wrapped.e_mode == 'Indirect':
         _processEfixed(wrapped)
     _processLoadedWSLimits(wrapped)
-    _loaded_workspaces[output_workspace] = wrapped
     return wrapped
 
 def wrap_workspace(raw_ws):
     if isinstance(raw_ws, IMDEventWorkspace):
-        return PixelWorkspace(raw_ws)
+        wrapped = PixelWorkspace(raw_ws)
     elif isinstance(raw_ws, IMDHistoWorkspace):
-        return HistogramWorkspace(raw_ws)
+        wrapped = HistogramWorkspace(raw_ws)
     else:
-        return MatrixWorkspace(raw_ws)
+        wrapped = MatrixWorkspace(raw_ws)
+    _loaded_workspaces[raw_ws.name()] = wrapped
+    return wrapped
 
 
 def rename_workspace(selected_workspace, new_name):
@@ -385,12 +386,13 @@ def propagate_properties(old_workspace, new_workspace):
     new_ws.e_mode = old_workspace.e_mode
     new_ws.limits = old_workspace.limits
     new_ws.is_PSD = old_workspace.is_PSD
+    return new_ws
 
 def getComment(workspace):
     if hasattr(workspace, 'getComment'):
         return workspace.getComment()
     ws_handle = get_workspace_handle(workspace)
-    return ws_handle.getComment()
+    return ws_handle.raw_ws.getComment()
 
 def setCutParameters(workspace, axis, parameters):
     if workspace not in _cutParameters:

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -7,7 +7,7 @@ It uses mantid to perform the workspace operations
 # -----------------------------------------------------------------------------
 from __future__ import (absolute_import, division, print_function)
 import os.path
-from six import string_types
+from six import string_types, iterkeys
 from mantid.api import IMDEventWorkspace, IMDHistoWorkspace
 
 import mantid.simpleapi as mantid_algs
@@ -57,7 +57,7 @@ def get_workspace_handle(workspace_name):
 
 
 def run_alg(alg_name, output_name=None, store=True, **kwargs):
-    if 'InputWorkspace' in kwargs.keys() and isinstance(kwargs['InputWorkspace'], Workspace):
+    if isinstance(kwargs.get('InputWorkspace'), Workspace):
         kwargs['InputWorkspace'] = kwargs['InputWorkspace'].raw_ws
     if output_name is not None:
         kwargs['OutputWorkspace'] = output_name
@@ -70,7 +70,7 @@ def run_alg(alg_name, output_name=None, store=True, **kwargs):
 
 
 def get_workspace_names():
-    return [key for key in _loaded_workspaces.keys() if key[:2] != '__']
+    return [key for key in iterkeys(_loaded_workspaces) if key[:2] != '__']
 
 
 def get_workspace_name(workspace):
@@ -87,7 +87,7 @@ def delete_workspace(workspace):
 
 
 def workspace_exists(ws_name):
-    return True if ws_name in _loaded_workspaces.keys() else False
+    return ws_name in _loaded_workspaces
 
 
 def get_limits(workspace, axis):
@@ -412,8 +412,7 @@ def propagate_properties(old_workspace, new_workspace):
     new_workspace.is_PSD = old_workspace.is_PSD
 
 
-
-def getComment(workspace):
+def get_comment(workspace):
     if hasattr(workspace, 'getComment'):
         return workspace.getComment()
     ws_handle = get_workspace_handle(workspace)

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -41,7 +41,7 @@ def get_workspace_handle(workspace_name):
         return workspace_name
     return loaded_workspaces[workspace_name]
 
-def get_workspace_names(self):
+def get_workspace_names():
     return loaded_workspaces.keys()
 
 def delete_workspace(workspace):
@@ -95,7 +95,7 @@ def process_limits(ws, efix):
     en = ws.raw_ws.getAxis(0).extractValues()
     theta = _get_theta_for_limits(ws)
     # Use minimum energy (Direct geometry) or maximum energy (Indirect) to get qmax
-    emax = -np.min(en) if (str(ws.getEMode()) == 'Direct') else np.max(en)
+    emax = -np.min(en) if (str(ws.e_mode == 'Direct')) else np.max(en)
     qmin, qmax, qstep = get_q_limits(theta, emax, efix)
     set_limits(ws, qmin, qmax, qstep, theta, np.min(en), np.max(en), np.mean(np.diff(en)))
 
@@ -294,16 +294,15 @@ def get_workspace_name(workspace):
     """Returns the name of a workspace given the workspace handle"""
     if isinstance(workspace, string_types):
         return workspace
-    return workspace.name()
+    return workspace.raw_ws.name()
 
 def get_EMode(workspace):
     """Returns the energy analysis mode (direct or indirect of a workspace)"""
-    workspace_handle = get_workspace_handle(workspace)
-    emode = str(_get_ws_EMode(workspace_handle))
+    emode = str(_get_ws_EMode(workspace))
     if emode == 'Elastic':
         # Work-around for older versions of Mantid which does not set instrument name
         # in NXSPE files, so LoadNXSPE does not know if it is direct or indirect data
-        ei_log = workspace_handle.run().getProperty('Ei').value
+        ei_log = workspace.run().getProperty('Ei').value
         emode = 'Indirect' if np.isnan(ei_log) else 'Direct'
     return emode
 

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -30,7 +30,7 @@ E2q = 2. * constants.m_n / (constants.hbar ** 2)  # Energy to (neutron momentum)
 meV2J = constants.e / 1000.  # meV to Joules
 m2A = 1.e10  # metres to Angstrom
 
-loaded_workspaces = {}
+_loaded_workspaces = {}
 
 class Axis(object):
     def __init__(self, units, start, end, step):
@@ -53,10 +53,10 @@ def get_workspace_handle(workspace_name):
     # if passed a workspace handle return the handle
     if isinstance(workspace_name, Workspace):
         return workspace_name
-    return loaded_workspaces[workspace_name]
+    return _loaded_workspaces[workspace_name]
 
 def get_workspace_names():
-    return loaded_workspaces.keys()
+    return _loaded_workspaces.keys()
 
 def delete_workspace(workspace):
     ws = DeleteWorkspace(Workspace=workspace)
@@ -197,7 +197,7 @@ def load(filename, output_workspace):
     if wrapped.e_mode == 'Indirect':
         _processEfixed(wrapped)
     _processLoadedWSLimits(wrapped)
-    loaded_workspaces[output_workspace] = wrapped
+    _loaded_workspaces[output_workspace] = wrapped
     return wrapped
 
 def wrap_workspace(raw_ws):

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -223,12 +223,12 @@ def combine_workspace(selected_workspaces, new_name):
     step1 = []
     step2 = []
     for input_workspace in selected_workspaces:
-        step1.append(get_limits(input_workspace, ax1.name)[2])
-        step2.append(get_limits(input_workspace, ax2.name)[2])
-    if new_name not in _limits.keys():
-        _limits[new_name] = {}
-    _limits[new_name][ax1.name] = [ax1.getMinimum(), ax1.getMaximum(), np.max(step1)]
-    _limits[new_name][ax2.name] = [ax2.getMinimum(), ax2.getMaximum(), np.max(step2)]
+        in_ws = get_workspace_handle(input_workspace)
+        step1.append(get_limits(in_ws, ax1.name)[2])
+        step2.append(get_limits(in_ws, ax2.name)[2])
+    ws = wrap_workspace(ws)
+    ws.limits[ax1.name] = [ax1.getMinimum(), ax1.getMaximum(), np.max(step1)]
+    ws.limits[ax2.name] = [ax2.getMinimum(), ax2.getMaximum(), np.max(step2)]
     return ws
 
 def add_workspace_runs(selected_ws):

--- a/mslice/models/workspacemanager/mantid_workspace_provider.py
+++ b/mslice/models/workspacemanager/mantid_workspace_provider.py
@@ -85,7 +85,7 @@ def get_limits(workspace, axis):
         return workspace.limits[axis]
     else:
         # If we cannot get the step size from the data, use the old 1/100 steps.
-        ws_h = get_workspace_handle(workspace)
+        ws_h = get_workspace_handle(workspace).raw_ws
         dim = ws_h.getDimension(ws_h.getDimensionIndexByName(axis))
         minimum = dim.getMinimum()
         maximum = dim.getMaximum()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -254,9 +254,6 @@ class CutPlot(object):
                 self._legends_visible[i] = line_data[i]['legend']
         axes.legend(handles_to_show, labels_to_show, fontsize='medium').draggable()  # add new legends
 
-    def workspace_provider(self):
-        return self._cut_plotter.workspace_provider
-
     def set_line_visible(self, line_index, visible):
         self._lines_visible[line_index] = visible
         for child in self._canvas.figure.gca().containers[line_index].get_children():

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -2,6 +2,8 @@ from matplotlib.widgets import RectangleSelector
 
 from mslice.presenters.slice_plotter_presenter import Axis
 from mslice.models.cut.mantid_cut_algorithm import MantidCutAlgorithm
+from mslice.models.workspacemanager.mantid_workspace_provider import (get_workspace_handle, get_limits,
+                                                                      get_workspace_name)
 
 
 class InteractiveCut(object):
@@ -46,7 +48,7 @@ class InteractiveCut(object):
         end = pos2[not self.horizontal]
         units = self._canvas.figure.gca().get_xaxis().units if self.horizontal else \
             self._canvas.figure.gca().get_yaxis().units
-        step = self.slice_plot.workspace_provider().get_limits(self._ws_title, units)[2]
+        step = get_limits(get_workspace_handle(self._ws_title), units)[2]
         ax = Axis(units, start, end, step)
         integration_start = pos1[self.horizontal]
         integration_end = pos2[self.horizontal]
@@ -69,14 +71,10 @@ class InteractiveCut(object):
         integration_axis = Axis(units, integration_start, integration_end, 0)
         output_ws = self._cut_plotter.save_cut((str(self._ws_title), ax, integration_axis, False))
         self.update_workspaces()
-        return self.slice_plot.workspace_provider().get_workspace_name(output_ws)
+        return get_workspace_name(output_ws)
 
     def update_workspaces(self):
         self.slice_plot.update_workspaces()
-
-    def set_workspace_provider(self, workspace_provider):
-        self._cut_algorithm.set_workspace_provider(workspace_provider)
-        self._cut_plotter.set_workspace_provider(workspace_provider)
 
     def clear(self):
         self._cut_plotter.set_icut(None)

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -15,6 +15,7 @@ from mslice.plotting.plot_window.cut_plot import CutPlot
 from mslice.plotting.plot_window.base_plot_window import BasePlotWindow
 from mslice.util.qt import load_ui
 from mslice.models.workspacemanager.file_io import get_save_directory
+from mslice.models.workspacemanager.mantid_workspace_provider import save_workspaces
 
 # The FigureCanvas & Toolbar are QWidgets so we must import it from the mpl backend that matches
 # the version of Qt we are running with
@@ -157,7 +158,7 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
         file_path, save_name, ext = get_save_directory(save_as_image=True)
         workspace = self._plot_handler.ws_name
         try:
-            self._plot_handler.workspace_provider().save_workspaces([workspace], file_path, save_name, ext, slice_nonpsd=True)
+            save_workspaces([workspace], file_path, save_name, ext, slice_nonpsd=True)
         except RuntimeError as e:
             if e.message == "unrecognised file extension":
                 self.save_image(os.path.join(file_path, save_name))
@@ -167,7 +168,7 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
                 raise RuntimeError(e)
         except KeyError:   # Could be case of interactive cuts when the workspace has not been saved yet
             workspace = self._plot_handler.save_icut()
-            self._plot_handler.workspace_provider().save_workspaces([workspace], file_path, save_name, ext)
+            save_workspaces([workspace], file_path, save_name, ext)
 
     def save_image(self, path):
         self.canvas.figure.savefig(path)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -10,6 +10,7 @@ from matplotlib.lines import Line2D
 
 from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
 from .interactive_cut import InteractiveCut
 from .plot_options import SlicePlotOptions
 
@@ -259,7 +260,7 @@ class SlicePlot(object):
         return True
 
     def ask_sample_temperature_field(self, ws_name):
-        ws = self._slice_plotter.workspace_provider.get_workspace_handle(ws_name)
+        ws = get_workspace_handle(ws_name)
         try:
             keys = ws.run().keys()
         except AttributeError:
@@ -337,7 +338,6 @@ class SlicePlot(object):
             self.icut = None
         else:
             self.icut = InteractiveCut(self, self._canvas, self.ws_name)
-            self.icut.set_workspace_provider(self._slice_plotter.get_workspace_provider())
 
     def save_icut(self):
         self.icut.save_cut()
@@ -347,9 +347,6 @@ class SlicePlot(object):
 
     def update_workspaces(self):
         self._slice_plotter.update_displayed_workspaces()
-
-    def workspace_provider(self):
-        return self._slice_plotter.workspace_provider
 
     def disconnect(self, plot_figure):
         plot_figure.actionInteractive_Cuts.triggered.disconnect()

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -262,9 +262,9 @@ class SlicePlot(object):
     def ask_sample_temperature_field(self, ws_name):
         ws = get_workspace_handle(ws_name)
         try:
-            keys = ws.run().keys()
+            keys = ws.raw_ws.run().keys()
         except AttributeError:
-            keys = ws.getExperimentInfo(0).run().keys()
+            keys = ws.raw_ws.getExperimentInfo(0).run().keys()
         temp_field, confirm = QtWidgets.QInputDialog.getItem(self.plot_figure, 'Sample Temperature',
                                                              'Sample Temperature not found. Select the sample ' +
                                                              'temperature field or enter a value in Kelvin:',

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 from .busy import show_busy
 from mslice.models.cut.cut_algorithm import CutAlgorithm
 from mslice.models.cut.cut_plotter import CutPlotter
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
 from mslice.presenters.presenter_utility import PresenterUtility
 from mslice.presenters.slice_plotter_presenter import Axis
 from mslice.views.cut_view import CutView
@@ -167,7 +168,7 @@ class CutPresenter(PresenterUtility):
         return cut_axis, integration_axis, norm_to_one, intensity_start, intensity_end, width
 
     def _set_minimum_step(self, workspace, axis):
-        """Gets axes limits from workspace_provider and then sets the minimumStep dictionary with those values"""
+        """Gets axes limits and then sets the minimumStep dictionary with those values"""
         for ax in axis:
             try:
                 self._minimumStep[ax] = self._cut_algorithm.get_axis_range(workspace, ax)[2]
@@ -191,7 +192,7 @@ class CutPresenter(PresenterUtility):
             self._previous_cut = None
             self._previous_axis = None
         else:
-            non_psd = all([not self._cut_plotter.workspace_provider.is_PSD(ws) for ws in workspace_selection])
+            non_psd = all([not get_workspace_handle(ws).is_PSD for ws in workspace_selection])
             self._cut_view.enable_integration_axis(non_psd)
             self._populate_fields_using_workspace(workspace_selection[0])
 
@@ -246,6 +247,3 @@ class CutPresenter(PresenterUtility):
         min_step = self._minimumStep[self._cut_view.get_cut_axis()]
         self._cut_view.set_minimum_step(min_step)
         self._cut_view.update_integration_axis()
-
-    def set_workspace_provider(self, workspace_provider):
-        self._cut_plotter.set_workspace_provider(workspace_provider)

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 
 from .busy import show_busy
-from mslice.models.workspacemanager.mantid_workspace_provider import load, loaded_workspaces, get_workspace_names
+from mslice.models.workspacemanager.mantid_workspace_provider import load, get_workspace_handle, get_workspace_names
 from mslice.presenters.interfaces.data_loader_presenter import DataLoaderPresenterInterface
 from mslice.presenters.presenter_utility import PresenterUtility
 from mslice.models.workspacemanager.file_io import load_from_ascii
@@ -52,15 +52,15 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     if not allChecked:
                         allChecked = self.check_efixed(ws_name, multi)
                     else:
-                        loaded_workspaces[ws_name].e_fixed = self._EfCache
+                        get_workspace_handle(ws_name).e_fixed = self._EfCache
                     self._main_presenter.show_workspace_manager_tab()
                     self._main_presenter.update_displayed_workspaces()
-                    self._main_presenter.show_tab_for_workspace(loaded_workspaces[ws_name])
+                    self._main_presenter.show_tab_for_workspace(get_workspace_handle(ws_name))
         self._report_load_errors(ws_names, not_opened, not_loaded)
 
     def check_efixed(self, ws_name, multi=False):
         '''checks if a newly loaded workspace has efixed set'''
-        ws = loaded_workspaces[ws_name]
+        ws = get_workspace_handle(ws_name)
         if ws.e_mode == 'Indirect' and not ws.ef_defined:
             Ef, allChecked = self._view.get_workspace_efixed(ws_name, multi, self._EfCache)
             self._EfCache = Ef

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -46,8 +46,8 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                         load(filename=file_paths[i], output_workspace=ws_name)
                 except ValueError as e:
                     self._view.error_loading_workspace(e)
-                except RuntimeError:
-                    not_opened.append(ws_name)
+                # except RuntimeError:
+                #     not_opened.append(ws_name)
                 else:
                     if not allChecked:
                         allChecked = self.check_efixed(ws_name, multi)

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 
 from .busy import show_busy
+from mslice.models.workspacemanager.mantid_workspace_provider import load, loaded_workspaces, get_workspace_names
 from mslice.presenters.interfaces.data_loader_presenter import DataLoaderPresenterInterface
 from mslice.presenters.presenter_utility import PresenterUtility
 from mslice.models.workspacemanager.file_io import load_from_ascii
@@ -10,15 +11,10 @@ from mslice.models.workspacemanager.file_io import load_from_ascii
 
 class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
 
-
     def __init__(self, data_loader_view):
         self._view = data_loader_view
         self._main_presenter = None
-        self._workspace_provider = None
         self._EfCache = None
-
-    def set_workspace_provider(self, workspace_provider):
-        self._workspace_provider = workspace_provider
 
     def load_workspace(self, file_paths, merge=False):
         '''
@@ -47,7 +43,7 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     if file_paths[i].endswith('.txt'):
                         load_from_ascii(file_paths[i], ws_name)
                     else:
-                        self._workspace_provider.load(filename=file_paths[i], output_workspace=ws_name)
+                        load(filename=file_paths[i], output_workspace=ws_name)
                 except ValueError as e:
                     self._view.error_loading_workspace(e)
                 except RuntimeError:
@@ -56,23 +52,23 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     if not allChecked:
                         allChecked = self.check_efixed(ws_name, multi)
                     else:
-                        self._workspace_provider.set_efixed(ws_name, self._EfCache)
+                        loaded_workspaces[ws_name].e_fixed = self._EfCache
                     self._main_presenter.show_workspace_manager_tab()
                     self._main_presenter.update_displayed_workspaces()
-                    self._main_presenter.show_tab_for_workspace(self._workspace_provider.get_workspace_handle(ws_name))
+                    self._main_presenter.show_tab_for_workspace(loaded_workspaces[ws_name])
         self._report_load_errors(ws_names, not_opened, not_loaded)
 
     def check_efixed(self, ws_name, multi=False):
         '''checks if a newly loaded workspace has efixed set'''
-        if self._workspace_provider.get_EMode(ws_name) == 'Indirect' and not self._workspace_provider.has_efixed(
-                ws_name):
+        ws = loaded_workspaces[ws_name]
+        if ws.e_mode == 'Indirect' and not ws.ef_defined:
             Ef, allChecked = self._view.get_workspace_efixed(ws_name, multi, self._EfCache)
             self._EfCache = Ef
-            self._workspace_provider.set_efixed(ws_name, Ef)
+            ws.e_fixed = Ef
             return allChecked
 
     def _confirm_workspace_overwrite(self, ws_name):
-        if ws_name in self._workspace_provider.get_workspace_names():
+        if ws_name in get_workspace_names():
             return self._view.confirm_overwrite_workspace()
         else:
             return True

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -46,8 +46,8 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                         load(filename=file_paths[i], output_workspace=ws_name)
                 except ValueError as e:
                     self._view.error_loading_workspace(e)
-                # except RuntimeError:
-                #     not_opened.append(ws_name)
+                except RuntimeError:
+                    not_opened.append(ws_name)
                 else:
                     if not allChecked:
                         allChecked = self.check_efixed(ws_name, multi)

--- a/mslice/presenters/interfaces/data_loader_presenter.py
+++ b/mslice/presenters/interfaces/data_loader_presenter.py
@@ -9,10 +9,6 @@ class DataLoaderPresenterInterface(object):
         pass
 
     @abc.abstractmethod
-    def set_workspace_provider(self, workspace_provider):
-        pass
-
-    @abc.abstractmethod
     def load_workspace(self, file_paths, merge):
         pass
 

--- a/mslice/presenters/interfaces/powder_projection_presenter.py
+++ b/mslice/presenters/interfaces/powder_projection_presenter.py
@@ -14,9 +14,5 @@ class PowderProjectionPresenterInterface(object):
         pass
 
     @abc.abstractmethod
-    def set_workspace_provider(self, workspace_provider):
-        pass
-
-    @abc.abstractmethod
     def workspace_selection_changed(self):
         pass

--- a/mslice/presenters/interfaces/slice_plotter_presenter.py
+++ b/mslice/presenters/interfaces/slice_plotter_presenter.py
@@ -16,7 +16,3 @@ class SlicePlotterPresenterInterface(object):
     @abc.abstractmethod
     def workspace_selection_changed(self):
         pass
-
-    @abc.abstractmethod
-    def set_workspace_provider(self, workspace_provider):
-        pass

--- a/mslice/presenters/interfaces/workspace_manager_presenter.py
+++ b/mslice/presenters/interfaces/workspace_manager_presenter.py
@@ -21,9 +21,5 @@ class WorkspaceManagerPresenterInterface(object):
         pass
 
     @abc.abstractmethod
-    def get_workspace_provider(self):
-        pass
-
-    @abc.abstractmethod
     def update_displayed_workspaces(self):
         pass

--- a/mslice/presenters/powder_projection_presenter.py
+++ b/mslice/presenters/powder_projection_presenter.py
@@ -75,9 +75,6 @@ class PowderProjectionPresenter(PresenterUtility, PowderProjectionPresenterInter
         if axes[curr_axis] != self._available_axes[-1] and axes[other_axis] != self._available_axes[-1]:
             axes_set[other_axis](self._available_axes[-1])
 
-    def set_workspace_provider(self, workspace_provider):
-        self._projection_calculator.set_workspace_provider(workspace_provider)
-
     def workspace_selection_changed(self):
         workspace_selection = self._main_presenter.get_selected_workspaces()
         try:

--- a/mslice/presenters/powder_projection_presenter.py
+++ b/mslice/presenters/powder_projection_presenter.py
@@ -83,7 +83,6 @@ class PowderProjectionPresenter(PresenterUtility, PowderProjectionPresenterInter
         try:
             for workspace in workspace_selection:
                 self._projection_calculator.validate_workspace(workspace)
-                self._projection_calculator.get_emode(workspace)
         except TypeError as e:
             self._powder_view.disable_calculate_projections(True)
             self._powder_view.display_projection_error(str(e))

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 from .busy import show_busy
 from mslice.models.slice.slice_plotter import SlicePlotter
-from mslice.models.workspacemanager.mantid_workspace_provider import Axis, loaded_workspaces
+from mslice.models.workspacemanager.mantid_workspace_provider import Axis, get_workspace_handle
 from mslice.presenters.presenter_utility import PresenterUtility
 from mslice.views.slice_plotter_view import SlicePlotterView
 from mslice.widgets.slice.command import Command
@@ -129,19 +129,19 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             self._slice_view.clear_input_fields()
             self._slice_view.disable()
         else:
-            non_psd = all([not loaded_workspaces[ws].is_PSD for ws in workspace_selection])
+            non_psd = all([not get_workspace_handle(ws).is_PSD for ws in workspace_selection])
             workspace_selection = workspace_selection[0]
 
             self._slice_view.enable()
             self._slice_view.enable_units_choice(non_psd)
-            axis = self._slice_plotter.get_available_axis(loaded_workspaces[workspace_selection])
+            axis = self._slice_plotter.get_available_axis(get_workspace_handle(workspace_selection))
             self._slice_view.populate_slice_x_options(axis)
             self._slice_view.populate_slice_y_options(axis[::-1])
             self.populate_slice_params()
 
     def populate_slice_params(self):
         try:
-            workspace_selection = loaded_workspaces[self._get_main_presenter().get_selected_workspaces()[0]]
+            workspace_selection = get_workspace_handle(self._get_main_presenter().get_selected_workspaces()[0])
             x_min, x_max, x_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_x_axis())
             y_min, y_max, y_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_y_axis())
         except (KeyError, RuntimeError, IndexError):

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -157,6 +157,3 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
 
     def update_workspaces(self):
         self._main_presenter.update_displayed_workspaces()
-
-    def set_workspace_provider(self, workspace_provider):
-        self._slice_plotter.set_workspace_provider(workspace_provider)

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -1,29 +1,12 @@
 from __future__ import (absolute_import, division, print_function)
 from .busy import show_busy
 from mslice.models.slice.slice_plotter import SlicePlotter
+from mslice.models.workspacemanager.mantid_workspace_provider import Axis, loaded_workspaces
 from mslice.presenters.presenter_utility import PresenterUtility
 from mslice.views.slice_plotter_view import SlicePlotterView
 from mslice.widgets.slice.command import Command
 from .interfaces.slice_plotter_presenter import SlicePlotterPresenterInterface
 from .validation_decorators import require_main_presenter
-
-
-class Axis(object):
-    def __init__(self, units, start, end, step):
-        self.units = units
-        self.start = start
-        self.end = end
-        self.step = step
-
-    def __eq__(self, other):
-        # This is required for Unit testing
-        return self.units == other.units and self.start == other.start and self.end == other.end \
-            and self.step == other.step and isinstance(other, Axis)
-
-    def __repr__(self):
-        info = (self.units, self.start, self.end, self.step)
-        return "Axis(" + " ,".join(map(repr, info)) + ")"
-
 
 INVALID_PARAMS = 1
 INVALID_X_PARAMS = 2
@@ -146,19 +129,19 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             self._slice_view.clear_input_fields()
             self._slice_view.disable()
         else:
-            non_psd = all([not self._slice_plotter.workspace_provider.is_PSD(ws) for ws in workspace_selection])
+            non_psd = all([not loaded_workspaces[ws].is_PSD for ws in workspace_selection])
             workspace_selection = workspace_selection[0]
 
             self._slice_view.enable()
             self._slice_view.enable_units_choice(non_psd)
-            axis = self._slice_plotter.get_available_axis(workspace_selection)
+            axis = self._slice_plotter.get_available_axis(loaded_workspaces[workspace_selection])
             self._slice_view.populate_slice_x_options(axis)
             self._slice_view.populate_slice_y_options(axis[::-1])
             self.populate_slice_params()
 
     def populate_slice_params(self):
         try:
-            workspace_selection = self._get_main_presenter().get_selected_workspaces()[0]
+            workspace_selection = loaded_workspaces[self._get_main_presenter().get_selected_workspaces()[0]]
             x_min, x_max, x_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_x_axis())
             y_min, y_max, y_step = self._slice_plotter.get_axis_range(workspace_selection, self._slice_view.get_slice_y_axis())
         except (KeyError, RuntimeError, IndexError):

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -5,7 +5,7 @@ from .busy import show_busy
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.models.workspacemanager.file_io import get_save_directory
-from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
+from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces, get_workspace_name
 from .interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
 from .interfaces.main_presenter import MainPresenterInterface
 from .validation_decorators import require_main_presenter
@@ -64,7 +64,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
 
     def workspace_selection_changed(self):
         if self._workspace_manager_view.current_tab() == TAB_2D:
-            psd = all([self.get_workspace_provider().is_PSD(ws) for ws in self._workspace_manager_view.get_workspace_selected()])
+            psd = all([loaded_workspaces[ws].is_PSD for ws in self._workspace_manager_view.get_workspace_selected()])
             if psd and not self._psd:
                 self._workspace_manager_view.tab_changed.emit(TAB_2D)
                 self._psd = True
@@ -173,7 +173,6 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
 
     def set_selected_workspaces(self, workspace_list):
         get_index = self._workspace_manager_view.get_workspace_index
-        get_name = self._workspace_provider.get_workspace_name
         index_list = []
         for item in workspace_list:
             if isinstance(item, string_types):
@@ -181,7 +180,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             elif isinstance(item, int):
                 index_list.append(item)
             else:
-                index_list.append(get_index(get_name(item)))
+                index_list.append(get_index(get_workspace_name(item)))
         self._workspace_manager_view.set_workspace_selected(index_list)
 
     def update_displayed_workspaces(self):

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -11,10 +11,9 @@ from .validation_decorators import require_main_presenter
 
 
 class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
-    def __init__(self, workspace_view, workspace_provider):
+    def __init__(self, workspace_view):
         # TODO add validation checks
         self._workspace_manager_view = workspace_view
-        self._workspace_provider = workspace_provider
         self._main_presenter = None
         self._psd = True
 

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -5,7 +5,8 @@ from .busy import show_busy
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.models.workspacemanager.file_io import get_save_directory
-from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces, get_workspace_name
+from mslice.models.workspacemanager.mantid_workspace_provider import (get_workspace_handle, get_workspace_name,
+                                                                      get_workspace_names)
 from .interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
 from .interfaces.main_presenter import MainPresenterInterface
 from .validation_decorators import require_main_presenter
@@ -64,7 +65,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
 
     def workspace_selection_changed(self):
         if self._workspace_manager_view.current_tab() == TAB_2D:
-            psd = all([loaded_workspaces[ws].is_PSD for ws in self._workspace_manager_view.get_workspace_selected()])
+            psd = all([get_workspace_handle(ws).is_PSD for ws in self._workspace_manager_view.get_workspace_selected()])
             if psd and not self._psd:
                 self._workspace_manager_view.tab_changed.emit(TAB_2D)
                 self._psd = True
@@ -189,7 +190,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         This function must be called by the main presenter if any other
         presenter does any operation that changes the name or type of any existing workspace or creates or removes a
         workspace"""
-        self._workspace_manager_view.display_loaded_workspaces(loaded_workspaces.keys())
+        self._workspace_manager_view.display_loaded_workspaces(get_workspace_names())
 
     def _clear_displayed_error(self):
         self._workspace_manager_view.clear_displayed_error()

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -5,6 +5,7 @@ from .busy import show_busy
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.models.workspacemanager.file_io import get_save_directory
+from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
 from .interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
 from .interfaces.main_presenter import MainPresenterInterface
 from .validation_decorators import require_main_presenter
@@ -183,16 +184,13 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 index_list.append(get_index(get_name(item)))
         self._workspace_manager_view.set_workspace_selected(index_list)
 
-    def get_workspace_provider(self):
-        return self._workspace_provider
-
     def update_displayed_workspaces(self):
         """Update the workspaces shown to user.
 
         This function must be called by the main presenter if any other
         presenter does any operation that changes the name or type of any existing workspace or creates or removes a
         workspace"""
-        self._workspace_manager_view.display_loaded_workspaces(self._workspace_provider.get_workspace_names())
+        self._workspace_manager_view.display_loaded_workspaces(loaded_workspaces.keys())
 
     def _clear_displayed_error(self):
         self._workspace_manager_view.clear_displayed_error()

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import mock
-from mock import call
+from mock import call, patch
 import unittest
 import warnings
 
@@ -24,6 +24,7 @@ class CutPresenterTest(unittest.TestCase):
         self.main_presenter = mock.create_autospec(MainPresenterInterface)
 
     def test_constructor_success(self):
+        self.view.disable = mock.Mock()
         CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         self.view.disable.assert_called()
 
@@ -36,7 +37,9 @@ class CutPresenterTest(unittest.TestCase):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
         self.main_presenter.get_selected_workspace = mock.Mock(return_value=['a', 'b'])
-
+        for attribute in dir(CutView):
+            if not attribute.startswith("__"):
+                setattr(self.view, attribute, mock.Mock())
         cut_presenter.workspace_selection_changed()
         # make sure only the attributes in the tuple were called and nothing else
         for attribute in dir(CutView):
@@ -49,6 +52,7 @@ class CutPresenterTest(unittest.TestCase):
     def test_notify_presenter_clears_error(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
+        self.view.clear_displayed_error = mock.Mock()
         # This unit test will verify that notifying cut presenter will cause the error to be cleared on the view.
         # The actual subsequent procedure will fail, however this irrelevant to this. Hence the try, except blocks
         for command in [x for x in dir(Command) if x[0] != "_"]:
@@ -56,7 +60,8 @@ class CutPresenterTest(unittest.TestCase):
             self.view.clear_displayed_error.assert_called()
             self.view.reset_mock()
 
-    def test_workspace_selection_changed_single_cuttable_workspace(self):
+    @patch('mslice.presenters.cut_presenter.get_workspace_handle')
+    def test_workspace_selection_changed_single_cuttable_workspace(self, get_ws_handle_mock):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
         workspace = 'workspace'
@@ -69,6 +74,9 @@ class CutPresenterTest(unittest.TestCase):
         self.cut_algorithm.get_saved_cut_parameters = mock.Mock(return_value=(None, None))
         self.cut_plotter.workspace_provider = mock.create_autospec(WorkspaceProvider)
         self.cut_plotter.workspace_provider.is_PSD = mock.Mock(return_value=True)
+        ws_mock = mock.Mock()
+        ws_mock.is_PSD = False
+        get_ws_handle_mock.return_value = ws_mock
         cut_presenter.workspace_selection_changed()
         self.view.populate_cut_axis_options.assert_called_with(available_dimensions)
         self.view.enable.assert_called_with()
@@ -229,10 +237,8 @@ class CutPresenterTest(unittest.TestCase):
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
 
         cut_presenter.notify(Command.Plot)
-        self.cut_plotter.plot_cut.assert_called_with(selected_workspace=workspace, cut_axis=processed_axis,
-                                                     integration_axis=integration_axis,
-                                                     norm_to_one=is_norm, intensity_start=intensity_start,
-                                                     intensity_end=intensity_end, plot_over=False)
+        self.cut_plotter.plot_cut.assert_called_with(workspace, processed_axis, integration_axis,
+                                                     is_norm, intensity_start, intensity_end, plot_over=False)
 
     def test_plot_over_cut_fail(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
@@ -251,10 +257,8 @@ class CutPresenterTest(unittest.TestCase):
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         cut_presenter.notify(Command.PlotOver)
-        self.cut_plotter.plot_cut.assert_called_with(selected_workspace=workspace, cut_axis=processed_axis,
-                                                     integration_axis=integration_axis,
-                                                     norm_to_one=is_norm, intensity_start=None,
-                                                     intensity_end=intensity_end, plot_over=True)
+        self.cut_plotter.plot_cut.assert_called_with(workspace, processed_axis, integration_axis,
+                                                     is_norm, None, intensity_end, plot_over=True)
 
     def test_cut_single_save_to_workspace(self):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
@@ -273,6 +277,7 @@ class CutPresenterTest(unittest.TestCase):
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         self.cut_algorithm.compute_cut_xye = mock.Mock(return_value=('x', 'y', 'e'))
+        self.cut_plotter.plot_cut = mock.Mock()
         cut_presenter.notify(Command.SaveToWorkspace)
         self.cut_plotter.save_cut.assert_called_with((workspace, processed_axis, integration_axis, is_norm))
         self.cut_plotter.plot_cut.assert_not_called()
@@ -281,32 +286,29 @@ class CutPresenterTest(unittest.TestCase):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
         axis = Axis("units", "0", "100", "1")
-        processed_axis = Axis("units", 0, 100, 1)
-        integration_start = 3
-        integration_end = 8
+        processed_axis = Axis("units", 0.0, 100.0, 1.0)
+        integration_start = 3.0
+        integration_end = 8.0
         width = "2"
-        intensity_start = 11
-        intensity_end = 30
+        intensity_start = 11.0
+        intensity_end = 30.0
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
-        integration_axis1 = Axis('integrated axis', 3, 5, 0)
-        integration_axis2 = Axis('integrated axis', 5, 7, 0)
-        integration_axis3 = Axis('integrated axis', 7, 8, 0)
+        integration_axis1 = Axis('integrated axis', 3.0, 5.0, 0)
+        integration_axis2 = Axis('integrated axis', 5.0, 7.0, 0)
+        integration_axis3 = Axis('integrated axis', 7.0, 8.0, 0)
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
 
         cut_presenter.notify(Command.Plot)
         call_list = [
-            call(selected_workspace=workspace, cut_axis=processed_axis, integration_axis=integration_axis1,
-                 norm_to_one=is_norm, intensity_start=intensity_start,
-                 intensity_end=intensity_end, plot_over=False),
-            call(selected_workspace=workspace, cut_axis=processed_axis, integration_axis=integration_axis2,
-                 norm_to_one=is_norm, intensity_start=intensity_start,
-                 intensity_end=intensity_end, plot_over=True),
-            call(selected_workspace=workspace, cut_axis=processed_axis, integration_axis=integration_axis3,
-                 norm_to_one=is_norm, intensity_start=intensity_start,
-                 intensity_end=intensity_end, plot_over=True)
+            call(workspace, processed_axis, integration_axis1, is_norm,
+                 intensity_start, intensity_end, plot_over=False),
+            call(workspace, processed_axis, integration_axis2,
+                 is_norm, intensity_start, intensity_end, plot_over=True),
+            call(workspace, processed_axis, integration_axis3,
+                 is_norm, intensity_start, intensity_end, plot_over=True)
         ]
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
 
@@ -329,16 +331,15 @@ class CutPresenterTest(unittest.TestCase):
         self.cut_algorithm.get_saved_cut_parameters = mock.Mock(return_value=(None, None))
         cut_presenter.notify(Command.Plot)
         call_list = [
-            call(selected_workspace=selected_workspaces[0], cut_axis=processed_axis,
-                 integration_axis=integration_axis, norm_to_one=is_norm, intensity_start=intensity_start,
-                 intensity_end=intensity_end, plot_over=False),
-            call(selected_workspace=selected_workspaces[1], cut_axis=processed_axis,
-                 integration_axis=integration_axis, norm_to_one=is_norm, intensity_start=intensity_start,
-                 intensity_end=intensity_end, plot_over=True),
+            call(selected_workspaces[0], processed_axis, integration_axis, is_norm,
+                 intensity_start, intensity_end, plot_over=False),
+            call(selected_workspaces[1], processed_axis, integration_axis, is_norm,
+                 intensity_start, intensity_end, plot_over=True),
         ]
         self.cut_plotter.plot_cut.assert_has_calls(call_list)
 
-    def test_change_axis(self):
+    @patch('mslice.presenters.cut_presenter.get_workspace_handle')
+    def test_change_axis(self, get_ws_handle_mock):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
         # Set up a mock workspace with two sets of cutable axes, then change to this ws
@@ -348,8 +349,9 @@ class CutPresenterTest(unittest.TestCase):
         available_dimensions = ["dim1", "dim2"]
         self.cut_algorithm.get_available_axis = mock.Mock(return_value=available_dimensions)
         self.cut_algorithm.get_saved_cut_parameters = mock.Mock(return_value=(None, None))
-        self.cut_plotter.workspace_provider = mock.create_autospec(WorkspaceProvider)
-        self.cut_plotter.workspace_provider.is_PSD = mock.Mock(return_value=True)
+        ws_mock = mock.Mock()
+        ws_mock.is_PSD = False
+        get_ws_handle_mock.return_value = ws_mock
         cut_presenter.workspace_selection_changed()
         # Set up a set of input values for this cut, then simulate changing axes.
         fields1 = dict()
@@ -362,6 +364,7 @@ class CutPresenterTest(unittest.TestCase):
         self.view.get_input_fields = mock.Mock(return_value=fields1)
         self.view.get_cut_axis = mock.Mock(return_value='dim2')
         self.view.is_fields_cleared = mock.Mock(return_value=False)
+        self.view.populate_input_fields = mock.Mock()
         cut_presenter.notify(Command.AxisChanged)
         self.cut_algorithm.set_saved_cut_parameters.assert_called_with(workspace, 'dim1', fields1)
         self.view.clear_input_fields.assert_called_with(keep_axes=True)
@@ -382,7 +385,8 @@ class CutPresenterTest(unittest.TestCase):
         self.cut_algorithm.get_saved_cut_parameters.assert_called_with(workspace, 'dim1')
         self.view.populate_input_fields.assert_called_with(fields1)
 
-    def test_cut_step_size(self):
+    @patch('mslice.presenters.cut_presenter.get_workspace_handle')
+    def test_cut_step_size(self, get_ws_handle_mock):
         cut_presenter = CutPresenter(self.view, self.cut_algorithm, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
         workspace = 'workspace'
@@ -393,6 +397,9 @@ class CutPresenterTest(unittest.TestCase):
         available_dimensions = ["dim1", "dim2"]
         self.cut_algorithm.get_available_axis = mock.Mock(return_value=available_dimensions)
         self.cut_algorithm.get_saved_cut_parameters = mock.Mock(return_value=(None, None))
+        ws_mock = mock.Mock()
+        ws_mock.is_PSD = False
+        get_ws_handle_mock.return_value = ws_mock
         cut_presenter.workspace_selection_changed()
         self.cut_algorithm.get_axis_range.assert_any_call(workspace, available_dimensions[0])
         self.cut_algorithm.get_axis_range.assert_any_call(workspace, available_dimensions[1])
@@ -418,6 +425,7 @@ class CutPresenterTest(unittest.TestCase):
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         self.view.get_cut_axis_step = mock.Mock(return_value="")
         self.view.get_minimum_step = mock.Mock(return_value=1)
+        self.cut_algorithm.compute_cut = mock.Mock()
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")

--- a/mslice/tests/data_loader_test.py
+++ b/mslice/tests/data_loader_test.py
@@ -4,44 +4,50 @@ from os.path import join
 import unittest
 
 import mock
-from mock import call, patch
+from mock import call, patch, PropertyMock
 
-from mslice.models.workspacemanager.workspace_provider import WorkspaceProvider
 from mslice.presenters.data_loader_presenter import DataLoaderPresenter
 from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.widgets.dataloader.dataloader import DataLoaderWidget
 
 class DataLoaderTest(unittest.TestCase):
 
+
     def setUp(self):
-        self.workspace_provider = mock.create_autospec(spec=WorkspaceProvider)
         self.view = mock.create_autospec(spec=DataLoaderWidget)
         self.view.busy.emit = mock.Mock()
         self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.presenter = DataLoaderPresenter(self.view)
         self.presenter.register_master(self.main_presenter)
-        self.presenter.set_workspace_provider(self.workspace_provider)
 
-    def test_load_one_workspace(self):
+    @patch('mslice.presenters.data_loader_presenter.load')
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_handle')
+    def test_load_one_workspace(self, get_ws_handle_mock, load_mock):
         # Create a view that will return a path on call to get_workspace_to_load_path
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path_to_nexus = join(tempdir, 'cde.nxs')
         workspace_name = 'cde'
-        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[])
-        self.workspace_provider.get_EMode = mock.Mock(return_value='Indirect')
-        self.workspace_provider.has_efixed = mock.Mock(return_value=False)
-        self.workspace_provider.set_efixed = mock.Mock()
         self.view.get_workspace_efixed = mock.Mock(return_value=(1.845, False))
+        ws_mock = mock.Mock()
+        get_ws_handle_mock.return_value = ws_mock
+        e_fixed = PropertyMock()
+        e_mode = PropertyMock(return_value="Indirect")
+        ef_defined = PropertyMock(return_value=False)
+        type(ws_mock).e_fixed = e_fixed
+        type(ws_mock).e_mode = e_mode
+        type(ws_mock).ef_defined = ef_defined
 
         self.presenter.load_workspace([path_to_nexus])
-        self.workspace_provider.load.assert_called_with(filename=path_to_nexus, output_workspace=workspace_name)
-        self.view.get_workspace_efixed.assert_called_with(workspace_name, False, None)
-        self.workspace_provider.set_efixed.assert_called_once_with(workspace_name, 1.845)
+        load_mock.assert_called_with(filename=path_to_nexus, output_workspace=workspace_name)
+        e_fixed.assert_called_once_with(1.845)
         self.main_presenter.show_workspace_manager_tab.assert_called_once()
         self.main_presenter.show_tab_for_workspace.assert_called_once()
         self.main_presenter.update_displayed_workspaces.assert_called_once()
 
-    def test_load_multiple_workspaces(self):
+    @patch('mslice.presenters.data_loader_presenter.load')
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_names')
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_handle')
+    def test_load_multiple_workspaces(self, get_ws_handle_mock, get_ws_names_mock, load_mock):
         # Create a view that will return three filepaths on 3 subsequent calls to get_workspace_to_load_path
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path1 = join(tempdir, 'file1.nxs')
@@ -51,76 +57,100 @@ class DataLoaderTest(unittest.TestCase):
         ws_name2 = 'file2'
         ws_name3 = 'file3'
         # Make the third workspace something not in current workspace list, so don't need ask overwrite
-        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[ws_name1, ws_name2, ''])
-        self.workspace_provider.get_EMode = mock.Mock(return_value='Direct')
+        get_ws_names_mock.return_value=[ws_name1, ws_name2, '']
+        ws_mock = mock.Mock()
+        get_ws_handle_mock.return_value = ws_mock
+        e_mode = PropertyMock(return_value='Direct')
+        type(ws_mock).e_mode = e_mode
         # Makes the first file not load because of a name collision
         self.view.confirm_overwrite_workspace = mock.Mock(side_effect=[False, True, True])
         # Makes the second file fail to load, to check if it raise the correct error
-        self.workspace_provider.load = mock.Mock(side_effect=[RuntimeError, 0, 0])
+        load_mock.side_effect=[RuntimeError, 0, 0]
         self.presenter.load_workspace([path1, path2, path3])
         # Because of the name collision, the first file name is not loaded.
         load_calls = [call(filename=path2, output_workspace=ws_name2),
                       call(filename=path3, output_workspace=ws_name3)]
-        self.workspace_provider.load.assert_has_calls(load_calls)
+        load_mock.assert_has_calls(load_calls)
         self.view.error_unable_to_open_file.assert_called_once_with(ws_name2)
         self.view.no_workspace_has_been_loaded.assert_called_once_with(ws_name1)
         self.view.get_workspace_efixed.assert_not_called()
 
-    def test_load_workspace_dont_overwrite(self):
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_names')
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_handle')
+    def test_load_workspace_dont_overwrite(self, get_ws_handle_mock, get_ws_names_mock):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path = join(tempdir, 'file.nxs')
         ws_name = 'file'
-        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[ws_name])
-        self.workspace_provider.get_EMode = mock.Mock(return_value='Direct')
+        get_ws_names_mock.return_value=[ws_name]
+        ws_mock = mock.Mock()
+        get_ws_handle_mock.return_value = ws_mock
+        e_mode = PropertyMock(return_value='Direct')
+        type(ws_mock).e_mode = e_mode
         self.view.confirm_overwrite_workspace = mock.Mock(return_value=False)
 
         self.presenter.load_workspace([path])
         self.view.confirm_overwrite_workspace.assert_called_once()
         self.view.no_workspace_has_been_loaded.assert_called_once()
 
-    def test_load_workspace_fail(self):
+    @patch('mslice.presenters.data_loader_presenter.load')
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_names')
+    def test_load_workspace_fail(self, get_ws_names_mock, load_mock):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path_to_nexus = join(tempdir, 'cde.nxs')
         workspace_name = 'cde'
-        self.workspace_provider.get_workspace_names = mock.Mock(return_value=[workspace_name])
-        self.workspace_provider.load = mock.Mock(side_effect=RuntimeError)
+        get_ws_names_mock.return_value=[workspace_name]
+        load_mock.side_effect=RuntimeError
 
         self.presenter.load_workspace([path_to_nexus])
         self.view.error_unable_to_open_file.assert_called_once()
 
-    def test_load_and_merge(self):
+    @patch('mslice.presenters.data_loader_presenter.load')
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_handle')
+    def test_load_and_merge(self, get_ws_handle_mock, load_mock):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path1 = join(tempdir, 'file1.nxs')
         path2 = join(tempdir, 'file2.nxs')
         path3 = join(tempdir, 'file3.nxs')
-        self.workspace_provider.get_EMode = mock.Mock(return_value='Direct')
-
+        # self.workspace_provider.get_EMode = mock.Mock(return_value='Direct')
+        ws_mock = mock.Mock()
+        get_ws_handle_mock.return_value = ws_mock
         self.presenter.load_workspace([path1, path2, path3], True)
-        self.workspace_provider.load.assert_called_once_with(filename=path1 + '+' + path2 +'+' + path3,
+        load_mock.assert_called_once_with(filename=path1 + '+' + path2 +'+' + path3,
                                                              output_workspace='file1_merged')
 
     @patch('mslice.presenters.data_loader_presenter.load_from_ascii')
-    def test_load_ascii(self, load_ascii_mock):
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_handle')
+    @patch('mslice.presenters.data_loader_presenter.load')
+    def test_load_ascii(self, load_mock, get_ws_handle_mock, load_ascii_mock):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path = join(tempdir, 'abc.txt')
-        self.workspace_provider.get_EMode = mock.Mock(return_value='Direct')
+        ws_mock = mock.Mock()
+        get_ws_handle_mock.return_value = ws_mock
+        e_mode = PropertyMock(return_value='Direct')
+        type(ws_mock).e_mode = e_mode
 
         self.presenter.load_workspace([path])
         load_ascii_mock.assert_called_once_with(path, 'abc')
-        self.workspace_provider.load.assert_not_called()
+        load_mock.assert_not_called()
         self.view.get_workspace_efixed.assert_not_called()
         self.main_presenter.show_workspace_manager_tab.assert_called_once()
         self.main_presenter.show_tab_for_workspace.assert_called_once()
         self.main_presenter.update_displayed_workspaces.assert_called_once()
 
     @patch('mslice.presenters.data_loader_presenter.load_from_ascii')
-    def test_load_multiple_types(self, load_ascii_mock):
+    @patch('mslice.presenters.data_loader_presenter.get_workspace_handle')
+    @patch('mslice.presenters.data_loader_presenter.load')
+    def test_load_multiple_types(self, load_mock, get_ws_handle_mock, load_ascii_mock):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path_ascii = join(tempdir, 'ascii.txt')
         path_nexus = join(tempdir, 'nexus.nxs')
-        self.workspace_provider.get_EMode = mock.Mock(return_value='Direct')
+        ws_mock = mock.Mock()
+        get_ws_handle_mock.return_value = ws_mock
+        e_mode = PropertyMock(return_value='Direct')
+        type(ws_mock).e_mode = e_mode
+
         self.presenter.load_workspace([path_ascii, path_nexus])
-        self.workspace_provider.load.assert_called_once_with(filename=path_nexus, output_workspace='nexus')
+        load_mock.assert_called_once_with(filename=path_nexus, output_workspace='nexus')
         load_ascii_mock.assert_called_once_with(path_ascii, 'ascii')
         self.main_presenter.show_workspace_manager_tab.assert_called()
         self.main_presenter.update_displayed_workspaces.assert_called()

--- a/mslice/tests/data_loader_test.py
+++ b/mslice/tests/data_loader_test.py
@@ -10,8 +10,8 @@ from mslice.presenters.data_loader_presenter import DataLoaderPresenter
 from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.widgets.dataloader.dataloader import DataLoaderWidget
 
-class DataLoaderTest(unittest.TestCase):
 
+class DataLoaderTest(unittest.TestCase):
 
     def setUp(self):
         self.view = mock.create_autospec(spec=DataLoaderWidget)
@@ -57,11 +57,8 @@ class DataLoaderTest(unittest.TestCase):
         ws_name2 = 'file2'
         ws_name3 = 'file3'
         # Make the third workspace something not in current workspace list, so don't need ask overwrite
-        get_ws_names_mock.return_value=[ws_name1, ws_name2, '']
-        ws_mock = mock.Mock()
-        get_ws_handle_mock.return_value = ws_mock
-        e_mode = PropertyMock(return_value='Direct')
-        type(ws_mock).e_mode = e_mode
+        get_ws_names_mock.return_value = [ws_name1, ws_name2, '']
+        get_ws_handle_mock.e_mode.return_value = 'Direct'
         # Makes the first file not load because of a name collision
         self.view.confirm_overwrite_workspace = mock.Mock(side_effect=[False, True, True])
         # Makes the second file fail to load, to check if it raise the correct error
@@ -81,11 +78,8 @@ class DataLoaderTest(unittest.TestCase):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path = join(tempdir, 'file.nxs')
         ws_name = 'file'
-        get_ws_names_mock.return_value=[ws_name]
-        ws_mock = mock.Mock()
-        get_ws_handle_mock.return_value = ws_mock
-        e_mode = PropertyMock(return_value='Direct')
-        type(ws_mock).e_mode = e_mode
+        get_ws_names_mock.return_value = [ws_name]
+        get_ws_handle_mock.e_mode.return_value = 'Direct'
         self.view.confirm_overwrite_workspace = mock.Mock(return_value=False)
 
         self.presenter.load_workspace([path])
@@ -115,8 +109,8 @@ class DataLoaderTest(unittest.TestCase):
         ws_mock = mock.Mock()
         get_ws_handle_mock.return_value = ws_mock
         self.presenter.load_workspace([path1, path2, path3], True)
-        load_mock.assert_called_once_with(filename=path1 + '+' + path2 +'+' + path3,
-                                                             output_workspace='file1_merged')
+        load_mock.assert_called_once_with(filename=path1 + '+' + path2 + '+' + path3,
+                                          output_workspace='file1_merged')
 
     @patch('mslice.presenters.data_loader_presenter.load_from_ascii')
     @patch('mslice.presenters.data_loader_presenter.get_workspace_handle')
@@ -124,10 +118,7 @@ class DataLoaderTest(unittest.TestCase):
     def test_load_ascii(self, load_mock, get_ws_handle_mock, load_ascii_mock):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path = join(tempdir, 'abc.txt')
-        ws_mock = mock.Mock()
-        get_ws_handle_mock.return_value = ws_mock
-        e_mode = PropertyMock(return_value='Direct')
-        type(ws_mock).e_mode = e_mode
+        get_ws_handle_mock.return_value.e_mode = 'Direct'
 
         self.presenter.load_workspace([path])
         load_ascii_mock.assert_called_once_with(path, 'abc')
@@ -144,10 +135,7 @@ class DataLoaderTest(unittest.TestCase):
         tempdir = gettempdir()  # To ensure sample paths are valid on platform of execution
         path_ascii = join(tempdir, 'ascii.txt')
         path_nexus = join(tempdir, 'nexus.nxs')
-        ws_mock = mock.Mock()
-        get_ws_handle_mock.return_value = ws_mock
-        e_mode = PropertyMock(return_value='Direct')
-        type(ws_mock).e_mode = e_mode
+        get_ws_handle_mock.return_value.e_mode = 'Direct'
 
         self.presenter.load_workspace([path_ascii, path_nexus])
         load_mock.assert_called_once_with(filename=path_nexus, output_workspace='nexus')

--- a/mslice/tests/file_io_test.py
+++ b/mslice/tests/file_io_test.py
@@ -82,8 +82,8 @@ class FileIOTest(unittest.TestCase):
     def test_save_cut_to_ascii(self, output_method):
         ws_name = output_workspace_name("workspace", -1.5, 2)
         raw_ws = CreateMDHistoWorkspace(SignalInput=[1, 2], ErrorInput=[4, 5], Dimensionality=1, Extents=[-1, 5],
-                                    NumberOfBins=2, Names='Dim1', Units="units", OutputWorkspace=ws_name,
-                                    StoreInADS=False)
+                                        NumberOfBins=2, Names='Dim1', Units="units", OutputWorkspace=ws_name,
+                                        StoreInADS=False)
         ws = HistogramWorkspace(raw_ws)
         _save_cut_to_ascii(ws, ws_name, "some_path")
         output_method.assert_called_once()
@@ -93,8 +93,8 @@ class FileIOTest(unittest.TestCase):
     @patch('mslice.models.workspacemanager.file_io._output_data_to_ascii')
     def test_save_slice_to_ascii(self, output_method):
         raw_ws = CreateMDHistoWorkspace(SignalInput=[1, 2, 3, 4], ErrorInput=[3, 4, 5, 6], Dimensionality=2,
-                                    Extents=[-10, 10, -10, 10], NumberOfBins='2,2', Names='Dim1,Dim2',
-                                    Units="units1,units2", OutputWorkspace='workspace', StoreInADS=False)
+                                        Extents=[-10, 10, -10, 10], NumberOfBins='2,2', Names='Dim1,Dim2',
+                                        Units="units1,units2", OutputWorkspace='workspace', StoreInADS=False)
         ws = HistogramWorkspace(raw_ws)
         _save_slice_to_ascii(ws, "path1")
         output_method.assert_called_once()

--- a/mslice/tests/file_io_test.py
+++ b/mslice/tests/file_io_test.py
@@ -10,6 +10,7 @@ from mantid.simpleapi import CreateMDHistoWorkspace
 
 from mslice.models.cut.mantid_cut_algorithm import output_workspace_name
 from mslice.models.workspacemanager.file_io import _save_cut_to_ascii, _save_slice_to_ascii, get_save_directory
+from mslice.workspace.histogram_workspace import HistogramWorkspace
 
 
 class FileIOTest(unittest.TestCase):
@@ -80,9 +81,10 @@ class FileIOTest(unittest.TestCase):
     @patch('mslice.models.workspacemanager.file_io._output_data_to_ascii')
     def test_save_cut_to_ascii(self, output_method):
         ws_name = output_workspace_name("workspace", -1.5, 2)
-        ws = CreateMDHistoWorkspace(SignalInput=[1, 2], ErrorInput=[4, 5], Dimensionality=1, Extents=[-1, 5],
+        raw_ws = CreateMDHistoWorkspace(SignalInput=[1, 2], ErrorInput=[4, 5], Dimensionality=1, Extents=[-1, 5],
                                     NumberOfBins=2, Names='Dim1', Units="units", OutputWorkspace=ws_name,
                                     StoreInADS=False)
+        ws = HistogramWorkspace(raw_ws)
         _save_cut_to_ascii(ws, ws_name, "some_path")
         output_method.assert_called_once()
         self.assertEqual(output_method.call_args[0][0], 'some_path')
@@ -90,9 +92,10 @@ class FileIOTest(unittest.TestCase):
 
     @patch('mslice.models.workspacemanager.file_io._output_data_to_ascii')
     def test_save_slice_to_ascii(self, output_method):
-        ws = CreateMDHistoWorkspace(SignalInput=[1, 2, 3, 4], ErrorInput=[3, 4, 5, 6], Dimensionality=2,
+        raw_ws = CreateMDHistoWorkspace(SignalInput=[1, 2, 3, 4], ErrorInput=[3, 4, 5, 6], Dimensionality=2,
                                     Extents=[-10, 10, -10, 10], NumberOfBins='2,2', Names='Dim1,Dim2',
                                     Units="units1,units2", OutputWorkspace='workspace', StoreInADS=False)
+        ws = HistogramWorkspace(raw_ws)
         _save_slice_to_ascii(ws, "path1")
         output_method.assert_called_once()
         self.assertEqual(output_method.call_args[0][0], 'path1')

--- a/mslice/tests/file_io_test.py
+++ b/mslice/tests/file_io_test.py
@@ -82,9 +82,8 @@ class FileIOTest(unittest.TestCase):
     def test_save_cut_to_ascii(self, output_method):
         ws_name = output_workspace_name("workspace", -1.5, 2)
         raw_ws = CreateMDHistoWorkspace(SignalInput=[1, 2], ErrorInput=[4, 5], Dimensionality=1, Extents=[-1, 5],
-                                        NumberOfBins=2, Names='Dim1', Units="units", OutputWorkspace=ws_name,
-                                        StoreInADS=False)
-        ws = HistogramWorkspace(raw_ws)
+                                        NumberOfBins=2, Names='Dim1', Units="units", OutputWorkspace=ws_name)
+        ws = HistogramWorkspace(raw_ws, ws_name)
         _save_cut_to_ascii(ws, ws_name, "some_path")
         output_method.assert_called_once()
         self.assertEqual(output_method.call_args[0][0], 'some_path')
@@ -94,8 +93,8 @@ class FileIOTest(unittest.TestCase):
     def test_save_slice_to_ascii(self, output_method):
         raw_ws = CreateMDHistoWorkspace(SignalInput=[1, 2, 3, 4], ErrorInput=[3, 4, 5, 6], Dimensionality=2,
                                         Extents=[-10, 10, -10, 10], NumberOfBins='2,2', Names='Dim1,Dim2',
-                                        Units="units1,units2", OutputWorkspace='workspace', StoreInADS=False)
-        ws = HistogramWorkspace(raw_ws)
+                                        Units="units1,units2", OutputWorkspace='workspace')
+        ws = HistogramWorkspace(raw_ws, 'workspace')
         _save_slice_to_ascii(ws, "path1")
         output_method.assert_called_once()
         self.assertEqual(output_method.call_args[0][0], 'path1')

--- a/mslice/tests/histogram_workspace_test.py
+++ b/mslice/tests/histogram_workspace_test.py
@@ -17,10 +17,10 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   SignalInput=signal, ErrorInput=error,
                                                                   NumberOfBins='10,10', Names='Dim1,Dim2',
                                                                   Units='U,U', OutputWorkspace='testHistoWorkspace',
-                                                                  StoreInADS=False))
+                                                                  ), 'testHistoWorkspace')
 
     def test_invalid_workspace(self):
-        self.assertRaises(TypeError, lambda: HistogramWorkspace(4))
+        self.assertRaises(TypeError, lambda: HistogramWorkspace(4, 'name'))
 
     def test_get_coordinates(self):
         expected = np.linspace(0, 100, 10)

--- a/mslice/tests/pixel_workspace_test.py
+++ b/mslice/tests/pixel_workspace_test.py
@@ -12,12 +12,12 @@ class PixelWorkspaceTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):  # create (non-zero) test data
         sim_workspace = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-10, 1, 10],
-                                                  UnitX='DeltaE', OutputWorkspace='simws', StoreInADS=False)
-        AddSampleLog(sim_workspace, LogName='Ei', LogText='3.', LogType='Number', StoreInADS=False)
+                                                  UnitX='DeltaE', OutputWorkspace='simws')
+        AddSampleLog(sim_workspace, LogName='Ei', LogText='3.', LogType='Number')
         cls.workspace = ConvertToMD(InputWorkspace=sim_workspace, OutputWorkspace="convert_ws", QDimensions='|Q|',
                                     dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
-                                    SplitInto='50,50', StoreInADS=False)
-        cls.workspace = PixelWorkspace(cls.workspace)
+                                    SplitInto='50,50')
+        cls.workspace = PixelWorkspace(cls.workspace, 'convert_ws')
 
     def test_invalid_workspace(self):
         self.assertRaises(TypeError, lambda: PixelWorkspace(4))

--- a/mslice/tests/slice_algorithm_test.py
+++ b/mslice/tests/slice_algorithm_test.py
@@ -46,10 +46,9 @@ class SliceAlgorithmTest(unittest.TestCase):
         self.assertAlmostEqual(chi_m[10][15], 0.005713, 6)
         self.assertAlmostEqual(chi_m[29][24], 0.016172, 6)
 
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EFixed')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_workspace_handle')
-    def test_compute_d2sigma(self, ws_handle_mock, get_efixed_mock):
-        get_efixed_mock.return_value = 20
+    @patch('mslice.models.slice.mantid_slice_algorithm.get_workspace_handle')
+    def test_compute_d2sigma(self, ws_handle_mock):
+        ws_handle_mock.return_value.e_fixed = 20
         d2sigma = self.slice_alg.compute_d2sigma(self.sim_scattering_data, None, self.e_axis, True)
         d2sigma_rotated = self.slice_alg.compute_d2sigma(self.scattering_rotated, None, self.e_axis, False)
         np.testing.assert_array_almost_equal(d2sigma, invert_axes(d2sigma_rotated), 6)
@@ -73,46 +72,39 @@ class SliceAlgorithmTest(unittest.TestCase):
         self.assertAlmostEqual(gdos[10][15], 0.697758, 6)
         self.assertAlmostEqual(gdos[29][24], 2246.999938, 6)
 
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EFixed')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EMode')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_workspace_handle')
-    def test_recoil_line(self, ws_handle_mock, emode_mock, efixed_mock):
-        emode_mock.return_value = 'Direct'
-        efixed_mock.return_value = 20
+    @patch('mslice.models.slice.mantid_slice_algorithm.get_workspace_handle')
+    def test_recoil_line(self, ws_handle_mock):
+        ws_handle_mock.return_value.e_mode = 'Direct'
+        ws_handle_mock.return_value.e_fixed = 20
         x_axis, line = self.slice_alg.compute_recoil_line('ws_name', self.q_axis)
         self.assertEqual(len(line), 30)
         self.assertAlmostEqual(line[0], 0.020721, 6)
         self.assertAlmostEqual(line[10], 2.507271, 6)
         self.assertAlmostEqual(line[29], 18.649123, 6)
 
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EFixed')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EMode')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_workspace_handle')
-    def test_recoil_line_mass(self, ws_handle_mock, emode_mock, efixed_mock):
-        emode_mock.return_value = 'Direct'
-        efixed_mock.return_value = 20
+    @patch('mslice.models.slice.mantid_slice_algorithm.get_workspace_handle')
+    def test_recoil_line_mass(self, ws_handle_mock):
+        ws_handle_mock.return_value.e_mode = 'Direct'
+        ws_handle_mock.return_value.e_fixed = 20
         x_axis, line = self.slice_alg.compute_recoil_line('ws_name', self.q_axis, 4)
         self.assertEqual(len(line), 30)
         self.assertAlmostEqual(line[0], 0.005180, 6)
         self.assertAlmostEqual(line[10], 0.626818, 6)
         self.assertAlmostEqual(line[29], 4.662281, 6)
 
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EFixed')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EMode')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_workspace_handle')
-    def test_recoil_line_degrees(self, ws_handle_mock, emode_mock, efixed_mock):
-        emode_mock.return_value = 'Direct'
-        efixed_mock.return_value = 20
+    @patch('mslice.models.slice.mantid_slice_algorithm.get_workspace_handle')
+    def test_recoil_line_degrees(self, ws_handle_mock):
+        ws_handle_mock.return_value.e_mode = 'Direct'
+        ws_handle_mock.return_value.e_fixed = 20
         x_axis, line = self.slice_alg.compute_recoil_line('ws_name', self.q_axis_degrees)
         self.assertEqual(len(line), 30)
         self.assertAlmostEqual(line[0], 0.054744, 6)
         self.assertAlmostEqual(line[10], 0.999578, 6)
         self.assertAlmostEqual(line[29], 5.276328, 6)
 
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EFixed')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_workspace_handle')
-    def test_powder_line(self, ws_handle_mock, efixed_mock):
-        efixed_mock.return_value = 20
+    @patch('mslice.models.slice.mantid_slice_algorithm.get_workspace_handle')
+    def test_powder_line(self, ws_handle_mock):
+        ws_handle_mock.return_value.e_fixed = 20
         x, y = self.slice_alg.compute_powder_line('ws_name', Axis('|Q|', 0.1, 9.1, 0.1), 'Copper')
         self.assertEqual(len(x), len(y))
         self.assertAlmostEqual(x[0], 3.010539, 6)
@@ -121,10 +113,9 @@ class SliceAlgorithmTest(unittest.TestCase):
         self.assertEqual(y[0], 1)
         self.assertEqual(y[1], -1)
 
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_EFixed')
-    @patch('mslice.models.slice.mantid_slice_algorithm.MantidWorkspaceProvider.get_workspace_handle')
-    def test_powder_line_degrees(self, ws_handle_mock, efixed_mock):
-        efixed_mock.return_value = 20
+    @patch('mslice.models.slice.mantid_slice_algorithm.get_workspace_handle')
+    def test_powder_line_degrees(self, ws_handle_mock):
+        ws_handle_mock.return_value.e_fixed = 20
         x, y = self.slice_alg.compute_powder_line('ws_name', Axis('Degrees', 3, 93, 1), 'Copper')
         self.assertEqual(len(x), len(y))
         self.assertAlmostEqual(x[0], 57.961394, 6)

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -120,7 +120,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_colourmap.return_value = colourmap
 
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_plotter.plot_slice.assert_not_called( )
+        assert(not self.slice_plotter.plot_slice.called)
         self.slice_view.error_invalid_x_params.assert_called_once_with()
 
     def test_plot_slice_x_start_bigger_than_x_stop_fail(self):
@@ -150,7 +150,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_colourmap.return_value = colourmap
 
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_plotter.plot_slice.assert_not_called( )
+        assert(not self.slice_plotter.plot_slice.called)
         self.slice_view.error_invalid_x_params.assert_called_once_with()
 
     def test_plot_slice_invalid_string_y_params_fail(self):
@@ -180,7 +180,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_colourmap.return_value = colourmap
 
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_plotter.plot_slice.assert_not_called( )
+        assert(not self.slice_plotter.plot_slice.called)
         self.slice_view.error_invalid_y_params.assert_called_once_with()
 
     def test_plot_slice_invalid_y_params_y_end_less_than_y_start_fail(self):
@@ -210,7 +210,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_colourmap.return_value = colourmap
 
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_plotter.plot_slice.assert_not_called( )
+        assert(not self.slice_plotter.plot_slice.called)
         self.slice_view.error_invalid_y_params.assert_called_once_with()
 
     def test_plot_slice_invalid_intensity_params_fail(self):
@@ -240,7 +240,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_colourmap.return_value = colourmap
 
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_plotter.plot_slice.assert_not_called( )
+        assert(not self.slice_plotter.plot_slice.called)
         self.slice_view.error_invalid_intensity_params.assert_called_once_with()
 
     def test_plot_slice_intensity_end_less_than_intensity_start_fail(self):
@@ -270,7 +270,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_colourmap.return_value = colourmap
 
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_plotter.plot_slice.assert_not_called( )
+        assert(not self.slice_plotter.plot_slice.called)
         self.slice_view.error_invalid_intensity_params.assert_called_once_with()
 
     def test_plot_slice_error_handling(self):
@@ -305,25 +305,26 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         # Test empty workspace, multiple workspaces
         self.main_presenter.get_selected_workspaces.return_value = []
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_view.error_select_one_workspace.assert_called()
+        assert(self.slice_view.error_select_one_workspace.called)
         self.main_presenter.get_selected_workspaces.return_value = [selected_workspace, selected_workspace]
+        self.slice_view.error_select_one_workspace.reset_mock()
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_view.error_select_one_workspace.assert_called()
+        assert(self.slice_view.error_select_one_workspace.called)
         # Test invalid axes
         self.main_presenter.get_selected_workspaces.return_value = [selected_workspace]
         self.slice_view.get_slice_y_axis.return_value = x.units
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_view.error_invalid_plot_parameters.assert_called()
+        assert(self.slice_view.error_invalid_plot_parameters.called)
         # Test invalid smoothing parameters
         self.slice_view.get_slice_y_axis.return_value = y.units
         self.slice_view.get_slice_smoothing.return_value = 'a'
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_view.error_invalid_smoothing_params.assert_called()
+        assert(self.slice_view.error_invalid_smoothing_params.called)
         # Simulate matplotlib error
         self.slice_view.get_slice_smoothing.return_value = smoothing
         self.slice_plotter.plot_slice = mock.Mock(side_effect=ValueError('minvalue must be less than or equal to maxvalue'))
         self.slice_plotter_presenter.notify(Command.DisplaySlice)
-        self.slice_view.error_invalid_intensity_params.assert_called()
+        assert(self.slice_view.error_invalid_intensity_params.called)
         self.slice_plotter.plot_slice = mock.Mock(side_effect=ValueError('something bad'))
         self.assertRaises(ValueError, self.slice_plotter_presenter.notify, Command.DisplaySlice)
 
@@ -336,31 +337,35 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_plotter.get_available_axis = mock.Mock(return_value=axis)
 
         slice_plotter_presenter.workspace_selection_changed()
-        self.slice_view.clear_input_fields.assert_called()
+        assert(self.slice_view.clear_input_fields.called)
 
-    def test_workspace_selection_changed(self):
+    @mock.patch('mslice.presenters.slice_plotter_presenter.get_workspace_handle')
+    def test_workspace_selection_changed(self, get_ws_handle_mock):
         slice_plotter_presenter = SlicePlotterPresenter( self.slice_view, self.slice_plotter )
         slice_plotter_presenter.register_master(self.main_presenter)
         workspace = 'workspace'
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=[workspace])
+        ws_mock = mock.Mock()
+        get_ws_handle_mock.return_value = ws_mock
         dims = ['dim1', 'dim2']
         self.slice_plotter.get_available_axis = mock.Mock(return_value=dims)
         self.slice_plotter.get_axis_range = mock.Mock(return_value=(0,1,0.1))
         self.slice_plotter.workspace_provider = mock.create_autospec(WorkspaceProvider)
         self.slice_plotter.workspace_provider.is_PSD = mock.Mock(return_value=True)
         slice_plotter_presenter.workspace_selection_changed()
-        self.slice_view.populate_slice_x_options.assert_called()
-        self.slice_view.populate_slice_y_options.assert_called()
-        self.slice_plotter.get_available_axis.assert_called()
-        self.slice_plotter.get_axis_range.assert_called()
+        assert(self.slice_view.populate_slice_x_options.called)
+        assert(self.slice_view.populate_slice_y_options.called)
+        assert(self.slice_plotter.get_available_axis.called)
+        assert(self.slice_plotter.get_axis_range.called)
         # Test error handling
         self.slice_plotter.get_axis_range = mock.Mock(side_effect=KeyError)
         slice_plotter_presenter.workspace_selection_changed()
-        self.slice_view.clear_input_fields.assert_called()
+        assert(self.slice_view.clear_input_fields.called)
 
     def test_notify_presenter_clears_error(self):
         presenter = SlicePlotterPresenter(self.slice_view, self.slice_plotter)
         presenter.register_master(self.main_presenter)
+        self.slice_view.clear_displayed_error = mock.Mock()
         # This unit test will verify that notifying cut presenter will cause the error to be cleared on the view.
         # The actual subsequent procedure will fail, however this irrelevant to this. Hence the try, except blocks
         for command in [x for x in dir(Command) if x[0] != "_"]:

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -7,20 +7,19 @@ from mslice.models.workspacemanager.mantid_workspace_provider import (wrap_works
                                                                       get_workspace_names, subtract,
                                                                       get_workspace_handle, add_workspace_runs,
                                                                       combine_workspace, rename_workspace,
-                                                                      propagate_properties, get_limits)
+                                                                      propagate_properties, get_limits, run_alg)
 from mslice.models.workspacemanager.mantid_workspace_provider import _processEfixed
 
 class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def setUp(self):
-        self.test_ws_2d = wrap_workspace(CreateSimulationWorkspace(Instrument='MAR', BinParams=[-10, 1, 10],
-                                                                   UnitX='DeltaE',
-                                                                   OutputWorkspace='test_ws_2d'), 'test_ws_2d')
-        AddSampleLog(self.test_ws_2d.raw_ws, LogName='Ei', LogText='3.', LogType='Number')
-        self.test_ws_md = ConvertToMD(InputWorkspace=self.test_ws_2d.raw_ws, OutputWorkspace="test_ws_md", QDimensions='|Q|',
-                                      dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
-                                      SplitInto='50,50')
-        self.test_ws_md = wrap_workspace(self.test_ws_md, 'test_ws_md')
+        self.test_ws_2d = run_alg('CreateSimulationWorkspace', output_name='test_ws_2d', Instrument='MAR',
+                                  BinParams=[-10, 1, 10], UnitX='DeltaE')
+        run_alg('AddSampleLog', Workspace=self.test_ws_2d.raw_ws, store=False, LogName='Ei', LogText='3.',
+                LogType='Number')
+        self.test_ws_md = run_alg('ConvertToMD', output_name='test_ws_md', InputWorkspace=self.test_ws_2d,
+                                  QDimensions='|Q|', dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
+                                  SplitInto='50,50')
         self.test_ws_md.ef_defined = False
         self.test_ws_md.limits = {'DeltaE': [0, 2, 1]}
 
@@ -43,8 +42,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     @patch('mslice.models.workspacemanager.mantid_workspace_provider._original_step_size')
     def test_combine_workspace(self, step_mock):
-        ws_2 = wrap_workspace(CloneWorkspace(InputWorkspace=self.test_ws_md.raw_ws, OutputWorkspace='ws_2',
-                                             StoreInADS=False), 'ws_2')
+        ws_2 = run_alg('CloneWorkspace', output_name='ws_2', InputWorkspace=self.test_ws_md)
         step_mock.return_value = 1
         combined = combine_workspace([self.test_ws_md, ws_2], 'combined')
         np.testing.assert_array_almost_equal(combined.limits['DeltaE'], [-10, 10, 1], 4)
@@ -63,9 +61,9 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         self.assertEqual(new_ws.limits['DeltaE'], [0, 2, 1])
 
     def test_propagate_properties(self):
-        ws_2 = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-1, 1, 20],
-                                                    UnitX='DeltaE', OutputWorkspace='test_ws_2')
-        ws_2 = propagate_properties(self.test_ws_md, ws_2, 'test_ws_2')
+        ws_2 = run_alg('CreateSimulationWorkspace', output_name='test_ws_2', Instrument='MAR', BinParams=[-1, 1, 20],
+                                                    UnitX='DeltaE')
+        propagate_properties(self.test_ws_md, ws_2)
         delete_workspace('test_ws_md')
         self.assertFalse(ws_2.ef_defined)
         self.assertEqual({'DeltaE': [0, 2, 1]}, ws_2.limits)

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -2,8 +2,12 @@ from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from mock import patch
 import unittest
-from mantid.simpleapi import CreateWorkspace, CreateSimulationWorkspace, AddSampleLog, ConvertToMD, CloneWorkspace
-from mslice.models.workspacemanager.mantid_workspace_provider import *
+from mantid.simpleapi import CreateSimulationWorkspace, AddSampleLog, ConvertToMD, CloneWorkspace
+from mslice.models.workspacemanager.mantid_workspace_provider import (wrap_workspace, delete_workspace,
+                                                                      get_workspace_names, subtract,
+                                                                      get_workspace_handle, add_workspace_runs,
+                                                                      combine_workspace, rename_workspace,
+                                                                      propagate_properties, get_limits)
 from mslice.models.workspacemanager.mantid_workspace_provider import _processEfixed
 
 class MantidWorkspaceProviderTest(unittest.TestCase):

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -2,8 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from mock import patch
 import unittest
-from mantid.simpleapi import CreateSimulationWorkspace, AddSampleLog, ConvertToMD, CloneWorkspace
-from mslice.models.workspacemanager.mantid_workspace_provider import (wrap_workspace, delete_workspace,
+from mslice.models.workspacemanager.mantid_workspace_provider import (delete_workspace,
                                                                       get_workspace_names, subtract,
                                                                       get_workspace_handle, add_workspace_runs,
                                                                       combine_workspace, rename_workspace,
@@ -62,7 +61,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def test_propagate_properties(self):
         ws_2 = run_alg('CreateSimulationWorkspace', output_name='test_ws_2', Instrument='MAR', BinParams=[-1, 1, 20],
-                                                    UnitX='DeltaE')
+                       UnitX='DeltaE')
         propagate_properties(self.test_ws_md, ws_2)
         delete_workspace('test_ws_md')
         self.assertFalse(ws_2.ef_defined)

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -1,93 +1,89 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
+from mock import patch
 import unittest
-from mantid.simpleapi import CreateWorkspace, CreateSimulationWorkspace, AddSampleLog, ConvertToMD
-from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
+from mantid.simpleapi import CreateWorkspace, CreateSimulationWorkspace, AddSampleLog, ConvertToMD, CloneWorkspace
+from mslice.models.workspacemanager.mantid_workspace_provider import *
+from mslice.models.workspacemanager.mantid_workspace_provider import _processEfixed
 
 class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def setUp(self):
-        self.ws_provider = MantidWorkspaceProvider()
-
-        self.test_ws_2d = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-10, 1, 10],
-                                                    UnitX='DeltaE', OutputWorkspace='test_ws_2d')
-        AddSampleLog(self.test_ws_2d, LogName='Ei', LogText='3.', LogType='Number')
-        self.test_ws_md = ConvertToMD(InputWorkspace=self.test_ws_2d, OutputWorkspace="test_ws_md", QDimensions='|Q|',
+        self.test_ws_2d = wrap_workspace(CreateSimulationWorkspace(Instrument='MAR', BinParams=[-10, 1, 10],
+                                                                   UnitX='DeltaE', OutputWorkspace='test_ws_2d'))
+        AddSampleLog(self.test_ws_2d.raw_ws, LogName='Ei', LogText='3.', LogType='Number')
+        self.test_ws_md = ConvertToMD(InputWorkspace=self.test_ws_2d.raw_ws, OutputWorkspace="test_ws_md", QDimensions='|Q|',
                                       dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
                                       SplitInto='50,50')
+        self.test_ws_md = wrap_workspace(self.test_ws_md)
+        self.test_ws_md.ef_defined = False
+        self.test_ws_md.limits = {'DeltaE': [0, 2, 1]}
 
     def test_delete_workspace(self):
-        self.ws_provider._EfDefined['test_ws_md'] = False
-        self.ws_provider._limits['test_ws_md'] = [0, 2, 1]
-
-        self.ws_provider.delete_workspace('test_ws_md')
-
-        self.assertFalse('test_ws_md' in self.ws_provider.get_workspace_names())
-        self.assertRaises(KeyError, lambda: self.ws_provider._EfDefined['test_ws_md'])
-        self.assertRaises(KeyError, lambda: self.ws_provider._limits['test_ws_md'])
+        delete_workspace('test_ws_md')
+        self.assertFalse('test_ws_md' in get_workspace_names())
 
     def test_subtract_workspace(self):
-        self.ws_provider.subtract(['test_ws_2d'], 'test_ws_2d', 0.95)
-        result = self.ws_provider.get_workspace_handle('test_ws_2d_subtracted')
-        np.testing.assert_array_almost_equal(result.dataY(0), [0.05] * 20)
-        np.testing.assert_array_almost_equal(self.test_ws_2d.dataY(0), [1] * 20)
-        self.assertFalse('scaled_bg_ws' in self.ws_provider.get_workspace_names())
+        subtract(['test_ws_2d'], 'test_ws_2d', 0.95)
+        result = get_workspace_handle('test_ws_2d_subtracted')
+        np.testing.assert_array_almost_equal(result.raw_ws.dataY(0), [0.05] * 20)
+        np.testing.assert_array_almost_equal(self.test_ws_2d.raw_ws.dataY(0), [1] * 20)
+        self.assertFalse('scaled_bg_ws' in get_workspace_names())
 
     def test_add_workspace(self):
-        self.ws_provider.add_workspace_runs(['test_ws_2d', 'test_ws_2d'])
-        result = self.ws_provider.get_workspace_handle('test_ws_2d_sum')
-        np.testing.assert_array_almost_equal(result.dataY(0), [2.0] * 20)
-        np.testing.assert_array_almost_equal(self.test_ws_2d.dataY(0), [1] * 20)
+        add_workspace_runs(['test_ws_2d', 'test_ws_2d'])
+        result = get_workspace_handle('test_ws_2d_sum')
+        np.testing.assert_array_almost_equal(result.raw_ws.dataY(0), [2.0] * 20)
+        np.testing.assert_array_almost_equal(self.test_ws_2d.raw_ws.dataY(0), [1] * 20)
 
-    def test_combine_workspace(self):
-        assert(False) #TODO
+    @patch('mslice.models.workspacemanager.mantid_workspace_provider._original_step_size')
+    def test_combine_workspace(self, step_mock):
+        ws_2 = wrap_workspace(CloneWorkspace(InputWorkspace=self.test_ws_md.raw_ws, OutputWorkspace='ws_2'))
+        step_mock.return_value = 1
+        combined = combine_workspace([self.test_ws_md, ws_2], 'combined')
+        np.testing.assert_array_almost_equal(combined.limits['DeltaE'], [-10, 10, 1], 4)
+        np.testing.assert_array_almost_equal(combined.limits['|Q|'], [0.071989, 3.45243, 0.033804], 4)
 
     def test_process_EFixed(self):
-        self.ws_provider._processEfixed('test_ws_2d')
-        self.assertTrue(self.ws_provider._EfDefined['test_ws_2d'])
+        _processEfixed(self.test_ws_2d)
+        self.assertTrue(self.test_ws_2d.ef_defined)
 
     def test_rename_workspace(self):
-        self.ws_provider._EfDefined['test_ws_md'] = False
-        self.ws_provider._limits['test_ws_md'] = [0, 2, 1]
-        self.ws_provider.rename_workspace('test_ws_md', 'newname')
-        self.assertTrue('newname' in self.ws_provider.get_workspace_names())
-        self.assertRaises(KeyError, lambda: self.ws_provider._EfDefined['test_ws_md'])
-        self.assertRaises(KeyError, lambda: self.ws_provider._limits['test_ws_md'])
-        self.assertEqual(False, self.ws_provider._EfDefined['newname'])
-        self.assertEqual([0, 2, 1], self.ws_provider._limits['newname'])
+        rename_workspace('test_ws_md', 'newname')
+        self.assertTrue('newname' in get_workspace_names())
+        self.assertFalse('test_ws_md' in get_workspace_names())
+        new_ws = get_workspace_handle('newname')
+        self.assertFalse(new_ws.ef_defined)
+        self.assertEqual(new_ws.limits['DeltaE'], [0, 2, 1])
 
     def test_propagate_properties(self):
-        x = np.linspace(0, 99, 100)
-        y = x * 1
-        CreateWorkspace(x, y, OutputWorkspace='test_ws_2')
-        self.ws_provider._EfDefined['test_ws_2'] = False
-        self.ws_provider._limits['test_ws_2'] = [0, 2, 1]
-        self.ws_provider.propagate_properties('test_ws_2', 'test_ws_md')
-        self.ws_provider.delete_workspace('test_ws_2')
-        self.assertEqual(False, self.ws_provider._EfDefined['test_ws_md'])
-        self.assertEqual([0, 2, 1], self.ws_provider._limits['test_ws_md'])
+        ws_2 = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-1, 1, 20],
+                                                    UnitX='DeltaE', OutputWorkspace='test_ws_2')
+        ws_2 = propagate_properties(self.test_ws_md, ws_2)
+        delete_workspace('test_ws_md')
+        self.assertFalse(ws_2.ef_defined)
+        self.assertEqual({'DeltaE': [0, 2, 1]}, ws_2.limits)
 
     def test_get_limits(self):
-        limits = self.ws_provider.get_limits('test_ws_2d', 'DeltaE')
-        self.assertEqual(limits[0], -10)
-        self.assertEqual(limits[1], 10)
+        limits = get_limits('test_ws_md', 'DeltaE')
+        self.assertEqual(limits[0], 0)
+        self.assertEqual(limits[1], 2)
         self.assertEqual(limits[2], 1)
 
-    def test_get_limits_100_steps(self):
-        self.ws_provider._limits['test_ws_md'] = []
-        limits = self.ws_provider.get_limits('test_ws_md', 'DeltaE')
-        self.assertAlmostEqual(limits[0], -10, places=4)
-        self.assertAlmostEqual(limits[1], 10, places=4)
-        self.assertAlmostEqual(limits[2], 0.2, places=4)
-        limits = self.ws_provider.get_limits('test_ws_md', '|Q|')
-        self.assertAlmostEqual(limits[0], 0.07199, places=4)
-        self.assertAlmostEqual(limits[1], 3.45243, places=4)
-        self.assertAlmostEqual(limits[2], 0.033804, places=4)
+    @patch('mslice.models.workspacemanager.mantid_workspace_provider._original_step_size')
+    def test_get_limits_100_steps(self, step_mock):
+        self.test_ws_md.limits = {}
+        step_mock.return_value = 1
+        limits = get_limits('test_ws_md', 'DeltaE')
+        np.testing.assert_array_almost_equal(limits, [-10, 10, 1], 4)
+        limits = get_limits('test_ws_md', '|Q|')
+        np.testing.assert_array_almost_equal(limits, [0.06, 3.4645, 0.004], 4)
+
 
     def test_get_limits_saved(self):
-        self.ws_provider.get_limits('test_ws_2d', 'DeltaE')
-        limits = self.ws_provider._limits['test_ws_2d']
-        np.testing.assert_array_equal(limits['DeltaE'], [-10, 10, 1])
-        np.testing.assert_array_equal(limits['|Q|'], limits['MomentumTransfer'])
-        np.testing.assert_almost_equal(limits['|Q|'], [0.05998867,  3.46446147,  0.00401079], 5)
-        np.testing.assert_almost_equal(limits['Degrees'], [3.43, 134.14, 0.5729578], 5)
+        self.test_ws_2d.limits = {}
+        get_limits('test_ws_2d', 'DeltaE')
+        np.testing.assert_array_equal(self.test_ws_2d.limits['DeltaE'], [-10, 10, 1])
+        np.testing.assert_array_equal(self.test_ws_2d.limits['|Q|'], self.test_ws_2d.limits['MomentumTransfer'])
+        np.testing.assert_almost_equal(self.test_ws_2d.limits['|Q|'], [0.05998867,  3.46446147,  0.00401079], 5)
+        np.testing.assert_almost_equal(self.test_ws_2d.limits['Degrees'], [3.43, 134.14, 0.5729578], 5)

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -14,12 +14,12 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def setUp(self):
         self.test_ws_2d = wrap_workspace(CreateSimulationWorkspace(Instrument='MAR', BinParams=[-10, 1, 10],
-                                                                   UnitX='DeltaE', OutputWorkspace='test_ws_2d',
-                                                                   StoreInADS=False), 'test_ws_2d')
-        AddSampleLog(self.test_ws_2d.raw_ws, LogName='Ei', LogText='3.', LogType='Number', StoreInADS=False)
+                                                                   UnitX='DeltaE',
+                                                                   OutputWorkspace='test_ws_2d'), 'test_ws_2d')
+        AddSampleLog(self.test_ws_2d.raw_ws, LogName='Ei', LogText='3.', LogType='Number')
         self.test_ws_md = ConvertToMD(InputWorkspace=self.test_ws_2d.raw_ws, OutputWorkspace="test_ws_md", QDimensions='|Q|',
                                       dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
-                                      SplitInto='50,50', StoreInADS=False)
+                                      SplitInto='50,50')
         self.test_ws_md = wrap_workspace(self.test_ws_md, 'test_ws_md')
         self.test_ws_md.ef_defined = False
         self.test_ws_md.limits = {'DeltaE': [0, 2, 1]}
@@ -64,7 +64,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def test_propagate_properties(self):
         ws_2 = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-1, 1, 20],
-                                                    UnitX='DeltaE', OutputWorkspace='test_ws_2', StoreInADS=False)
+                                                    UnitX='DeltaE', OutputWorkspace='test_ws_2')
         ws_2 = propagate_properties(self.test_ws_md, ws_2, 'test_ws_2')
         delete_workspace('test_ws_md')
         self.assertFalse(ws_2.ef_defined)

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -39,6 +39,9 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(result.dataY(0), [2.0] * 20)
         np.testing.assert_array_almost_equal(self.test_ws_2d.dataY(0), [1] * 20)
 
+    def test_combine_workspace(self):
+        assert(False) #TODO
+
     def test_process_EFixed(self):
         self.ws_provider._processEfixed('test_ws_2d')
         self.assertTrue(self.ws_provider._EfDefined['test_ws_2d'])

--- a/mslice/tests/workspace_test.py
+++ b/mslice/tests/workspace_test.py
@@ -59,7 +59,7 @@ class WorkspaceTest(BaseWorkspaceTest):
         x = np.linspace(0, 99, 100)
         y = x * 1
         e = y * 0 + 2
-        cls.workspace = Workspace(CreateWorkspace(x, y, e, OutputWorkspace="testBaseWorkspace", StoreInADS=False))
+        cls.workspace = Workspace(CreateWorkspace(x, y, e, OutputWorkspace="testBaseWorkspace"), 'testBaseWorkspace')
 
     def test_invalid_workspace(self):
         self.assertRaises(TypeError, lambda: Workspace(4))

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -4,7 +4,6 @@ import unittest
 import mock
 from mock import call, patch
 
-from mslice.models.workspacemanager.workspace_provider import WorkspaceProvider
 from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.views.mainview import MainView
@@ -16,23 +15,22 @@ from mslice.widgets.workspacemanager.command import Command
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
     def setUp(self):
-        self.workspace_provider = mock.create_autospec(spec=WorkspaceProvider)
         self.view = mock.create_autospec(spec=WorkspaceView)
         self.mainview = mock.create_autospec(MainView)
         self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
 
     def test_register_master_success(self):
-        workspace_presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        workspace_presenter = WorkspaceManagerPresenter(self.view)
         workspace_presenter.register_master(self.main_presenter)
         self.main_presenter.register_workspace_selector.assert_called_once_with(workspace_presenter)
 
     def test_register_master_invalid_master_fail(self):
-        workspace_presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        workspace_presenter = WorkspaceManagerPresenter(self.view)
         self.assertRaises(AssertionError ,workspace_presenter.register_master, 3)
 
     def test_rename_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
         # name on call to get_workspace_new_name
         old_workspace_name = 'file1'
@@ -48,7 +46,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_rename_workspace_multiple_workspace_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
         selected_workspaces = ['ws1', 'ws2']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
@@ -59,7 +57,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.rename_workspace.assert_not_called()
 
     def test_rename_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -70,7 +68,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_workspace(self, save_dir_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path'
@@ -87,7 +85,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_ascii_workspace(self, save_dir_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path'
@@ -102,7 +100,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_matlab_workspace(self, save_dir_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path'
@@ -118,7 +116,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_workspace_multiple_selected(self, save_dir_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         #Create a view that reports multiple workspaces are selected on calls to get_workspace_selected
         path_to_save_to = r'A:\file\path'
         self.view.get_workspace_selected = mock.Mock(return_value=['file1','file2'])
@@ -132,7 +130,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_workspace_non_selected_prompt_user(self, save_dir_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         #Create a view that reports no workspaces arw selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -144,7 +142,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     def test_save_workspace_cancelled(self, save_dir_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = "" # view returns empty string to indicate operation cancelled
@@ -160,7 +158,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.workspace_provider.save_workspaces.assert_not_called()
 
     def test_remove_workspace(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a workspace that reports a single selected workspace on calls to get_workspace_selected
         workspace_to_be_removed = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_be_removed])
@@ -171,7 +169,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called_once()
 
     def test_remove_multiple_workspaces(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports 3 selected workspaces on calls to get_workspace_selected
         workspace1 = 'file1'
         workspace2 = 'file2'
@@ -185,7 +183,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_called()
 
     def test_remove_workspace_non_selected_prompt_user(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports no workspace selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
@@ -196,18 +194,18 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.display_loaded_workspaces.assert_not_called()
 
     def test_broadcast_success(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         self.presenter.register_master(self.main_presenter)
         self.presenter.notify(Command.SelectionChanged)
         self.main_presenter.notify_workspace_selection_changed()
 
     def test_call_presenter_with_unknown_command(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         unknown_command = 10
         self.assertRaises(ValueError,self.presenter.notify, unknown_command)
 
     def test_notify_presenter_clears_error(self):
-        presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        presenter = WorkspaceManagerPresenter(self.view)
         presenter.register_master(self.main_presenter)
         # This unit test will verify that notifying cut presenter will cause the error to be cleared on the view.
         # The actual subsequent procedure will fail, however this irrelevant to this. Hence the try, except blocks
@@ -220,14 +218,14 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             self.view.reset_mock()
 
     def test_set_selected_workspace_index(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         self.view.get_workspace_index = mock.Mock()
         self.workspace_provider.get_workspace_name = mock.Mock()
         self.presenter.set_selected_workspaces([1])
         self.view.set_workspace_selected.assert_called_once_with([1])
 
     def test_set_selected_workspace_name(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         self.view.get_workspace_index = mock.Mock(return_value=0)
         self.workspace_provider.get_workspace_name = mock.Mock()
         self.presenter.set_selected_workspaces(['ws'])
@@ -235,7 +233,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.set_workspace_selected.assert_called_once_with([0])
 
     def test_set_selected_workspace_handle(self):
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         self.view.get_workspace_index = mock.Mock(return_value=0)
         self.workspace_provider.get_workspace_name = mock.Mock(return_value='ws')
         self.presenter.set_selected_workspaces([mock.Mock()])
@@ -245,7 +243,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_combine_workspace_single_ws(self):
         # Checks that it will fail if only one workspace is selected.
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         selected_workspaces = ['ws1']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
         self.view.add_workspace_dialog = mock.Mock(return_value='ws2')
@@ -256,7 +254,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_combine_workspace_wrong_type(self):
         # Checks that it will fail if one of the workspace is not a MDEventWorkspace
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         selected_workspaces = ['ws1', 'ws2']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
         self.workspace_provider.is_pixel_workspace = mock.Mock(side_effect=[True, False])
@@ -268,7 +266,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_combine_workspace(self):
         # Now checks it suceeds otherwise
-        self.presenter = WorkspaceManagerPresenter(self.view, self.workspace_provider)
+        self.presenter = WorkspaceManagerPresenter(self.view)
         selected_workspaces = ['ws1', 'ws2']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
         self.workspace_provider.is_pixel_workspace = mock.Mock(side_effect=[True, True])

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -3,17 +3,36 @@ import unittest
 
 import mock
 from mock import call, patch
+import numpy as np
 
 from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.views.mainview import MainView
 from mslice.views.workspace_view import WorkspaceView
 from mslice.widgets.workspacemanager.command import Command
+from mslice.models.workspacemanager.mantid_workspace_provider import wrap_workspace
+from mantid.simpleapi import AddSampleLog, CreateWorkspace, CreateSimulationWorkspace, ConvertToMD, CloneWorkspace
 
-
-#TODO Test constructor and make this test specific
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        x = np.linspace(0, 99, 100)
+        y = x * 1
+        e = y * 0 + 2
+        cls.m_workspace = wrap_workspace(CreateWorkspace(x, y, e, OutputWorkspace="m_ws"))
+
+        sim_workspace = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-10, 1, 10],
+                                                  UnitX='DeltaE', OutputWorkspace='ws1')
+        AddSampleLog(sim_workspace, LogName='Ei', LogText='3.', LogType='Number')
+        cls.px_workspace = ConvertToMD(InputWorkspace=sim_workspace, OutputWorkspace="ws1", QDimensions='|Q|',
+                                       dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
+                                       SplitInto='50,50')
+        cls.px_workspace_clone = CloneWorkspace(InputWorkspace=cls.px_workspace, OutputWorkspace='ws2')
+        cls.px_workspace = wrap_workspace(cls.px_workspace)
+        cls.px_workspace_clone = wrap_workspace(cls.px_workspace_clone)
+
     def setUp(self):
         self.view = mock.create_autospec(spec=WorkspaceView)
         self.mainview = mock.create_autospec(MainView)
@@ -27,9 +46,11 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_register_master_invalid_master_fail(self):
         workspace_presenter = WorkspaceManagerPresenter(self.view)
-        self.assertRaises(AssertionError ,workspace_presenter.register_master, 3)
+        self.assertRaises(AssertionError, workspace_presenter.register_master, 3)
 
-    def test_rename_workspace(self):
+    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
+    @patch('mslice.presenters.workspace_manager_presenter.get_workspace_names')
+    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
         # name on call to get_workspace_new_name
@@ -37,15 +58,17 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         new_workspace_name = 'new_name'
         self.view.get_workspace_selected = mock.Mock(return_value=[old_workspace_name])
         self.view.get_workspace_new_name = mock.Mock(return_value=new_workspace_name)
-        self.workspace_provider.get_workspace_names = mock.Mock(return_value=['file1', 'file2', 'file3'])
+        self.view.display_loaded_workspaces = mock.Mock()
+        get_ws_names_mock.return_value = ['file1', 'file2', 'file3']
 
         self.presenter.notify(Command.RenameWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_workspace_new_name.assert_called_once_with()
-        self.workspace_provider.rename_workspace.assert_called_once_with(selected_workspace='file1', new_name='new_name')
+        rename_ws_mock.assert_called_once_with('file1', 'new_name')
         self.view.display_loaded_workspaces.assert_called_once()
 
-    def test_rename_workspace_multiple_workspace_selected_prompt_user(self):
+    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
+    def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
         selected_workspaces = ['ws1', 'ws2']
@@ -54,9 +77,10 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.RenameWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.error_select_only_one_workspace.assert_called_once_with()
-        self.workspace_provider.rename_workspace.assert_not_called()
+        rename_ws_mock.assert_not_called()
 
-    def test_rename_workspace_non_selected_prompt_user(self):
+    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
+    def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
@@ -64,27 +88,28 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.RenameWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.error_select_one_workspace.assert_called_once_with()
-        self.workspace_provider.rename_workspace.assert_not_called()
+        rename_ws_mock.assert_not_called()
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
-    def test_save_workspace(self, save_dir_mock):
+    @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
+    def test_save_workspace(self, save_ws_mock, save_dir_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path'
         workspace_to_save = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_save])
-        save_dir_mock.return_value=(path_to_save_to, workspace_to_save, '.nxs')
+        save_dir_mock.return_value = (path_to_save_to, workspace_to_save, '.nxs')
 
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False,
                                               default_ext='.nxs')
-        self.workspace_provider.save_workspaces.assert_called_once_with(
-            [workspace_to_save], path_to_save_to, 'file1', '.nxs')
+        save_ws_mock.assert_called_once_with([workspace_to_save], path_to_save_to, 'file1', '.nxs')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
-    def test_save_ascii_workspace(self, save_dir_mock):
+    @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
+    def test_save_ascii_workspace(self, save_ws_mock, save_dir_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
@@ -95,94 +120,100 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.SaveSelectedWorkspaceAscii)
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False, default_ext='.txt')
         self.view.get_workspace_selected.assert_called_once_with()
-        self.workspace_provider.save_workspaces.assert_called_once_with(
-            [workspace_to_save], path_to_save_to, 'file1', '.txt')
+        save_ws_mock.assert_called_once_with([workspace_to_save], path_to_save_to, 'file1', '.txt')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
-    def test_save_matlab_workspace(self, save_dir_mock):
+    @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
+    def test_save_matlab_workspace(self, save_ws_mock, save_dir_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
         path_to_save_to = r'A:\file\path'
         workspace_to_save = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_save])
-        save_dir_mock.return_value=(path_to_save_to, workspace_to_save, '.mat')
+        save_dir_mock.return_value = (path_to_save_to, workspace_to_save, '.mat')
 
         self.presenter.notify(Command.SaveSelectedWorkspaceMatlab)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False, default_ext='.mat')
-        self.workspace_provider.save_workspaces.assert_called_once_with(
-            [workspace_to_save], path_to_save_to, 'file1', '.mat')
+        save_ws_mock.assert_called_once_with([workspace_to_save], path_to_save_to, 'file1', '.mat')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
-    def test_save_workspace_multiple_selected(self, save_dir_mock):
+    @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
+    def test_save_workspace_multiple_selected(self, save_ws_mock, save_dir_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
-        #Create a view that reports multiple workspaces are selected on calls to get_workspace_selected
+        # Create a view that reports multiple workspaces are selected on calls to get_workspace_selected
         path_to_save_to = r'A:\file\path'
-        self.view.get_workspace_selected = mock.Mock(return_value=['file1','file2'])
-        save_dir_mock.return_value=(path_to_save_to, None, '.nxs')
-        self.workspace_provider.save_workspaces = mock.Mock(side_effect=[True, RuntimeError])
+        self.view.get_workspace_selected = mock.Mock(return_value=['file1', 'file2'])
+        save_dir_mock.return_value = (path_to_save_to, None, '.nxs')
+        save_ws_mock.side_effect = [True, RuntimeError]
 
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=True, save_as_image=False, default_ext='.nxs')
-        self.workspace_provider.save_workspaces.assert_called_with(['file1', 'file2'], path_to_save_to, None, '.nxs')
+        save_ws_mock.assert_called_with(['file1', 'file2'], path_to_save_to, None, '.nxs')
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
-    def test_save_workspace_non_selected_prompt_user(self, save_dir_mock):
+    @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
+    def test_save_workspace_non_selected_prompt_user(self, save_ws_mock, save_dir_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
-        #Create a view that reports no workspaces arw selected on calls to get_workspace_selected
+        # Create a view that reports no workspaces arw selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
 
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.error_select_one_workspace.assert_called_once_with()
         save_dir_mock.assert_not_called()
-        self.workspace_provider.save_workspaces.assert_not_called()
+        save_ws_mock.assert_not_called()
 
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
-    def test_save_workspace_cancelled(self, save_dir_mock):
+    @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
+    def test_save_workspace_cancelled(self, save_ws_mock, save_dir_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that report a single selected workspace on calls to get_workspace_selected and supplies a path
         # to save to on calls to get_workspace_to_save_filepath
-        path_to_save_to = "" # view returns empty string to indicate operation cancelled
+        path_to_save_to = ""  # view returns empty string to indicate operation cancelled
         workspace_to_save = 'file1'
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_save])
-        save_dir_mock.return_value=(path_to_save_to, workspace_to_save, '.nxs')
+        self.view.error_invalid_save_path = mock.Mock()
+        save_dir_mock.return_value = (path_to_save_to, workspace_to_save, '.nxs')
 
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(multiple_files=False, save_as_image=False, default_ext='.nxs')
         self.view.error_invalid_save_path.assert_called_once()
-        self.workspace_provider.save_workspaces.assert_not_called()
+        save_ws_mock.assert_not_called()
 
-    def test_remove_workspace(self):
+    @patch('mslice.presenters.workspace_manager_presenter.delete_workspace')
+    def test_remove_workspace(self, delete_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a workspace that reports a single selected workspace on calls to get_workspace_selected
-        workspace_to_be_removed = 'file1'
+        workspace_to_be_removed = wrap_workspace(CloneWorkspace(self.m_workspace.raw_ws, OutputWorkspace='file1'))
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_be_removed])
+        self.view.display_loaded_workspaces = mock.Mock()
 
         self.presenter.notify(Command.RemoveSelectedWorkspaces)
         self.view.get_workspace_selected.assert_called_once_with()
-        self.workspace_provider.delete_workspace.assert_called_once_with(workspace_to_be_removed)
+        delete_ws_mock.assert_called_once_with(workspace_to_be_removed)
         self.view.display_loaded_workspaces.assert_called_once()
 
-    def test_remove_multiple_workspaces(self):
+    @patch('mslice.presenters.workspace_manager_presenter.delete_workspace')
+    def test_remove_multiple_workspaces(self, delete_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports 3 selected workspaces on calls to get_workspace_selected
-        workspace1 = 'file1'
-        workspace2 = 'file2'
-        workspace3 = 'file3'
-        self.view.get_workspace_selected = mock.Mock(return_value=[workspace1, workspace2, workspace3])
+        workspace1 = wrap_workspace(CloneWorkspace(self.m_workspace.raw_ws, OutputWorkspace='file1'))
+        workspace2 = wrap_workspace(CloneWorkspace(self.m_workspace.raw_ws, OutputWorkspace='file2'))
+        self.view.get_workspace_selected = mock.Mock(return_value=[workspace1, workspace2])
 
         self.presenter.notify(Command.RemoveSelectedWorkspaces)
         self.view.get_workspace_selected.assert_called_once_with()
-        delete_calls = [call(workspace1), call(workspace2), call(workspace3)]
-        self.workspace_provider.delete_workspace.assert_has_calls(delete_calls, any_order= True)
-        self.view.display_loaded_workspaces.assert_called()
+        delete_calls = [call(workspace1), call(workspace2)]
+        delete_ws_mock.assert_has_calls(delete_calls, any_order=True)
+        assert(self.view.display_loaded_workspaces.called)
 
-    def test_remove_workspace_non_selected_prompt_user(self):
+    @patch('mslice.presenters.workspace_manager_presenter.delete_workspace')
+    def test_remove_workspace_non_selected_prompt_user(self, delete_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports no workspace selected on calls to get_workspace_selected
         self.view.get_workspace_selected = mock.Mock(return_value=[])
@@ -190,8 +221,8 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.RemoveSelectedWorkspaces)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.error_select_one_or_more_workspaces.assert_called_once_with()
-        self.workspace_provider.delete_workspace.assert_not_called()
-        self.view.display_loaded_workspaces.assert_not_called()
+        delete_ws_mock.assert_not_called()
+        assert(not self.view.display_loaded_workspaces.called)
 
     def test_broadcast_success(self):
         self.presenter = WorkspaceManagerPresenter(self.view)
@@ -202,7 +233,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
     def test_call_presenter_with_unknown_command(self):
         self.presenter = WorkspaceManagerPresenter(self.view)
         unknown_command = 10
-        self.assertRaises(ValueError,self.presenter.notify, unknown_command)
+        self.assertRaises(ValueError, self.presenter.notify, unknown_command)
 
     def test_notify_presenter_clears_error(self):
         presenter = WorkspaceManagerPresenter(self.view)
@@ -214,34 +245,34 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
                 presenter.notify(command)
             except ValueError:
                 pass
-            self.view.clear_displayed_error.assert_called()
+            assert(self.view.clear_displayed_error.called)
             self.view.reset_mock()
 
     def test_set_selected_workspace_index(self):
         self.presenter = WorkspaceManagerPresenter(self.view)
         self.view.get_workspace_index = mock.Mock()
-        self.workspace_provider.get_workspace_name = mock.Mock()
         self.presenter.set_selected_workspaces([1])
         self.view.set_workspace_selected.assert_called_once_with([1])
 
     def test_set_selected_workspace_name(self):
         self.presenter = WorkspaceManagerPresenter(self.view)
         self.view.get_workspace_index = mock.Mock(return_value=0)
-        self.workspace_provider.get_workspace_name = mock.Mock()
         self.presenter.set_selected_workspaces(['ws'])
         self.view.get_workspace_index.assert_called_once_with('ws')
         self.view.set_workspace_selected.assert_called_once_with([0])
 
-    def test_set_selected_workspace_handle(self):
+    @patch('mslice.presenters.workspace_manager_presenter.get_workspace_name')
+    def test_set_selected_workspace_handle(self, get_ws_name_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         self.view.get_workspace_index = mock.Mock(return_value=0)
-        self.workspace_provider.get_workspace_name = mock.Mock(return_value='ws')
+        get_ws_name_mock.return_value = 'ws'
         self.presenter.set_selected_workspaces([mock.Mock()])
-        self.workspace_provider.get_workspace_name.called_once_with(mock.Mock())
+        get_ws_name_mock.called_once_with(mock.Mock())
         self.view.get_workspace_index.assert_called_once_with('ws')
         self.view.set_workspace_selected.assert_called_once_with([0])
 
-    def test_combine_workspace_single_ws(self):
+    @patch('mslice.presenters.workspace_manager_presenter.combine_workspace')
+    def test_combine_workspace_single_ws(self, combine_ws_mock):
         # Checks that it will fail if only one workspace is selected.
         self.presenter = WorkspaceManagerPresenter(self.view)
         selected_workspaces = ['ws1']
@@ -250,31 +281,32 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.CombineWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.add_workspace_dialog.assert_called_once()
-        self.workspace_provider.combine_workspace.assert_called_once_with(['ws1', 'ws2'], 'ws1_combined')
+        combine_ws_mock.assert_called_once_with(['ws1', 'ws2'], 'ws1_combined')
 
-    def test_combine_workspace_wrong_type(self):
+    @patch('mslice.presenters.workspace_manager_presenter.is_pixel_workspace')
+    def test_combine_workspace_wrong_type(self, is_pixel_ws_mock):
         # Checks that it will fail if one of the workspace is not a MDEventWorkspace
         self.presenter = WorkspaceManagerPresenter(self.view)
         selected_workspaces = ['ws1', 'ws2']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
-        self.workspace_provider.is_pixel_workspace = mock.Mock(side_effect=[True, False])
+        is_pixel_ws_mock.side_effect = [True, False]
         self.presenter.notify(Command.CombineWorkspace)
         self.view.get_workspace_selected.assert_called_once_with()
         check_calls = [call('ws1'), call('ws2')]
-        self.workspace_provider.is_pixel_workspace.assert_has_calls(check_calls, any_order= True)
-        self.view.error_select_more_than_one_workspaces.assert_called()
+        is_pixel_ws_mock.assert_has_calls(check_calls, any_order=True)
+        assert(self.view.error_select_more_than_one_workspaces.called)
 
-    def test_combine_workspace(self):
-        # Now checks it suceeds otherwise
+    @patch('mslice.presenters.workspace_manager_presenter.combine_workspace')
+    def test_combine_workspace(self, combine_ws_mock):
+        # Now checks it succeeds otherwise
         self.presenter = WorkspaceManagerPresenter(self.view)
         selected_workspaces = ['ws1', 'ws2']
         self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
-        self.workspace_provider.is_pixel_workspace = mock.Mock(side_effect=[True, True])
+
         self.presenter.notify(Command.CombineWorkspace)
         self.view.get_workspace_selected.assert_called()
-        self.view.error_select_more_than_one_workspaces.assert_not_called()
-        self.workspace_provider.combine_workspace.assert_called_once_with(selected_workspaces,
-                                                                          selected_workspaces[0]+'_combined')
+        assert(not self.view.error_select_more_than_one_workspaces.called)
+        combine_ws_mock.assert_called_once_with(selected_workspaces, selected_workspaces[0]+'_combined')
 
 if __name__ == '__main__':
     unittest.main()

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -21,14 +21,14 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         x = np.linspace(0, 99, 100)
         y = x * 1
         e = y * 0 + 2
-        cls.m_workspace = wrap_workspace(CreateWorkspace(x, y, e, OutputWorkspace="m_ws", StoreInADS=False), 'm_ws')
+        cls.m_workspace = wrap_workspace(CreateWorkspace(x, y, e, OutputWorkspace="m_ws"), 'm_ws')
 
         sim_workspace = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-10, 1, 10],
-                                                  UnitX='DeltaE', OutputWorkspace='ws1', StoreInADS=False)
-        AddSampleLog(sim_workspace, LogName='Ei', LogText='3.', LogType='Number', StoreInADS=False)
+                                                  UnitX='DeltaE', OutputWorkspace='ws1')
+        AddSampleLog(sim_workspace, LogName='Ei', LogText='3.', LogType='Number')
         cls.px_workspace = ConvertToMD(InputWorkspace=sim_workspace, OutputWorkspace="ws1", QDimensions='|Q|',
                                        dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
-                                       SplitInto='50,50', StoreInADS=False)
+                                       SplitInto='50,50')
         cls.px_workspace_clone = CloneWorkspace(InputWorkspace=cls.px_workspace, OutputWorkspace='ws2',
                                                 StoreInADS=False)
         cls.px_workspace = wrap_workspace(cls.px_workspace, 'ws1')

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -1,12 +1,15 @@
 
-from mantid.api import IMDEventWorkspace, IMDHistoWorkspace, Workspace
 
 from mslice.util.qt import QT_VERSION
 from mslice.util.qt.QtCore import Signal
 from mslice.util.qt.QtWidgets import QWidget, QListWidgetItem, QFileDialog, QInputDialog
+from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.util.qt import load_ui
 from mslice.views.workspace_view import WorkspaceView
+from mslice.workspace.workspace import Workspace
+from mslice.workspace.pixel_workspace import PixelWorkspace
+from mslice.workspace.histogram_workspace import HistogramWorkspace
 from .command import Command
 from .subtract_input_box import SubtractInputBox
 from . import TAB_2D, TAB_EVENT, TAB_HISTO
@@ -74,10 +77,10 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
     def add_workspace(self, workspace):
         item = QListWidgetItem(workspace)
         self.onscreen_workspaces.append(workspace)
-        workspace = self._presenter.get_workspace_provider().get_workspace_handle(workspace)
-        if isinstance(workspace, IMDEventWorkspace):
+        workspace = loaded_workspaces[workspace]
+        if isinstance(workspace, PixelWorkspace):
             self.listWorkspacesEvent.addItem(item)
-        elif isinstance(workspace, IMDHistoWorkspace):
+        elif isinstance(workspace, HistogramWorkspace):
             self.listWorkspacesHisto.addItem(item)
         elif isinstance(workspace, Workspace):
             self.listWorkspaces2D.addItem(item)

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -3,7 +3,7 @@
 from mslice.util.qt import QT_VERSION
 from mslice.util.qt.QtCore import Signal
 from mslice.util.qt.QtWidgets import QWidget, QListWidgetItem, QFileDialog, QInputDialog
-from mslice.models.workspacemanager.mantid_workspace_provider import loaded_workspaces
+from mslice.models.workspacemanager.mantid_workspace_provider import get_workspace_handle
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.util.qt import load_ui
 from mslice.views.workspace_view import WorkspaceView
@@ -77,7 +77,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
     def add_workspace(self, workspace):
         item = QListWidgetItem(workspace)
         self.onscreen_workspaces.append(workspace)
-        workspace = loaded_workspaces[workspace]
+        workspace = get_workspace_handle(workspace)
         if isinstance(workspace, PixelWorkspace):
             self.listWorkspacesEvent.addItem(item)
         elif isinstance(workspace, HistogramWorkspace):

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -5,7 +5,6 @@ from mslice.util.qt import QT_VERSION
 from mslice.util.qt.QtCore import Signal
 from mslice.util.qt.QtWidgets import QWidget, QListWidgetItem, QFileDialog, QInputDialog
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
-from mslice.models.workspacemanager.mantid_workspace_provider import MantidWorkspaceProvider
 from mslice.util.qt import load_ui
 from mslice.views.workspace_view import WorkspaceView
 from .command import Command
@@ -34,7 +33,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         self.listWorkspaces2D.itemSelectionChanged.connect(self.list_item_changed)
         self.listWorkspacesEvent.itemSelectionChanged.connect(self.list_item_changed)
         self.listWorkspacesHisto.itemSelectionChanged.connect(self.list_item_changed)
-        self._presenter = WorkspaceManagerPresenter(self, MantidWorkspaceProvider())
+        self._presenter = WorkspaceManagerPresenter(self)
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)

--- a/mslice/workspace/histo_mixin.py
+++ b/mslice/workspace/histo_mixin.py
@@ -38,7 +38,7 @@ class HistoMixin(object):
                                     Names=self._raw_ws.getDimension(0).getName(), Units='MomentumTransfer',
                                     StoreInADS=False)
         try:
-            replicated = ReplicateMD(ShapeWorkspace=self._raw_ws, DataWorkspace=ws, StoreInADS=False)
+            replicated = ReplicateMD(ShapeWorkspace=self._raw_ws, DataWorkspace=ws)
         except RuntimeError:
             raise RuntimeError("List or array must have same number of elements as an axis of the workspace")
         # return operator(self._raw_ws, replicated)

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -18,4 +18,4 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         self._cut_params = {}
 
     def rewrap(self, ws):
-        return HistogramWorkspace(ws)
+        return HistogramWorkspace(ws, self.name)

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -14,6 +14,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
             self._raw_ws = mantid_ws
         else:
             raise TypeError('HistogramWorkspace expected IMDHistoWorkspace, got %s' % mantid_ws.__class__.__name__)
+        self._cut_params = {}
 
     def rewrap(self, ws):
         return HistogramWorkspace(ws)

--- a/mslice/workspace/pixel_mixin.py
+++ b/mslice/workspace/pixel_mixin.py
@@ -19,7 +19,7 @@ class PixelMixin(object):
             histo_workspace = BinMD(InputWorkspace=self._raw_ws, OutputWorkspace=str(self),
                                     AlignedDim0=dim_values[0], AlignedDim1=dim_values[1],
                                     AlignedDim2=dim_values[2], AlignedDim3=dim_values[3],
-                                    AlignedDim4=dim_values[4], AlignedDim5=dim_values[5], StoreInADS=False)
+                                    AlignedDim4=dim_values[4], AlignedDim5=dim_values[5])
             self._histo_ws = HistogramWorkspace(histo_workspace)
         return self._histo_ws
 

--- a/mslice/workspace/pixel_mixin.py
+++ b/mslice/workspace/pixel_mixin.py
@@ -20,7 +20,7 @@ class PixelMixin(object):
                                     AlignedDim0=dim_values[0], AlignedDim1=dim_values[1],
                                     AlignedDim2=dim_values[2], AlignedDim3=dim_values[3],
                                     AlignedDim4=dim_values[4], AlignedDim5=dim_values[5])
-            self._histo_ws = HistogramWorkspace(histo_workspace)
+            self._histo_ws = HistogramWorkspace(histo_workspace, self.name)
         return self._histo_ws
 
     def get_signal(self):

--- a/mslice/workspace/pixel_mixin.py
+++ b/mslice/workspace/pixel_mixin.py
@@ -42,7 +42,7 @@ class PixelMixin(object):
         Note this wraps the result in HistogramWorkspace object, which is then passed
          to PixelWorkspace constructor in Workspace._binary_op.
         """
-        return HistogramWorkspace(self.get_histo_ws()._binary_op_array(operator, other))
+        return HistogramWorkspace(self.get_histo_ws()._binary_op_array(operator, other), self.name)
 
     def __pow__(self, other):
         return self.rewrap(self.get_histo_ws().__pow__(other))

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -21,6 +21,7 @@ class PixelWorkspace(PixelMixin, WorkspaceMixin, WorkspaceBase):
         else:
             raise TypeError("PixelWorkspace expected IMDEventWorkspace or HistogramWorkspace, got %s"
                             % mantid_ws.__class__.__name__)
+        self._cut_params = {}
 
     def rewrap(self, ws):
         return PixelWorkspace(ws)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -29,4 +29,4 @@ class PixelWorkspace(PixelMixin, WorkspaceMixin, WorkspaceBase):
         self.e_fixed = None
 
     def rewrap(self, ws):
-        return PixelWorkspace(ws)
+        return PixelWorkspace(ws, self.name)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -22,6 +22,10 @@ class PixelWorkspace(PixelMixin, WorkspaceMixin, WorkspaceBase):
             raise TypeError("PixelWorkspace expected IMDEventWorkspace or HistogramWorkspace, got %s"
                             % mantid_ws.__class__.__name__)
         self._cut_params = {}
+        self.limits = {}
+        self.is_PSD = None
+        self.e_mode = None
+        self.e_fixed = None
 
     def rewrap(self, ws):
         return PixelWorkspace(ws)

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -14,9 +14,9 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
         else:
             raise TypeError('Workspace expected matrixWorkspace, got %s' % mantid_ws.__class__.__name__)
 
+        self._cut_params = {}
         self.ef_defined = None
         self.limits = {}
-        self.cut_parameters = None
         self.is_PSD = None
         self.e_mode = None
         self.e_fixed = None

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -23,7 +23,3 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
 
     def rewrap(self, mantid_ws):
         return Workspace(mantid_ws)
-
-    @property
-    def raw_ws(self):
-        return self._raw_ws

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -22,4 +22,4 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
         self.e_fixed = None
 
     def rewrap(self, mantid_ws):
-        return Workspace(mantid_ws)
+        return Workspace(mantid_ws, self.name)

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -14,5 +14,15 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
         else:
             raise TypeError('Workspace expected matrixWorkspace, got %s' % mantid_ws.__class__.__name__)
 
+        self.ef_defined = None
+        self.limits = None
+        self.cut_parameters = None
+        self.is_PSD = None
+        self.e_mode = None
+
     def rewrap(self, mantid_ws):
         return Workspace(mantid_ws)
+
+    @property
+    def raw_ws(self):
+        return self._raw_ws

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -15,10 +15,11 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
             raise TypeError('Workspace expected matrixWorkspace, got %s' % mantid_ws.__class__.__name__)
 
         self.ef_defined = None
-        self.limits = None
+        self.limits = {}
         self.cut_parameters = None
         self.is_PSD = None
         self.e_mode = None
+        self.e_fixed = None
 
     def rewrap(self, mantid_ws):
         return Workspace(mantid_ws)

--- a/mslice/workspace/workspace_mixin.py
+++ b/mslice/workspace/workspace_mixin.py
@@ -85,9 +85,20 @@ class WorkspaceMixin(object):
                 return False
         return True
 
+    def set_cut_params(self, axis, params):
+        self._cut_params[axis] = params
+        self._cut_params['previous_axis'] = axis
+
+    def is_axis_saved(self, axis):
+        return True if axis in self._cut_params else False
+
     @property
     def raw_ws(self):
         return self._raw_ws
+
+    @property
+    def cut_params(self):
+        return self._cut_params
 
     def __add__(self, other):
         return self._binary_op(operator.add, other)

--- a/mslice/workspace/workspace_mixin.py
+++ b/mslice/workspace/workspace_mixin.py
@@ -85,6 +85,10 @@ class WorkspaceMixin(object):
                 return False
         return True
 
+    @property
+    def raw_ws(self):
+        return self._raw_ws
+
     def __add__(self, other):
         return self._binary_op(operator.add, other)
 


### PR DESCRIPTION
The `mantid_workspace_provider` class is used to store cached information about workspaces. This causes a problem with having to pass around references to this object everywhere, which would become even more difficult when the CLI is expanded.

It makes more sense to keep any state and cached values as part of the workspace itself. This PR stores this information in the workspace wrapper classes, and makes sure all workspaces are wrapped on load. 
This means `mantid_workspace_provider` no longer has state and is a module of free functions instead of a class.

This will make upcoming CLI improvements much easier to implement.

Fixes #178 
