### PR TITLE
Improve default Q limits for large data sets

### DIFF
--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -34,12 +34,13 @@ class Axis(object):
 
     @end.setter
     def end(self, value):
-        if value < self.start:
-            raise ValueError("Invalid axis parameter - end is smaller than start")
         try:
-            self._end = float(value)
+            end = float(value)
         except ValueError:
             raise ValueError("Invalid axis parameter - end '%s' is not a valid float" % value)
+        if end < self.start:
+            raise ValueError("Invalid axis parameter - end is smaller than start")
+        self._end = end
 
     @property
     def step(self):

--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -34,6 +34,8 @@ class Axis(object):
 
     @end.setter
     def end(self, value):
+        if value < self.start:
+            raise ValueError("Invalid axis parameter - end is smaller than start")
         try:
             self._end = float(value)
         except ValueError:

--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -35,12 +35,12 @@ class Axis(object):
     @end.setter
     def end(self, value):
         try:
-            end = float(value)
+            end_float = float(value)
         except ValueError:
             raise ValueError("Invalid axis parameter - end '%s' is not a valid float" % value)
-        if end < self.start:
+        if end_float < self.start:
             raise ValueError("Invalid axis parameter - end is smaller than start")
-        self._end = end
+        self._end = end_float
 
     @property
     def step(self):

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -50,3 +50,5 @@ class MantidProjectionCalculator(ProjectionCalculator):
                                Limits=workspace.limits['MomentumTransfer'], ProjectionType=projection_type)
         propagate_properties(workspace, new_ws)
         return new_ws
+
+

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -50,5 +50,3 @@ class MantidProjectionCalculator(ProjectionCalculator):
                                Limits=workspace.limits['MomentumTransfer'], ProjectionType=projection_type)
         propagate_properties(workspace, new_ws)
         return new_ws
-
-

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -107,6 +107,7 @@ def _get_property_from_history(name, history):
 
 
 def get_q_limits(theta, emax, efix):
+    # calculate |Q| limits in Angstrom^-1 from theta (scattering angle) in radians
     qmin, qmax, qstep = tuple(np.sqrt(E2q * 2 * efix * (1 - np.cos(theta)) * meV2J) / m2A)
     qmax = np.sqrt(E2q * (2 * efix + emax - 2 * np.sqrt(efix * (efix + emax)) * np.cos(theta[1])) * meV2J) / m2A
     return qmin, qmax, qstep
@@ -123,18 +124,8 @@ def set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep):
 def _get_theta_for_limits(ws):
     # Don't parse all spectra in cases where there are a lot to save time.
     num_hist = ws.raw_ws.getNumberHistograms()
-    if num_hist > 1000:
-        n_segments = 5
-        interval = int(num_hist / n_segments)
-        theta = []
-        for segment in range(n_segments):
-            i0 = segment * interval
-            theta.append([ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i))
-                          for i in range(i0, i0+200)])
-        round_fac = 573
-    else:
-        theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_hist)]
-        round_fac = 100
+    theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_hist)]
+    round_fac = 100
     ws.is_PSD = not all(x < y for x, y in zip(theta, theta[1:]))
     # Rounds the differences to avoid pixels with same 2theta. Implies min limit of ~0.5 degrees
     thdiff = np.diff(np.round(np.sort(theta)*round_fac)/round_fac)

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -79,7 +79,7 @@ def process_limits_event(ws):
     theta = _get_theta_for_limits_event(ws)
     estep = _original_step_size(ws)
     emax_1 = -emin if (str(ws.e_mode == 'Direct')) else emax
-    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed)
+    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed, ws.e_mode)
     set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep)
 
 
@@ -108,8 +108,8 @@ def get_q_limits(theta, en, efix, e_mode):
     #calculates the Q(E) line for the given two theta and then finds the min and max values
     direct = (e_mode == 'Direct')
     qlines = [np.sqrt(E2q * (2 * efix - en - 2 * np.sqrt(efix * (efix - en)) * np.cos(tth)) * meV2J) / 1e10 for tth in theta[:2]]
