### PR TITLE
Saving cuts bug fixes

### DIFF
--- a/mslice/models/cut/cut_functions.py
+++ b/mslice/models/cut/cut_functions.py
@@ -15,22 +15,23 @@ def output_workspace_name(selected_workspace, integration_start, integration_end
         integration_end) + ")"
 
 
-def compute_cut_xye(selected_workspace, cut_axis, integration_axis, is_norm):
+def compute_cut_xye(selected_workspace, cut_axis, integration_axis, is_norm, store=True):
     ws_handle = get_workspace_handle(selected_workspace)
     out_ws_name = output_workspace_name(selected_workspace, integration_axis.start, integration_axis.end)
 
-    cut = run_algorithm('Cut', output_name=out_ws_name, InputWorkspace=ws_handle,
+    cut = run_algorithm('Cut', output_name=out_ws_name, store=store, InputWorkspace=ws_handle,
                         CutAxis=cut_axis.to_dict(), IntegrationAxis=integration_axis.to_dict(),
                         EMode = ws_handle.e_mode, PSD=ws_handle.is_PSD, NormToOne=is_norm)
-
-    plot_data = _num_events_normalized_array(cut.raw_ws)
+    if store:
+        cut = cut.raw_ws
+    plot_data = _num_events_normalized_array(cut)
     plot_data = plot_data.squeeze()
     with np.errstate(invalid='ignore'):
-        if cut.raw_ws.displayNormalization() == MDNormalization.NoNormalization:
-            errors = np.sqrt(cut.get_variance())
-            errors[np.where(cut.raw_ws.getNumEventsArray() == 0)] = np.nan
+        if cut.displayNormalization() == MDNormalization.NoNormalization:
+            errors = np.sqrt(cut.getErrorSquaredArray())
+            errors[np.where(cut.getNumEventsArray() == 0)] = np.nan
         else:
-            errors = np.sqrt(cut.get_variance()) / cut.raw_ws.getNumEventsArray()
+            errors = np.sqrt(cut.getErrorSquaredArray()) / cut.getNumEventsArray()
     errors = errors.squeeze()
     x = np.linspace(cut_axis.start, cut_axis.end, plot_data.size)
     return x, plot_data, errors

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -79,7 +79,3 @@ class MatplotlibCutPlotter(CutPlotter):
 
     def get_icut(self):
         return self.icut
-
-    def save_cut(self, params):
-        #TODO: broken on master, issue #332
-        pass

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -33,11 +33,13 @@ class MatplotlibCutPlotter(CutPlotter):
         cur_fig = plt.gcf()
         cur_axes = cur_fig.gca()
         cur_axes.set_ylim(*intensity_range) if intensity_range is not None else cur_axes.autoscale()
-        leg = cur_axes.legend(fontsize='medium')
-        leg.draggable()
+        cur_canvas = cur_fig.canvas
+        if cur_canvas.manager.window.action_toggle_legends.isChecked():
+            leg = cur_axes.legend(fontsize='medium')
+            leg.draggable()
         cur_axes.set_xlabel(get_display_name(x_units, get_comment(selected_workspace)), picker=PICKER_TOL_PTS)
         cur_axes.set_ylabel(CUT_INTENSITY_LABEL, picker=PICKER_TOL_PTS)
-        cur_canvas = cur_fig.canvas
+
         if not plot_over:
             cur_canvas.set_window_title('Cut: ' + selected_workspace)
             cur_canvas.manager.update_grid()

--- a/mslice/models/cut/matplotlib_cut_plotter.py
+++ b/mslice/models/cut/matplotlib_cut_plotter.py
@@ -14,8 +14,8 @@ class MatplotlibCutPlotter(CutPlotter):
         self.icut = None
 
     def plot_cut(self, selected_workspace, cut_axis, integration_axis, norm_to_one, intensity_start,
-                 intensity_end, plot_over):
-        x, y, e = compute_cut_xye(selected_workspace, cut_axis, integration_axis, norm_to_one)
+                 intensity_end, plot_over, store=True):
+        x, y, e = compute_cut_xye(selected_workspace, cut_axis, integration_axis, norm_to_one, store)
         output_ws_name = output_workspace_name(selected_workspace, integration_axis.start, integration_axis.end)
         legend = generate_legend(selected_workspace, integration_axis.units, integration_axis.start,
                                  integration_axis.end)

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -46,11 +46,11 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
 def save_nexus(workspace, path, is_slice):
     if isinstance(workspace, HistogramWorkspace):
         if is_slice:
