### PR TITLE
E_fixed propagation

### DIFF
--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -345,6 +345,7 @@ def propagate_properties(old_workspace, new_workspace):
     new_workspace.e_mode = old_workspace.e_mode
     new_workspace.limits = old_workspace.limits
     new_workspace.is_PSD = old_workspace.is_PSD
+    new_workspace.e_fixed = old_workspace.e_fixed
 
 
 def get_comment(workspace):


### PR DESCRIPTION
Fixes a bug where the value of `e_fixed` was not propagated to child workspaces after e.g. calculating projections. This causes the calculation of the powder lines to fail.

**To test:**

Load a PSD dataset (e.g. https://github.com/mantidproject/mslice/files/2201161/test_mslice_HYS.zip or MER30936_Ei10.00meV_one2one.nxs 

Calculate projection and plot the slice. Then plot a powder line from `Information`->`Bragg Peaks`. 

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #347 