-    qmin = np.min(qlines[0 if direct else 1])
-    qmax = np.max(qlines[1 if direct else 0])
+    qmin = np.nanmin(qlines[0 if direct else 1])
+    qmax = np.nanmax(qlines[1 if direct else 0])
     e = efix if direct else -efix
     qstep = np.sqrt(E2q * 2 * e * (1 - np.cos(theta[2])) * meV2J) / m2A
     return qmin, qmax, qstep

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -68,7 +68,7 @@ def _processLoadedWSLimits(workspace):
 def process_limits(ws):
     en = ws.raw_ws.getAxis(0).extractValues()
     theta = _get_theta_for_limits(ws)
-    qmin, qmax, qstep = get_q_limits(theta, en, ws.e_fixed, ws.e_mode)
+    qmin, qmax, qstep = get_q_limits(theta, en, ws.e_fixed)
     set_limits(ws, qmin, qmax, qstep, theta, np.min(en), np.max(en), np.mean(np.diff(en)))
 
 
@@ -104,14 +104,12 @@ def _get_property_from_history(name, history):
     return None
 
 
-def get_q_limits(theta, en, efix, e_mode):
+def get_q_limits(theta, en, efix):
     #calculates the Q(E) line for the given two theta and then finds the min and max values
-    direct = (e_mode == 'Direct')
     qlines = [np.sqrt(E2q * (2 * efix - en - 2 * np.sqrt(efix * (efix - en)) * np.cos(tth)) * meV2J) / 1e10 for tth in theta[:2]]
-    qmin = np.nanmin(qlines[0 if direct else 1])
-    qmax = np.nanmax(qlines[1 if direct else 0])
-    e = efix if direct else -efix
-    qstep = np.sqrt(E2q * 2 * e * (1 - np.cos(theta[2])) * meV2J) / m2A
+    qmin = np.nanmin(qlines[0])
+    qmax = np.nanmax(qlines[1])
+    qstep = np.sqrt(E2q * 2 * efix * (1 - np.cos(theta[2])) * meV2J) / m2A
     return qmin, qmax, qstep
 
 

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -114,7 +114,6 @@ def get_q_limits(theta, en, efix, ndetectors):
         qstep = (qmax - qmin) / 100
     else:
         qstep = np.sqrt(E2q * 2 * efix * (1 - np.cos(theta[2])) * meV2J) / m2A
-        qstep = qstep / 3  # Use a step size a bit smaller than angular spacing ( / 3) so user can rebin if they want
     qmin -= qstep
     qmax += qstep
     return qmin, qmax, qstep

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -68,7 +68,7 @@ def _processLoadedWSLimits(workspace):
 def process_limits(ws):
     en = ws.raw_ws.getAxis(0).extractValues()
     theta = _get_theta_for_limits(ws)
-    qmin, qmax, qstep = get_q_limits(theta, en, ws.e_fixed, ws.raw_ws.getNumberHistograms())
+    qmin, qmax, qstep = get_q_limits(theta, en, ws.e_fixed)
     set_limits(ws, qmin, qmax, qstep, theta, np.min(en), np.max(en), np.mean(np.diff(en)))
 
 
@@ -79,7 +79,7 @@ def process_limits_event(ws):
     theta = _get_theta_for_limits_event(ws)
     estep = _original_step_size(ws)
     emax_1 = -emin if (str(ws.e_mode == 'Direct')) else emax
-    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed, ws.raw_ws.getNumberHistograms())
+    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed)
     set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep)
 
 
@@ -104,7 +104,7 @@ def _get_property_from_history(name, history):
     return None
 
 
-def get_q_limits(theta, en, efix, ndetectors):
+def get_q_limits(theta, en, efix):
     #calculates the Q(E) line for the given two theta and then finds the min and max values
     qlines = [np.sqrt(E2q * (2 * efix - en - 2 * np.sqrt(efix * (efix - en)) * np.cos(tth)) * meV2J) / 1e10 for tth in theta[:2]]
     qmin = np.nanmin(qlines[0])

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -79,7 +79,7 @@ def process_limits_event(ws):
     theta = _get_theta_for_limits_event(ws)
     estep = _original_step_size(ws)
     emax_1 = -emin if (str(ws.e_mode == 'Direct')) else emax
-    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed, ws.e_mode)
+    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed)
     set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep)
 
 

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -68,7 +68,7 @@ def _processLoadedWSLimits(workspace):
 def process_limits(ws):
     en = ws.raw_ws.getAxis(0).extractValues()
     theta = _get_theta_for_limits(ws)