-            run_algorithm('SaveMD', InputWorkspace=get_workspace_handle(workspace.name[2:]), Filename=path)
+            run_algorithm('SaveMD', store=False, InputWorkspace=get_workspace_handle(workspace.name[2:]), Filename=path)
         else:
-            run_algorithm('SaveMD', InputWorkspace=workspace, Filename=path)
+            run_algorithm('SaveMD', store=False, InputWorkspace=workspace, Filename=path)
     else:
-        run_algorithm('SaveNexus', InputWorkspace=workspace, Filename=path)
+        run_algorithm('SaveNexus', store=False, InputWorkspace=workspace, Filename=path)
 
 
 def save_ascii(workspace, path, is_slice):

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -240,7 +240,7 @@ def _save_single_ws(workspace, save_name, save_method, path, extension, slice_no
     save_as = save_name if save_name is not None else str(workspace) + extension
     full_path = os.path.join(str(path), save_as)
     workspace = get_workspace_handle(workspace)
-    non_psd_slice = slice_nonpsd and not workspace.is_PSD and isinstance(workspace, MatrixWorkspace)
+    non_psd_slice = slice_nonpsd and isinstance(workspace, MatrixWorkspace) and not workspace.is_PSD
     if is_pixel_workspace(workspace) or non_psd_slice:
         slice = True
         workspace = _get_slice_mdhisto(workspace, get_workspace_name(workspace))

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -32,6 +32,7 @@ class CutPlot(object):
         plot_window.menu_intensity.setDisabled(True)
         plot_window.menu_information.setDisabled(True)
         plot_window.action_interactive_cuts.setVisible(False)
+        plot_window.action_save_cut.setVisible(False)
         plot_window.action_save_cut.triggered.connect(self.save_icut)
         plot_window.action_flip_axis.setVisible(False)
         plot_window.action_flip_axis.triggered.connect(self.flip_icut)

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -49,7 +49,7 @@ class CutPlot(object):
     def is_icut(self, is_icut):
         self.plot_window.action_save_cut.setVisible(is_icut)
         self.plot_window.action_plot_options.setVisible(not is_icut)
-        self.plot_window.action_toggle_legends.setVisible(not is_icut)
+        self.plot_window.keep_make_current_seperator.setVisible(not is_icut)
         self.plot_window.action_keep.setVisible(not is_icut)
         self.plot_window.action_make_current.setVisible(not is_icut)
         self.plot_window.action_flip_axis.setVisible(is_icut)

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -39,7 +39,7 @@ class InteractiveCut(object):
             units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
                 self._canvas.figure.gca().get_xaxis().units
             integration_axis = Axis(units, integration_start, integration_end, 0)
-            self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False)
+            self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False, False)
 
     def get_cut_parameters(self, pos1, pos2):
         start = pos1[not self.horizontal]

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -1,6 +1,7 @@
 from matplotlib.widgets import RectangleSelector
 
 from mslice.models.axis import Axis
+from mslice.models.cut.cut_functions import output_workspace_name
 from mslice.models.workspacemanager.workspace_algorithms import (get_limits)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_name
 
@@ -33,13 +34,13 @@ class InteractiveCut(object):
         self.connect_event[2] = self._canvas.mpl_connect('button_press_event', self.clicked)
         self._rect_pos_cache = rect_pos
 
-    def plot_cut(self, x1, x2, y1, y2):
+    def plot_cut(self, x1, x2, y1, y2, store=False):
         if x2 > x1 and y2 > y1:
             ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
             units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
                 self._canvas.figure.gca().get_xaxis().units
             integration_axis = Axis(units, integration_start, integration_end, 0)
-            self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False, False)
+            self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False, store)
 
     def get_cut_parameters(self, pos1, pos2):
         start = pos1[not self.horizontal]
@@ -63,13 +64,10 @@ class InteractiveCut(object):
 
     def save_cut(self):
         x1, x2, y1, y2 = self.rect.extents
-        ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
-        units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
-            self._canvas.figure.gca().get_xaxis().units
-        integration_axis = Axis(units, integration_start, integration_end, 0)
-        output_ws = self._cut_plotter.save_cut((str(self._ws_title), ax, integration_axis, False))
+        self.plot_cut(x1, x2, y1, y2, store=True)
         self.update_workspaces()
