### PR TITLE
Improve error when merging different file types on load

### DIFF
--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -26,10 +26,12 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
         with show_busy(self._view):
             ws_names = [os.path.splitext(os.path.basename(base))[0] for base in file_paths]
             if merge:
+                if not self.file_types_match(file_paths):
+                    self._view.error_merge_different_file_formats()
+                    return
                 ws_names = [ws_names[0] + '_merged']
                 file_paths = ['+'.join(file_paths)]
             self._load_ws(file_paths, ws_names)
-
 
     def _load_ws(self, file_paths, ws_names):
         not_loaded = []
@@ -58,6 +60,10 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     self._main_presenter.update_displayed_workspaces()
                     self._main_presenter.show_tab_for_workspace(get_workspace_handle(ws_name))
         self._report_load_errors(ws_names, not_opened, not_loaded)
+
+    def file_types_match(self, selected_files):
+        extensions = [selection.rsplit('.', 1)[-1] for selection in selected_files]
+        return all(ext == extensions[0] for ext in extensions)
 
     def check_efixed(self, ws_name, multi=False):
         '''checks if a newly loaded workspace has efixed set'''

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -154,7 +154,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         try:
             add_workspace_runs(selected_ws)
         except ValueError as e:
-            self._workspace_manager_view.display_error(str(e))
+            self._workspace_manager_view._display_error(str(e))
         self.update_displayed_workspaces()
 
     def _subtract_workspace(self):

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -169,7 +169,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         try:
             subtract(selected_workspaces, background_ws, ssf)
         except ValueError as e:
-            self._workspace_manager_view.display_error(str(e))
+            self._workspace_manager_view._display_error(str(e))
         self.update_displayed_workspaces()
 
     def get_selected_workspaces(self):

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -101,8 +101,12 @@ class DataLoaderWidget(QWidget): # and some view interface
             if self.file_system.isDir(self.file_system.index(selection)):
                 return
         self.btnload.setEnabled(True)
-        if len(selected) > 1:
+        if len(selected) > 1 and self.file_types_match(selected):
             self.btnmerge.setEnabled(True)
+
+    def file_types_match(self, selected_files):
+        extensions = [selection.rsplit('.', 1)[-1] for selection in selected_files]
+        return all(ext == extensions[0] for ext in extensions)
 
     def get_selected_file_paths(self):
         selected = self.table_view.selectionModel().selectedRows()

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -101,12 +101,8 @@ class DataLoaderWidget(QWidget): # and some view interface
             if self.file_system.isDir(self.file_system.index(selection)):
                 return
         self.btnload.setEnabled(True)
-        if len(selected) > 1 and self.file_types_match(selected):
+        if len(selected) > 1:
             self.btnmerge.setEnabled(True)
-
-    def file_types_match(self, selected_files):
-        extensions = [selection.rsplit('.', 1)[-1] for selection in selected_files]
-        return all(ext == extensions[0] for ext in extensions)
 
     def get_selected_file_paths(self):
         selected = self.table_view.selectionModel().selectedRows()
@@ -126,6 +122,9 @@ class DataLoaderWidget(QWidget): # and some view interface
 
     def error_unable_to_open_file(self, filename=None):
         self._display_error('MSlice was not able to load %s' % ('the selected file' if filename is None else filename))
+
+    def error_merge_different_file_formats(self):
+        self._display_error('Cannot merge files with different formats')
 
     def no_workspace_has_been_loaded(self, filename=None):
         if filename is None:


### PR DESCRIPTION
Attempting to `Load and merge` files of different formats would cause an error. This now displays a more helpful error message.

**To test:**
- Select multiple files
- If they have the same extension (e.g.`.nxs`) the `Load and Merge` button should work as normal.
- If they have different extensions, an error message should say files of different formats cannot be merged.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #342