-    qmin, qmax, qstep = get_q_limits(theta, en, ws.e_fixed)
+    qmin, qmax, qstep = get_q_limits(theta, en, ws.e_fixed, ws.raw_ws.getNumberHistograms())
     set_limits(ws, qmin, qmax, qstep, theta, np.min(en), np.max(en), np.mean(np.diff(en)))
 
 
@@ -79,7 +79,7 @@ def process_limits_event(ws):
     theta = _get_theta_for_limits_event(ws)
     estep = _original_step_size(ws)
     emax_1 = -emin if (str(ws.e_mode == 'Direct')) else emax
-    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed)
+    qmin, qmax, qstep = get_q_limits(theta, emax_1, ws.e_fixed, ws.raw_ws.getNumberHistograms())
     set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep)
 
 
@@ -104,25 +104,31 @@ def _get_property_from_history(name, history):
     return None
 
 
-def get_q_limits(theta, en, efix):
+def get_q_limits(theta, en, efix, ndetectors):
     #calculates the Q(E) line for the given two theta and then finds the min and max values
     qlines = [np.sqrt(E2q * (2 * efix - en - 2 * np.sqrt(efix * (efix - en)) * np.cos(tth)) * meV2J) / 1e10 for tth in theta[:2]]
     qmin = np.nanmin(qlines[0])
     qmax = np.nanmax(qlines[1])
-    qstep = np.sqrt(E2q * 2 * efix * (1 - np.cos(theta[2])) * meV2J) / m2A
+
+    if(ndetectors > 1000):
+        qstep = (qmax - qmin) / 100
+    else:
+        qstep = np.sqrt(E2q * 2 * efix * (1 - np.cos(theta[2])) * meV2J) / m2A
+        qstep = qstep / 3  # Use a step size a bit smaller than angular spacing ( / 3) so user can rebin if they want
+    qmin -= qstep
+    qmax += qstep
     return qmin, qmax, qstep
 
 
 def set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep):
-    # Use a step size a bit smaller than angular spacing ( / 3) so user can rebin if they want...
-    ws.limits['MomentumTransfer'] = [qmin - qstep, qmax + qstep, qstep / 3]
+
+    ws.limits['MomentumTransfer'] = [qmin, qmax, qstep]
     ws.limits['|Q|'] = ws.limits['MomentumTransfer']  # ConvertToMD renames it(!)
     ws.limits['Degrees'] = theta * 180 / np.pi
     ws.limits['DeltaE'] = [emin, emax, estep]
 
 
 def _get_theta_for_limits(ws):
-    # Don't parse all spectra in cases where there are a lot to save time.
     num_hist = ws.raw_ws.getNumberHistograms()
     theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_hist)]
     round_fac = 100

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -109,11 +109,8 @@ def get_q_limits(theta, en, efix, ndetectors):
     qlines = [np.sqrt(E2q * (2 * efix - en - 2 * np.sqrt(efix * (efix - en)) * np.cos(tth)) * meV2J) / 1e10 for tth in theta[:2]]
     qmin = np.nanmin(qlines[0])
     qmax = np.nanmax(qlines[1])
-
-    if(ndetectors > 1000):
-        qstep = (qmax - qmin) / 100
-    else:
-        qstep = np.sqrt(E2q * 2 * efix * (1 - np.cos(theta[2])) * meV2J) / m2A
+    const_tth = np.radians(0.5)
+    qstep = np.sqrt(E2q * 2 * efix * (1 - np.cos(const_tth)) * meV2J) / m2A
     qmin -= qstep
     qmax += qstep
     return qmin, qmax, qstep

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -48,19 +48,10 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             return
 
         selected_workspace = selected_workspaces[0]
-        try:
-            x_axis = Axis(self._slice_view.get_slice_x_axis(), self._slice_view.get_slice_x_start(),
-                          self._slice_view.get_slice_x_end(), self._slice_view.get_slice_x_step())
-        except ValueError:
-            self._slice_view.error_invalid_x_params()
+        axes = self.create_axes_from_input()
+        if (not axes):
             return
-        try:
-            y_axis = Axis(self._slice_view.get_slice_y_axis(), self._slice_view.get_slice_y_start(),
-                          self._slice_view.get_slice_y_end(), self._slice_view.get_slice_y_step())
-        except ValueError:
-            self._slice_view.error_invalid_plot_parameters()
-            return
-
+        x_axis, y_axis = axes
         intensity_start = self._slice_view.get_slice_intensity_start()
         intensity_end = self._slice_view.get_slice_intensity_end()
         norm_to_one = bool(self._slice_view.get_slice_is_norm_to_one())