-        return get_workspace_name(output_ws)
+        ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
+        return output_workspace_name(str(self._ws_title), integration_start, integration_end)
 
     def update_workspaces(self):
         self.slice_plot.update_workspaces()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -3,7 +3,7 @@ from matplotlib.widgets import RectangleSelector
 from mslice.models.axis import Axis
 from mslice.models.cut.cut_functions import output_workspace_name
 from mslice.models.workspacemanager.workspace_algorithms import (get_limits)
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_name
+from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.widgets.cut.cut import CUT_PLOTTER
 
 

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -4,18 +4,18 @@ from mslice.models.axis import Axis
 from mslice.models.cut.cut_functions import output_workspace_name
 from mslice.models.workspacemanager.workspace_algorithms import (get_limits)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_name
+from mslice.widgets.cut.cut import CUT_PLOTTER
 
 
 class InteractiveCut(object):
 
     def __init__(self, slice_plot, canvas, ws_title):
-        from mslice.models.cut.matplotlib_cut_plotter import MatplotlibCutPlotter
         self.slice_plot = slice_plot
         self._canvas = canvas
         self._ws_title = ws_title
         self.horizontal = None
         self.connect_event = [None, None, None]
-        self._cut_plotter = MatplotlibCutPlotter()
+        self._cut_plotter = CUT_PLOTTER
         self._rect_pos_cache = [0, 0, 0, 0, 0, 0]
         self.rect = RectangleSelector(self._canvas.figure.gca(), self.plot_from_mouse_event,
                                       drawtype='box', useblit=True,

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -118,10 +118,11 @@ class PlotWindow(QtWidgets.QMainWindow):
         self.action_save_image = add_action(toolbar, self, "Save Image", icon_name='fa.save')
         self.action_print_plot = add_action(toolbar, self,  "Print", icon_name='fa.print')
         self.action_plot_options = add_action(toolbar, self, "Plot Options", icon_name='fa.cog')
-        self.action_interactive_cuts = add_action(toolbar, self,  "Interactive Cuts", checkable=True)
 
-        # Options enabled depending on whether we are slicing or cutting
-        self.action_save_cut = add_action(toolbar, self,  "Save Cut")
+        toolbar.addSeparator()
+        self.action_interactive_cuts = add_action(toolbar, self,  "Interactive Cuts", checkable=True)
+        # options for interactive cuts only
+        self.action_save_cut = add_action(toolbar, self,  "Save Cut to Workspace")
         self.action_flip_axis = add_action(toolbar, self,  "Flip Integration Axis",
                                            icon_name='fa.retweet')
 

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -113,7 +113,7 @@ class PlotWindow(QtWidgets.QMainWindow):
         self.keep_make_current_group = QtWidgets.QActionGroup(self)
         self.keep_make_current_group.addAction(self.action_keep)
         self.keep_make_current_group.addAction(self.action_make_current)
-        toolbar.addSeparator()
+        self.keep_make_current_seperator = toolbar.addSeparator()
 
         self.action_save_image = add_action(toolbar, self, "Save Image", icon_name='fa.save')
         self.action_print_plot = add_action(toolbar, self,  "Print", icon_name='fa.print')

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -83,6 +83,7 @@ class CutPresenter(PresenterUtility):
     def _plot_cut(self, params, plot_over):
         self._cut_plotter.plot_cut(*params, plot_over=plot_over)
         self._main_presenter.highlight_ws_tab(2)
+        self._main_presenter.update_displayed_workspaces()
 
     def _save_cut_to_workspace(self, params, _):
         cut_params = params[:4]

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -82,6 +82,7 @@ class CutPresenter(PresenterUtility):
 
     def _plot_cut(self, params, plot_over):
         self._cut_plotter.plot_cut(*params, plot_over=plot_over)
+        self._cut_plotter.set_icut(False)
         self._main_presenter.highlight_ws_tab(2)
         self._main_presenter.update_displayed_workspaces()
 
@@ -92,6 +93,8 @@ class CutPresenter(PresenterUtility):
 
     def _plot_cut_from_workspace(self, plot_over):
         selected_workspaces = self._main_presenter.get_selected_workspaces()
+        self._cut_plotter.set_icut(False)
+
         for workspace in selected_workspaces:
             x, y, e, units = get_arrays_from_workspace(workspace)
             self._cut_plotter.plot_cut_from_xye(x, y, e, units, workspace, plot_over=plot_over)

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 from .busy import show_busy
 from mslice.models.alg_workspace_ops import get_available_axes, get_axis_range
 from mslice.models.axis import Axis
-from mslice.models.cut.cut_functions import (get_arrays_from_workspace, is_cuttable)
+from mslice.models.cut.cut_functions import compute_cut_xye, get_arrays_from_workspace, is_cuttable
 from mslice.models.cut.cut_plotter import CutPlotter
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.presenters.presenter_utility import PresenterUtility
@@ -32,9 +32,9 @@ class CutPresenter(PresenterUtility):
         self._clear_displayed_error(self._cut_view)
         with show_busy(self._cut_view):
             if command == Command.Plot:
-                self._cut(output_method=self._plot_and_save_to_workspace)
+                self._cut(output_method=self._plot_cut)
             elif command == Command.PlotOver:
-                self._cut(output_method=self._plot_and_save_to_workspace, plot_over=True)
+                self._cut(output_method=self._plot_cut, plot_over=True)
             elif command == Command.PlotFromWorkspace:
                 self._plot_cut_from_workspace(plot_over=False)
             elif command == Command.PlotOverFromWorkspace:
@@ -80,17 +80,13 @@ class CutPresenter(PresenterUtility):
             # The first plot will respect which button the user pressed. The rest will over plot
             plot_over = True
 
-    def _plot_and_save_to_workspace(self, params, plot_over):
-        self._plot_cut(params, plot_over)
-        self._save_cut_to_workspace(params, plot_over)
-
     def _plot_cut(self, params, plot_over):
         self._cut_plotter.plot_cut(*params, plot_over=plot_over)
         self._main_presenter.highlight_ws_tab(2)
 
     def _save_cut_to_workspace(self, params, _):
         cut_params = params[:4]
-        self._cut_plotter.save_cut(cut_params)
+        compute_cut_xye(*cut_params)
         self._main_presenter.update_displayed_workspaces()
 
     def _plot_cut_from_workspace(self, plot_over):

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -252,7 +252,9 @@ class CutPresenterTest(unittest.TestCase):
         self.cut_plotter.plot_cut.assert_called_with(workspace, processed_axis, integration_axis,
                                                      is_norm, None, intensity_end, plot_over=True)
 
-    def test_cut_single_save_to_workspace(self):
+    @patch('mslice.presenters.cut_presenter.compute_cut_xye')
+    @patch('mslice.models.cut.cut_functions.get_workspace_handle')
+    def test_cut_single_save_to_workspace(self, get_workspace_handle_mock, compute_cut_xye_mock):
         cut_presenter = CutPresenter(self.view, self.cut_plotter)
         cut_presenter.register_master(self.main_presenter)
         axis = Axis("units", "0", "100", "1")
@@ -264,13 +266,15 @@ class CutPresenterTest(unittest.TestCase):
         intensity_end = 30
         is_norm = True
         workspace = "workspace"
+        ws_mock = mock.Mock()
+        get_workspace_handle_mock.return_value = ws_mock
         integrated_axis = 'integrated axis'
         integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis)
         self.cut_plotter.plot_cut = mock.Mock()
         cut_presenter.notify(Command.SaveToWorkspace)
