### PR TITLE
Use MANTIDPATH to find mantidpython if set

### DIFF
--- a/scripts/mslice
+++ b/scripts/mslice
@@ -1,18 +1,22 @@
 #!/bin/sh
 #
-# Launch MSlice using the Mantid Python wrappers. It is currently hardcoded to
-# use the nightly build
+# Launch MSlice using the Mantid Python wrappers. Uses MANTIDPATH
+# to determine where mantid is located otherwise it defaults to a
+# nightly build
 #
 
 # Get the directory this script resides in. This will only work on bash-like shells
 SCRIPT=$(readlink -f "$0")
 SCRIPT_PATH=$(dirname "$SCRIPT")
 
-INSTALL_PREFIX=/opt
-PACKAGE=mantidnightly
-MANTIDPYTHON=mantidpython
+if [ -n "$MANTIDPATH" ]; then
+  MANTIDPYTHON=$MANTIDPATH/mantidpython
+else
+  MANTIDPYTHON=/opt/mantidnightly/bin/mantidpython
+fi
+
 MANTIDPYTHON_ARGS="--classic"
 MAIN_SCRIPT=${SCRIPT_PATH}/start_mslice.py
 
 # Run
-${INSTALL_PREFIX}/${PACKAGE}/bin/${MANTIDPYTHON} ${MANTIDPYTHON_ARGS} ${MAIN_SCRIPT}
+${MANTIDPYTHON} ${MANTIDPYTHON_ARGS} ${MAIN_SCRIPT}

--- a/scripts/mslice.bat
+++ b/scripts/mslice.bat
@@ -1,9 +1,14 @@
 ::
-:: Launch MSlice using the Mantid Python wrappers. It is currently hardcoded to
-:: use the default install location
+:: Launch MSlice using the Mantid Python wrappers. Uses MANTIDPATH
+:: to determine where mantid is located otherwise it defaults to a
+:: C:\MantidInstall\bin
 ::
 
-set MANTIDPYTHON=C:\MantidInstall\bin\mantidpython.bat
+if DEFINED MANTIDPATH (
+  set MANTIDPYTHON=%MANTIDPATH%\mantidpython.bat
+) else (
+  set MANTIDPYTHON=C:\MantidInstall\bin\mantidpython.bat
+)
 set MANTIDPYTHON_ARGS=--classic
 set MAIN_SCRIPT=%~dp0start_mslice.py
 


### PR DESCRIPTION
Description of work.

Allows developers to redefine the version of mantid used for mslice. 

**To test:**

```shell
./mslicedevel.sh
```

 should still look for the nightly build.

Setting `MANTIDPATH` should use this version of Mantid, e.g.
```
MANTIDPATH=/media/data1/source/github/mantidproject/mantid-builds/nightly-py2/bin ./mslicedevel.sh
```

Fixes #338
