### PR TITLE
Fix exception when saving PNGs #337

### DIFF
--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -146,9 +146,9 @@ class PlotFigureManagerQT(QtCore.QObject):
         try:
             save_workspaces([workspace], file_path, save_name, ext, slice_nonpsd=True)
         except RuntimeError as e:
-            if e.message == "unrecognised file extension":
+            if str(e) == "unrecognised file extension":
                 self.save_image(os.path.join(file_path, save_name))
-            elif e.message == "dialog cancelled":
+            elif str(e) == "dialog cancelled":
                 pass
             else:
                 raise RuntimeError(e)

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -57,6 +57,9 @@ class PlotFigureManagerQT(QtCore.QObject):
         if self._plot_handler is not None:
             self._plot_handler.window_closing()
 
+    def resize(self, width, height):
+        self.window.resize(width, height)
+
     @property
     def canvas(self):
         return self.window.canvas

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -93,7 +93,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             save_directory, save_name, extension = get_save_directory(multiple_files=len(selected_workspaces) > 1,
                                                                       save_as_image=False, default_ext=extension)
         except RuntimeError as e:
-            if e.message == "dialog cancelled":
+            if str(e) == "dialog cancelled":
                 return
             else:
                 raise RuntimeError(e)


### PR DESCRIPTION
`BaseException.message` was used despite being deprecated, and this causes errors in Python 3. This PR changes these to `str(exception)` instead.

**To test:**
- Display 2D plot
- Click Save
- Select `.png` extension
- Check it saves as `.png` without errors.

Fixes #337 