-        self.cut_plotter.save_cut.assert_called_with((workspace, processed_axis, integration_axis, is_norm))
+        compute_cut_xye_mock.assert_called_with(workspace, processed_axis, integration_axis, is_norm)
         self.cut_plotter.plot_cut.assert_not_called()
 
     def test_plot_multiple_cuts_with_width(self):

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -19,6 +19,7 @@ from .command import Command
 # Classes and functions
 # -----------------------------------------------------------------------------
 
+CUT_PLOTTER = MatplotlibCutPlotter()
 
 class CutWidget(CutView, QWidget):
     error_occurred = Signal('QString')
@@ -34,8 +35,7 @@ class CutWidget(CutView, QWidget):
         }
         for button in self._command_lookup.keys():
             button.clicked.connect(self._btn_clicked)
-        cut_plotter = MatplotlibCutPlotter()
-        self._presenter = CutPresenter(self, cut_plotter)
+        self._presenter = CutPresenter(self, CUT_PLOTTER)
         self.cmbCutAxis.currentIndexChanged.connect(self.axis_changed)
         self._minimumStep = None
         self.lneCutStep.editingFinished.connect(self._step_edited)


### PR DESCRIPTION
Fixes some bugs with saving cuts.

**To test:**
1. Normal cuts
 - Plot a cut 
- 'Save Cut to Workspace' button should **not** be visible
- Plotted cut should appear in `MD Histo` tab of workspace manager
- Click the save icon in the plot window and make sure the cut saves to a file correctly
- Close the plot, select the cut in the workspace manager and click save, make sure it saves correctly

2 . Interactive cuts
- Start an interactive cut
- The cut should **not** appear in the `MD Histo` tab until 'Save Cut to Workspace' is clicked
- Test 'Save Cut to Workspace' button works on both slice and cut window, causing the cut to appear in the `MD Histo` tab.
- Click the save icon in the plot window and make sure the cut saves to a file correctly

Fixes #332 