@@ -95,6 +86,21 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             if str(e) != "minvalue must be less than or equal to maxvalue":
                 raise e
             self._slice_view.error_invalid_intensity_params()
+
+    def create_axes_from_input(self):
+        try:
+            x_axis = Axis(self._slice_view.get_slice_x_axis(), self._slice_view.get_slice_x_start(),
+                          self._slice_view.get_slice_x_end(), self._slice_view.get_slice_x_step())
+        except ValueError:
+            self._slice_view.error_invalid_x_params()
+            return False
+        try:
+            y_axis = Axis(self._slice_view.get_slice_y_axis(), self._slice_view.get_slice_y_start(),
+                          self._slice_view.get_slice_y_end(), self._slice_view.get_slice_y_step())
+        except ValueError:
+            self._slice_view.error_invalid_plot_parameters()
+            return False
+        return x_axis, y_axis
 
 
     @require_main_presenter

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -48,7 +48,7 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             return
 
         selected_workspace = selected_workspaces[0]
-        axes = self.create_axes_from_input()
+        axes = self.validate_axes()
         if (not axes):
             return
         x_axis, y_axis = axes
@@ -87,7 +87,7 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
                 raise e
             self._slice_view.error_invalid_intensity_params()
 
-    def create_axes_from_input(self):
+    def validate_axes(self):
         try:
             x_axis = Axis(self._slice_view.get_slice_x_axis(), self._slice_view.get_slice_x_start(),
                           self._slice_view.get_slice_x_end(), self._slice_view.get_slice_x_step())
@@ -98,6 +98,9 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             y_axis = Axis(self._slice_view.get_slice_y_axis(), self._slice_view.get_slice_y_start(),
                           self._slice_view.get_slice_y_end(), self._slice_view.get_slice_y_step())
         except ValueError:
+            self._slice_view.error_invalid_y_params()
+            return False
+        if x_axis.units == y_axis.units:
             self._slice_view.error_invalid_plot_parameters()
             return False
         return x_axis, y_axis

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -48,18 +48,16 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             return
 
         selected_workspace = selected_workspaces[0]
-        x_axis = Axis(self._slice_view.get_slice_x_axis(), self._slice_view.get_slice_x_start(),
-                      self._slice_view.get_slice_x_end(), self._slice_view.get_slice_x_step())
-        y_axis = Axis(self._slice_view.get_slice_y_axis(), self._slice_view.get_slice_y_start(),
-                      self._slice_view.get_slice_y_end(), self._slice_view.get_slice_y_step())
-        status = self._process_axis(x_axis, y_axis)
-        if status == INVALID_Y_PARAMS:
-            self._slice_view.error_invalid_y_params()
-            return
-        elif status == INVALID_X_PARAMS:
+        try:
+            x_axis = Axis(self._slice_view.get_slice_x_axis(), self._slice_view.get_slice_x_start(),
+                          self._slice_view.get_slice_x_end(), self._slice_view.get_slice_x_step())
+        except ValueError:
             self._slice_view.error_invalid_x_params()
             return
-        elif status == INVALID_PARAMS:
+        try:
+            y_axis = Axis(self._slice_view.get_slice_y_axis(), self._slice_view.get_slice_y_start(),
+                          self._slice_view.get_slice_y_end(), self._slice_view.get_slice_y_step())
+        except ValueError:
             self._slice_view.error_invalid_plot_parameters()
             return
 

--- a/mslice/tests/cut_presenter_test.py
+++ b/mslice/tests/cut_presenter_test.py
@@ -159,14 +159,6 @@ class CutPresenterTest(unittest.TestCase):
         # Bad cut axis
         with self.assertRaises(ValueError):
             Axis("units", "a", "100", "1")
