### PR TITLE
Fix error when displaying _combined workspaces

### DIFF
--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -179,7 +179,7 @@ def combine_workspace(selected_workspaces, new_name):
     workspace_names = [workspace.name for workspace in workspaces]
     with add_to_ads(workspaces):
         ws = run_algorithm('MergeMD', output_name=new_name, InputWorkspaces=workspace_names)
-    propagate_properties(selected_workspaces[0], ws)
+    propagate_properties(workspaces[0], ws)
     # Set limits for result workspace. Use precalculated step size, otherwise get limits directly from Mantid workspace
     ax1 = ws.raw_ws.getDimension(0)
     ax2 = ws.raw_ws.getDimension(1)

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -179,7 +179,8 @@ def combine_workspace(selected_workspaces, new_name):
     workspace_names = [workspace.name for workspace in workspaces]
     with add_to_ads(workspaces):
         ws = run_algorithm('MergeMD', output_name=new_name, InputWorkspaces=workspace_names)
-    # Use precalculated step size, otherwise get limits directly from workspace
+    propagate_properties(selected_workspaces[0], ws)
+    # Set limits for result workspace. Use precalculated step size, otherwise get limits directly from Mantid workspace
     ax1 = ws.raw_ws.getDimension(0)
     ax2 = ws.raw_ws.getDimension(1)
     step1 = []

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -21,6 +21,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
                                         QDimensions='|Q|', dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
                                         SplitInto='50,50')
         self.test_ws_md.ef_defined = False
+        self.test_ws_md.is_PSD = True
         self.test_ws_md.limits = {'DeltaE': [0, 2, 1]}
 
     def test_delete_workspace(self):
@@ -47,6 +48,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         combined = combine_workspace([self.test_ws_md, ws_2], 'combined')
         np.testing.assert_array_almost_equal(combined.limits['DeltaE'], [-10, 10, 1], 4)
         np.testing.assert_array_almost_equal(combined.limits['|Q|'], [0.071989, 3.45243, 0.033804], 4)
+        self.assertTrue(combined.is_PSD)
 
     def test_process_EFixed(self):
         processEfixed(self.test_ws_2d)


### PR DESCRIPTION
Fixes a problem where `_combined workspaces` were incorrectly being treated as `non-PSD` because their `is_PSD` property wasn't set. This meant they couldn't be sliced.

**To test:**
- Load two `PSD` workspaces.
- Select both and click `calculate projection`
- Select both resulting event workspaces and click `Merge`
- Select resulting `_combined` workspace and click `display` to plot a slice.


<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #314 
