### PR TITLE
Export cut to MantidPlot ADS

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -20,9 +20,9 @@ def show_gui():
     If this is the first call then an instance of the Windows is cached to ensure it
     survives for the duration of the application
     """
-    initialize_mantid()
+    in_mantidplot = initialize_mantid()
     global MAIN_WINDOW
     if MAIN_WINDOW is None:
         from mslice.app.mainwindow import MainWindow
-        MAIN_WINDOW = MainWindow()
+        MAIN_WINDOW = MainWindow(in_mantidplot)
     MAIN_WINDOW.show()

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -20,7 +20,7 @@ TAB_POWDER = 0
 
 class MainWindow(MainView, QMainWindow):
 
-    def __init__(self):
+    def __init__(self, in_mantidplot=False):
         QMainWindow.__init__(self)
         load_ui(__file__, 'mainwindow.ui', self)
         self.init_ui()
@@ -35,6 +35,8 @@ class MainWindow(MainView, QMainWindow):
                                   TAB_EVENT: [self.btnMerge],
                                   TAB_HISTO: [self.btnPlot, self.btnOverplot],
                                   TAB_NONPSD: [self.btnAdd, self.btnSubtract]}
+        if in_mantidplot:
+            self.buttons_to_enable[TAB_HISTO] += [self.btnSaveToADS]
 
         self.workspace_presenter = self.wgtWorkspacemanager.get_presenter()
         dataloader_presenter = self.data_loading.get_presenter()
@@ -54,6 +56,7 @@ class MainWindow(MainView, QMainWindow):
         self.btnMerge.clicked.connect(self.button_merge)
         self.btnPlot.clicked.connect(self.button_plot)
         self.btnOverplot.clicked.connect(self.button_overplot)
+        self.btnSaveToADS.clicked.connect(self.button_savetoads)
         self.btnHistory.hide()
         self.ws_tab_changed(0)
 
@@ -98,7 +101,7 @@ class MainWindow(MainView, QMainWindow):
 
     def enable_buttons(self, tab):
         '''enables correct buttons based on workspace tab'''
-        variable_buttons = [self.btnAdd, self.btnSubtract, self.btnMerge, self.btnPlot, self.btnOverplot]
+        variable_buttons = [self.btnAdd, self.btnSubtract, self.btnMerge, self.btnPlot, self.btnOverplot, self.btnSaveToADS]
         for button in variable_buttons:
             button.hide()
         for button in self.buttons_to_enable[tab]:
@@ -127,6 +130,9 @@ class MainWindow(MainView, QMainWindow):
 
     def button_overplot(self):
         self.cut_presenter.notify(cut_command.PlotOverFromWorkspace)
+
+    def button_savetoads(self):
+        self.workspace_presenter.notify(ws_command.SaveToADS)
 
     def init_ui(self):
         self.busy_text = QLabel()

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -108,8 +108,13 @@
                    <height>16777215</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <pointsize>9</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
-                  <string>Save to ADS</string>
+                  <string>Save to MantidPlot</string>
                  </property>
                 </widget>
                </item>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -98,7 +98,7 @@
                 </spacer>
                </item>
                <item row="6" column="1">
-                <widget class="QPushButton" name="btnHistory">
+                <widget class="QPushButton" name="btnSaveToADS">
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
@@ -109,7 +109,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>History</string>
+                  <string>Save to ADS</string>
                  </property>
                 </widget>
                </item>
@@ -216,6 +216,13 @@
                   </size>
                  </property>
                 </spacer>
+               </item>
+               <item row="7" column="1">
+                <widget class="QPushButton" name="btnHistory">
+                 <property name="text">
+                  <string>History</string>
+                 </property>
+                </widget>
                </item>
               </layout>
              </widget>

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -29,7 +29,7 @@ class Cut(PythonAlgorithm):
         int_axis = Axis(int_dict['units'].value, int_dict['start'].value, int_dict['end'].value, int_dict['step'].value)
         e_mode = self.getProperty('EMode').value
         PSD = self.getProperty('PSD').value
-        norm_to_one = self.getProperty('NormToOne')
+        norm_to_one = self.getProperty('NormToOne').value
         cut = compute_cut(workspace, cut_axis, int_axis, e_mode, PSD, norm_to_one)
         self.setProperty('OutputWorkspace', cut)
 

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -5,7 +5,7 @@ from .busy import show_busy
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.models.workspacemanager.file_io import get_save_directory
-from mslice.models.workspacemanager.workspace_algorithms import (save_workspaces,
+from mslice.models.workspacemanager.workspace_algorithms import (save_workspaces, export_workspace_to_ads,
                                                                  rename_workspace, subtract,
                                                                  is_pixel_workspace, combine_workspace,
                                                                  add_workspace_runs)
@@ -50,6 +50,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 self._add_workspaces()
             elif command  == Command.Subtract:
                 self._subtract_workspace()
+            elif command == Command.SaveToADS:
+                self._save_to_ads()
             else:
                 raise ValueError("Workspace Manager Presenter received an unrecognised command: {}".format(str(command)))
 
@@ -105,6 +107,14 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             save_workspaces(selected_workspaces, save_directory, save_name, extension)
         except RuntimeError:
             self._workspace_manager_view.error_unable_to_save()
+
+    def _save_to_ads(self):
+        selected_workspaces = self._workspace_manager_view.get_workspace_selected()
+        if not selected_workspaces:
+            self._workspace_manager_view.error_select_one_or_more_workspaces()
+            return
+        for workspace in selected_workspaces:
+            export_workspace_to_ads(workspace)
 
     def _remove_selected_workspaces(self):
         selected_workspaces = self._workspace_manager_view.get_workspace_selected()

--- a/mslice/util/mantid.py
+++ b/mslice/util/mantid.py
@@ -18,7 +18,7 @@ def initialize_mantid():
     s_api._create_algorithm_function('Slice', 1, Slice())
     s_api._create_algorithm_function('Cut', 1, Cut())
     try:
-        import mantidplot
+        import mantidplot # noqa: F401
     except ImportError:
         return(False)
     else:

--- a/mslice/util/mantid.py
+++ b/mslice/util/mantid.py
@@ -16,7 +16,13 @@ def initialize_mantid():
     AlgorithmFactory.subscribe(Cut)
     s_api._create_algorithm_function('MakeProjection', 1, MakeProjection())
     s_api._create_algorithm_function('Slice', 1, Slice())
-s_api._create_algorithm_function('Cut', 1, Cut())
+    s_api._create_algorithm_function('Cut', 1, Cut())
+    try:
+        import mantidplot
+    except ImportError:
+        return(False)
+    else:
+        return(True)
 
 
 def run_algorithm(alg_name, output_name=None, store=True, **kwargs):
@@ -33,8 +39,17 @@ def run_algorithm(alg_name, output_name=None, store=True, **kwargs):
     return ws
 
 
-@contextmanager
 def add_to_ads(workspaces):
+    try:
+        workspaces = iter(workspaces)
+    except TypeError:
+        workspaces = [workspaces]
+    for workspace in workspaces:
+        AnalysisDataService.Instance().addOrReplace(workspace.name, workspace.raw_ws)
+
+
+@contextmanager
+def wrap_in_ads(workspaces):
     '''Need to wrap some algorithm calls because they don't like input workspaces that aren't in the ADS...'''
     for workspace in workspaces:
         AnalysisDataService.Instance().addOrReplace(workspace.name, workspace.raw_ws)

--- a/mslice/widgets/workspacemanager/command.py
+++ b/mslice/widgets/workspacemanager/command.py
@@ -18,6 +18,7 @@ class Command(object):
     Add = 6
     SaveSelectedWorkspaceAscii = 7
     SaveSelectedWorkspaceMatlab = 8
+    SaveToADS = 9
     RenameWorkspace = 1000
     CombineWorkspace = 1010
     SelectionChanged = -1799

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -2,8 +2,10 @@ from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .histo_mixin import HistoMixin
 from .workspace_mixin import WorkspaceMixin
+from .workspace import Workspace
 
 from mantid.api import IMDHistoWorkspace
+from mantid.simpleapi import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
 
 
 class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
@@ -19,3 +21,12 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
 
     def rewrap(self, ws):
         return HistogramWorkspace(ws, self.name)
+
+    def convert_to_matrix(self):
+        ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization', 
+                                                  FindXAxis=False, StoreInADS=False, OutputWorkspace=self.name)
+        coord = self.get_coordinates()
+        bin_size = coord[coord.keys()[0]][1] - coord[coord.keys()[0]][0]
+        ws_conv = Scale(ws_conv, bin_size, OutputWorkspace=self.name, StoreInADS=False)
+        ConvertToDistribution(ws_conv, StoreInADS=False)
+        return Workspace(ws_conv, self.name)

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -23,7 +23,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         return HistogramWorkspace(ws, self.name)
 
     def convert_to_matrix(self):
-        ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization', 
+        ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization',
                                                   FindXAxis=False, StoreInADS=False, OutputWorkspace=self.name)
         coord = self.get_coordinates()
         bin_size = coord[coord.keys()[0]][1] - coord[coord.keys()[0]][0]


### PR DESCRIPTION
Adds the ability to export a saved cut to the MantidPlot ADS, since now we do not store MSlice workspaces in the ADS, so they are not visible from MantidPlot.

**To test:**

Run MSlice within MantidPlot, and check that in the `MD Histo` tab there is a `Save to ADS` button (when running MSlice outside MantidPlot, this button should be hidden).

Load a dataset and make a cut. Then in the `MD Histo` tab click `Save to ADS`. Check that a `MatrixWorkspace` appears in the list of workspaces in MantidPlot. Plot this workspace and check that the values agree with that plotted in MSlice.

Check that the fitting interface works on this workspace.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #341 
