### PR TITLE
Normalisation to unity

### DIFF
--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -29,7 +29,7 @@ class Cut(PythonAlgorithm):
         int_axis = Axis(int_dict['units'].value, int_dict['start'].value, int_dict['end'].value, int_dict['step'].value)
         e_mode = self.getProperty('EMode').value
         PSD = self.getProperty('PSD').value
-        norm_to_one = self.getProperty('NormToOne')
+        norm_to_one = self.getProperty('NormToOne').value
         cut = compute_cut(workspace, cut_axis, int_axis, e_mode, PSD, norm_to_one)
         self.setProperty('OutputWorkspace', cut)
 

--- a/mslice/models/cut/cut_normalisation.py
+++ b/mslice/models/cut/cut_normalisation.py
@@ -5,7 +5,7 @@ def _normalize_workspace(workspace):
     assert isinstance(workspace, IMDHistoWorkspace)
     num_events = workspace.getNumEventsArray()
     average_event_intensity = _num_events_normalized_array(workspace)
-    average_event_max = average_event_intensity.max()
+    average_event_max = np.abs(average_event_intensity).max()
 
     normed_average_event_intensity = average_event_intensity / average_event_max
     if workspace.displayNormalization() == MDNormalization.NoNormalization:
@@ -14,7 +14,6 @@ def _normalize_workspace(workspace):
         new_data = normed_average_event_intensity * num_events
     new_data = np.array(new_data)
 
-    new_data = np.nan_to_num(new_data)
     workspace.setSignalArray(new_data)
 
     errors = workspace.getErrorSquaredArray() / (average_event_max**2)
@@ -29,5 +28,5 @@ def _num_events_normalized_array(workspace):
             data[np.where(workspace.getNumEventsArray() == 0)] = np.nan
         else:
             data = workspace.getSignalArray() / workspace.getNumEventsArray()
-    data = np.ma.masked_where(np.isnan(data) + (data < 0), data)
+    data = np.ma.masked_where(np.isnan(data), data)
     return data

--- a/mslice/models/cut/cut_normalisation.py
+++ b/mslice/models/cut/cut_normalisation.py
@@ -5,9 +5,9 @@ def _normalize_workspace(workspace):
     assert isinstance(workspace, IMDHistoWorkspace)
     num_events = workspace.getNumEventsArray()
     average_event_intensity = _num_events_normalized_array(workspace)
-    average_event_range = average_event_intensity.max() - average_event_intensity.min()
+    average_event_max = average_event_intensity.max()
 
-    normed_average_event_intensity = (average_event_intensity - average_event_intensity.min())/average_event_range
+    normed_average_event_intensity = average_event_intensity / average_event_max
     if workspace.displayNormalization() == MDNormalization.NoNormalization:
         new_data = normed_average_event_intensity
     else:
@@ -17,7 +17,7 @@ def _normalize_workspace(workspace):
     new_data = np.nan_to_num(new_data)
     workspace.setSignalArray(new_data)
 
-    errors = workspace.getErrorSquaredArray() / (average_event_range**2)
+    errors = workspace.getErrorSquaredArray() / (average_event_max**2)
     workspace.setErrorSquaredArray(errors)
     workspace.setComment("Normalized By MSlice")
 
@@ -29,5 +29,5 @@ def _num_events_normalized_array(workspace):
             data[np.where(workspace.getNumEventsArray() == 0)] = np.nan
         else:
             data = workspace.getSignalArray() / workspace.getNumEventsArray()
-    data = np.ma.masked_where(np.isnan(data) & (data > 0), data)
+    data = np.ma.masked_where(np.isnan(data) + (data < 0), data)
     return data

--- a/mslice/models/cut/cut_normalisation.py
+++ b/mslice/models/cut/cut_normalisation.py
@@ -29,5 +29,5 @@ def _num_events_normalized_array(workspace):
             data[np.where(workspace.getNumEventsArray() == 0)] = np.nan
         else:
             data = workspace.getSignalArray() / workspace.getNumEventsArray()
-    data = np.ma.masked_where(np.isnan(data), data)
+    data = np.ma.masked_where(np.isnan(data) & (data > 0), data)
     return data

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -255,8 +255,7 @@ def compute_dvalues(d_min, d_max, structure):
     return dvalues
 
 def _norm_to_one(data):
-    data_range = np.nanmax(data) - np.nanmin(data)
-    return (data - np.nanmin(data))/data_range
+    return data / np.nanmax(data[np.where(data >= 0)])
 
 def is_sliceable(workspace):
     ws = get_workspace_handle(workspace)

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -255,7 +255,7 @@ def compute_dvalues(d_min, d_max, structure):
     return dvalues
 
 def _norm_to_one(data):
-    return data / np.nanmax(data[np.where(data >= 0)])
+    return data / np.nanmax(np.abs(data))
 
 def is_sliceable(workspace):
     ws = get_workspace_handle(workspace)

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -313,7 +313,7 @@ class CutPlot(object):
 
     @property
     def title(self):
-        return self.plot_window.title
+        return self.manager.title
 
     @title.setter
     def title(self, value):


### PR DESCRIPTION
Changes the behaviour of the `Norm to 1` option to using the (absolute) maximum value of the data rather than the range of the data as the normalisation factor.

The previous behaviour caused an implicit shift of the data, especially if there are negative values in the data.

Also fixes an issue where `Norm to 1` was applied to all cuts regardless of whether the option was checked or not.

**To test:**

Load any test dataset and make a cut. Check that when the `Norm to 1` option is checked the maximum value in the plot is `1` and if it is not checked that the cut for different values of the step size lie on top of each other (e.g. that the step size will not scale the data), and the value is different from `1`.

Also load this example file: [MAR18120_Ei39.53meV.nxspe.zip](https://github.com/mantidproject/mslice/files/2196183/MAR18120_Ei39.53meV.nxspe.zip) and make a cut along `DeltaE` from -10 to 40 in any steps (default of 0.2meV is fine), integrating from 0 to 10 in `|Q|`. With `Norm to 1` unset, check that around 40meV there is a significant negative signal (around -40). This is due to a background subtraction in the data reduction process and is not a bug. 

Now check `Norm to 1` and replot. Confirm that the maximum intensity around 0meV is `1` and the intensity around 40meV is around -0.5

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #334.