-        # Invalid axis range
-        axis = Axis("units", "100", "0", "1")
-        cut_presenter = CutPresenter(self.view, self.cut_plotter)
-        cut_presenter.register_master(self.main_presenter)
-        self._create_cut(axis, processed_axis, integration_start, integration_end, width,
-                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
-        cut_presenter.notify(Command.Plot)
-        self.assertRaises(ValueError)
         axis = Axis("units", "0", "100", "1")
         # Bad integration
         integration_start = "a"

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -208,8 +208,6 @@ class SlicePlotterPresenterTest(unittest.TestCase):
     def test_plot_slice_invalid_intensity_params_fail(self):
         self.slice_plotter_presenter = SlicePlotterPresenter( self.slice_view, self.slice_plotter )
         self.slice_plotter_presenter.register_master(self.main_presenter)
-        x = Axis('x','0','7','1')
-        y = Axis('y','2','8','3')
         intensity_start = '7'
         intensity_end = "j" #invalid
         norm_to_one = '9'

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -124,8 +124,6 @@ class SlicePlotterPresenterTest(unittest.TestCase):
     def test_plot_slice_x_start_bigger_than_x_stop_fail(self):
         self.slice_plotter_presenter = SlicePlotterPresenter( self.slice_view, self.slice_plotter )
         self.slice_plotter_presenter.register_master(self.main_presenter)
-        x = Axis('x','2','1','.1')
-        y = Axis('y','2','8','3')
         intensity_start = '7'
         intensity_end = '8'
         norm_to_one = '9'
@@ -133,14 +131,14 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         colourmap = 'colormap'
         selected_workspace = 'workspace1'
         self.main_presenter.get_selected_workspaces.return_value = [selected_workspace]
-        self.slice_view.get_slice_x_axis.return_value = x.units
-        self.slice_view.get_slice_x_start.return_value = x.start
-        self.slice_view.get_slice_x_end.return_value = x.end
-        self.slice_view.get_slice_x_step.return_value = x.step
-        self.slice_view.get_slice_y_axis.return_value = y.units
-        self.slice_view.get_slice_y_start.return_value = y.start
-        self.slice_view.get_slice_y_end.return_value = y.end
-        self.slice_view.get_slice_y_step.return_value = y.step
+        self.slice_view.get_slice_x_axis.return_value = 'x'
+        self.slice_view.get_slice_x_start.return_value = '2'
+        self.slice_view.get_slice_x_end.return_value = '1' # invalid
+        self.slice_view.get_slice_x_step.return_value = '.1'
+        self.slice_view.get_slice_y_axis.return_value = 'y'
+        self.slice_view.get_slice_y_start.return_value = '2'
+        self.slice_view.get_slice_y_end.return_value = '8'
+        self.slice_view.get_slice_y_step.return_value = '3'
         self.slice_view.get_slice_intensity_start.return_value = intensity_start
         self.slice_view.get_slice_intensity_end.return_value = intensity_end
         self.slice_view.get_slice_is_norm_to_one.return_value = norm_to_one
@@ -182,8 +180,6 @@ class SlicePlotterPresenterTest(unittest.TestCase):
     def test_plot_slice_invalid_y_params_y_end_less_than_y_start_fail(self):
         self.slice_plotter_presenter = SlicePlotterPresenter( self.slice_view, self.slice_plotter )
         self.slice_plotter_presenter.register_master(self.main_presenter)
-        x = Axis('x','0','7','1')
-        y = Axis('y','20','8','3')
         intensity_start = '7'
         intensity_end = '8'
         norm_to_one = '9'
@@ -191,14 +187,14 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         colourmap = 'colormap'
         selected_workspace = 'workspace1'
         self.main_presenter.get_selected_workspaces.return_value = [selected_workspace]
-        self.slice_view.get_slice_x_axis.return_value = x.units
-        self.slice_view.get_slice_x_start.return_value = x.start
-        self.slice_view.get_slice_x_end.return_value = x.end
-        self.slice_view.get_slice_x_step.return_value = x.step
-        self.slice_view.get_slice_y_axis.return_value = y.units
-        self.slice_view.get_slice_y_start.return_value = y.start
-        self.slice_view.get_slice_y_end.return_value = y.end
-        self.slice_view.get_slice_y_step.return_value = y.step
+        self.slice_view.get_slice_x_axis.return_value = 'x'
+        self.slice_view.get_slice_x_start.return_value = '0'
+        self.slice_view.get_slice_x_end.return_value = '7'
+        self.slice_view.get_slice_x_step.return_value = '1'
+        self.slice_view.get_slice_y_axis.return_value = 'y'
+        self.slice_view.get_slice_y_start.return_value = '20' # invalid
+        self.slice_view.get_slice_y_end.return_value = '8'
+        self.slice_view.get_slice_y_step.return_value = '3'
         self.slice_view.get_slice_intensity_start.return_value = intensity_start
         self.slice_view.get_slice_intensity_end.return_value = intensity_end
         self.slice_view.get_slice_is_norm_to_one.return_value = norm_to_one
@@ -215,20 +211,20 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         x = Axis('x','0','7','1')
         y = Axis('y','2','8','3')
         intensity_start = '7'
-        intensity_end = "j"
+        intensity_end = "j" #invalid
         norm_to_one = '9'
         smoothing = '10'
         colourmap = 'colormap'
         selected_workspace = 'workspace1'
         self.main_presenter.get_selected_workspaces.return_value = [selected_workspace]
-        self.slice_view.get_slice_x_axis.return_value = x.units
-        self.slice_view.get_slice_x_start.return_value = x.start
-        self.slice_view.get_slice_x_end.return_value = x.end
-        self.slice_view.get_slice_x_step.return_value = x.step
-        self.slice_view.get_slice_y_axis.return_value = y.units
-        self.slice_view.get_slice_y_start.return_value = y.start
-        self.slice_view.get_slice_y_end.return_value = y.end
-        self.slice_view.get_slice_y_step.return_value = y.step
+        self.slice_view.get_slice_x_axis.return_value = 'x'
+        self.slice_view.get_slice_x_start.return_value = '0'
+        self.slice_view.get_slice_x_end.return_value = '7'
+        self.slice_view.get_slice_x_step.return_value = '1'
+        self.slice_view.get_slice_y_axis.return_value = 'y'
+        self.slice_view.get_slice_y_start.return_value = '2'
+        self.slice_view.get_slice_y_end.return_value = '8'
+        self.slice_view.get_slice_y_step.return_value = '3'
         self.slice_view.get_slice_intensity_start.return_value = intensity_start
         self.slice_view.get_slice_intensity_end.return_value = intensity_end
         self.slice_view.get_slice_is_norm_to_one.return_value = norm_to_one

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -116,8 +116,9 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_is_norm_to_one.return_value = norm_to_one
         self.slice_view.get_slice_smoothing.return_value = smoothing
         self.slice_view.get_slice_colourmap.return_value = colourmap
-        with self.assertRaises(ValueError):
-            self.slice_plotter_presenter.notify(Command.DisplaySlice)
+
+        self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_view.error_invalid_x_params.assert_called_once_with()
         assert(not self.slice_plotter.plot_slice.called)
 
     def test_plot_slice_x_start_bigger_than_x_stop_fail(self):
@@ -174,8 +175,8 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         self.slice_view.get_slice_smoothing.return_value = smoothing
         self.slice_view.get_slice_colourmap.return_value = colourmap
 
-        with self.assertRaises(ValueError):
-            self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_plotter_presenter.notify(Command.DisplaySlice)
+        self.slice_view.error_invalid_y_params()
         assert(not self.slice_plotter.plot_slice.called)
 
     def test_plot_slice_invalid_y_params_y_end_less_than_y_start_fail(self):

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -86,7 +86,8 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         limits = get_limits('test_ws_md', 'DeltaE')
         np.testing.assert_array_almost_equal(limits, [-10, 10, 1], 4)
         limits = get_limits('test_ws_md', '|Q|')
-        np.testing.assert_array_almost_equal(limits, [0.5393, 8.622, 0.0164], 4)
+        np.testing.assert_allclose(limits, [0.545576, 8.615743, 0.042867], rtol=0, atol=1e-3)
+
 
 
     def test_get_limits_saved(self):
@@ -94,5 +95,5 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         get_limits('test_ws_2d', 'DeltaE')
         np.testing.assert_array_equal(self.test_ws_2d.limits['DeltaE'], [-10, 10, 1])
         np.testing.assert_array_equal(self.test_ws_2d.limits['|Q|'], self.test_ws_2d.limits['MomentumTransfer'])
-        np.testing.assert_almost_equal(self.test_ws_2d.limits['|Q|'], [0.2449,  9.53079,  0.01637], 5)
+        np.testing.assert_almost_equal(self.test_ws_2d.limits['|Q|'], [0.25116,  9.52454,  0.04287], 5)
         np.testing.assert_almost_equal(self.test_ws_2d.limits['Degrees'], [3.43, 134.14, 0.57296], 5)

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -15,13 +15,15 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
     def setUp(self):
         self.test_ws_2d = run_algorithm('CreateSimulationWorkspace', output_name='test_ws_2d', Instrument='MAR',
                                         BinParams=[-10, 1, 10], UnitX='DeltaE')
-        run_algorithm('AddSampleLog', Workspace=self.test_ws_2d.raw_ws, store=False, LogName='Ei', LogText='3.',
+        run_algorithm('AddSampleLog', Workspace=self.test_ws_2d.raw_ws, store=False, LogName='Ei', LogText='50.',
                       LogType='Number')
         self.test_ws_md = run_algorithm('ConvertToMD', output_name='test_ws_md', InputWorkspace=self.test_ws_2d,
                                         QDimensions='|Q|', dEAnalysisMode='Direct', MinValues='-10,0,0', MaxValues='10,6,500',
                                         SplitInto='50,50')
+        self.test_ws_2d.e_mode = "Direct"
         self.test_ws_md.ef_defined = False
         self.test_ws_md.is_PSD = True
+        self.test_ws_md.e_mode = "Direct"
         self.test_ws_md.limits = {'DeltaE': [0, 2, 1]}
 
     def test_delete_workspace(self):
@@ -44,10 +46,11 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
     @patch('mslice.models.workspacemanager.workspace_algorithms._original_step_size')
     def test_combine_workspace(self, step_mock):
         ws_2 = run_algorithm('CloneWorkspace', output_name='ws_2', InputWorkspace=self.test_ws_md)
+        ws_2.e_mode = "Direct"
         step_mock.return_value = 1
         combined = combine_workspace([self.test_ws_md, ws_2], 'combined')
         np.testing.assert_array_almost_equal(combined.limits['DeltaE'], [-10, 10, 1], 4)
-        np.testing.assert_array_almost_equal(combined.limits['|Q|'], [0.071989, 3.45243, 0.033804], 4)
+        np.testing.assert_array_almost_equal(combined.limits['|Q|'], [0.2939, 9.4817, 0.0919], 4)
         self.assertTrue(combined.is_PSD)
 
     def test_process_EFixed(self):
@@ -83,7 +86,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         limits = get_limits('test_ws_md', 'DeltaE')
         np.testing.assert_array_almost_equal(limits, [-10, 10, 1], 4)
         limits = get_limits('test_ws_md', '|Q|')
-        np.testing.assert_array_almost_equal(limits, [0.06, 3.4645, 0.004], 4)
+        np.testing.assert_array_almost_equal(limits, [0.5393, 8.622, 0.0164], 4)
 
 
     def test_get_limits_saved(self):
@@ -91,5 +94,5 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         get_limits('test_ws_2d', 'DeltaE')
         np.testing.assert_array_equal(self.test_ws_2d.limits['DeltaE'], [-10, 10, 1])
         np.testing.assert_array_equal(self.test_ws_2d.limits['|Q|'], self.test_ws_2d.limits['MomentumTransfer'])
-        np.testing.assert_almost_equal(self.test_ws_2d.limits['|Q|'], [0.05998867,  3.46446147,  0.00401079], 5)
-        np.testing.assert_almost_equal(self.test_ws_2d.limits['Degrees'], [3.43, 134.14, 0.5729578], 5)
+        np.testing.assert_almost_equal(self.test_ws_2d.limits['|Q|'], [0.2449,  9.53079,  0.01637], 5)
+        np.testing.assert_almost_equal(self.test_ws_2d.limits['Degrees'], [3.43, 134.14, 0.57296], 5)

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -88,8 +88,6 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         limits = get_limits('test_ws_md', '|Q|')
         np.testing.assert_allclose(limits, [0.545576, 8.615743, 0.042867], rtol=0, atol=1e-3)
 
-
-
     def test_get_limits_saved(self):
         self.test_ws_2d.limits = {}
         get_limits('test_ws_2d', 'DeltaE')


### PR DESCRIPTION
Previously, if a workspace had more than a thousand histograms, reading the `theta` values would be cut short to save time. This resulted in incorrect default Q limits. This PR removes this 'shortcut'.

Also tidied up some of the validation when entering slice values, so that the user gets meaningful error messages if a value is invalid. This is just a quick fix for now as there is already an issue to refactor this particular part of the code (#322).

**To test:**
See issue

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #335 
