### PR TITLE
Clear cut figure when plot window is closed

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -267,6 +267,10 @@ class CutPlot(object):
             self._lines_visible[line_index] = True
             return True
 
+    def close_event(self, event):
+        self._canvas.figure.clf()
+        event.accept()
+
     @property
     def x_log(self):
         return 'log' in self._canvas.figure.gca().get_xscale()

--- a/mslice/plotting/plot_window/plot_figure.py
+++ b/mslice/plotting/plot_window/plot_figure.py
@@ -197,6 +197,9 @@ class PlotFigureManager(BasePlotWindow, PlotWindowUI, QtWidgets.QMainWindow):
     def move_window(self, x, y):
         self.move(self.pos().x() + x, self.pos().y() + y)
 
+    def closeEvent(self, event):
+        self._plot_handler.close_event(event)
+
     def get_window_title(self):
         return six.text_type(self.windowTitle())
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -368,6 +368,9 @@ class SlicePlot(object):
         plot_figure.actionTantalum.triggered.disconnect()
         plot_figure.actionCIF_file.triggered.disconnect()
 
+    def close_event(self, event):
+        event.accept()
+
     @property
     def colorbar_label(self):
         return self._canvas.figure.get_axes()[1].get_ylabel()


### PR DESCRIPTION
Prevents a bug when replotting a cut by clearing the figure when the plot window is closed. 

**To test:**
See issue 

Fixes #319 
