### PR TITLE
CLI - Fix workspace type error in MakeProjection

### DIFF
--- a/mslice/models/cut/cut_functions.py
+++ b/mslice/models/cut/cut_functions.py
@@ -20,8 +20,8 @@ def compute_cut_xye(selected_workspace, cut_axis, integration_axis, is_norm, sto
     out_ws_name = output_workspace_name(selected_workspace, integration_axis.start, integration_axis.end)
 
     cut = mantid_algorithms.Cut(OutputWorkspace=out_ws_name, store=store, InputWorkspace=ws_handle,
-                        CutAxis=cut_axis.to_dict(), IntegrationAxis=integration_axis.to_dict(),
-                        EMode = ws_handle.e_mode, PSD=ws_handle.is_PSD, NormToOne=is_norm)
+                                CutAxis=cut_axis.to_dict(), IntegrationAxis=integration_axis.to_dict(),
+                                EMode = ws_handle.e_mode, PSD=ws_handle.is_PSD, NormToOne=is_norm)
     if store:
         cut = cut.raw_ws
     plot_data = _num_events_normalized_array(cut)

--- a/mslice/models/projection/powder/make_projection.py
+++ b/mslice/models/projection/powder/make_projection.py
@@ -69,16 +69,16 @@ class MakeProjection(PythonAlgorithm):
         numSpectra = input_workspace.getNumberHistograms()
         if emode == 'Indirect' or numSpectra > 1000:
             retval = ConvertToMD(InputWorkspace=input_workspace, QDimensions=MOD_Q_LABEL,
-                                 PreprocDetectorsWS='-', dEAnalysisMode=emode)
+                                 PreprocDetectorsWS='-', dEAnalysisMode=emode, StoreInADS=False)
             if axis1 == DELTA_E_LABEL and axis2 == MOD_Q_LABEL:
                 retval = self._flip_axes(retval)
         # Otherwise first run SofQW3 to rebin it in |Q| properly before calling ConvertToMD with CopyToMD
         else:
             limits = self.getProperty('Limits').value
             limits = ','.join([str(limits[i]) for i in [0, 2, 1]])
-            retval = SofQW3(InputWorkspace=input_workspace,
-                            QAxisBinning=limits, Emode=emode)
-            retval = ConvertToMD(InputWorkspace=retval, QDimensions='CopyToMD', PreprocDetectorsWS='-', dEAnalysisMode=emode)
+            retval = SofQW3(InputWorkspace=input_workspace, QAxisBinning=limits, Emode=emode, StoreInADS=False)
+            retval = ConvertToMD(InputWorkspace=retval, QDimensions='CopyToMD', PreprocDetectorsWS='-',
+                                 dEAnalysisMode=emode, StoreInADS=False)
             if axis1 == MOD_Q_LABEL:
                 retval = self._flip_axes(retval)
         return retval
@@ -89,7 +89,7 @@ class MakeProjection(PythonAlgorithm):
         # Work-around for a bug in ConvertToMD.
         wsdet = self._getDetWS(input_workspace) if emode == 'Indirect' else '-'
         retval = ConvertToMD(InputWorkspace=retval, QDimensions='CopyToMD', PreprocDetectorsWS=wsdet,
-                             dEAnalysisMode=emode)
+                             dEAnalysisMode=emode, StoreInADS=False)
         if emode == 'Indirect':
             DeleteWorkspace(wsdet)
         if axis1 == THETA_LABEL:

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -25,9 +25,9 @@ class MantidProjectionCalculator(ProjectionCalculator):
             raise TypeError('Input workspace for projection calculation must be a reduced '
                             'data workspace with a spectra and energy transfer axis.')
 
-    def calculate_projection(self, input_workspace_name, axis1, axis2, units):
+    def calculate_projection(self, input_workspace, axis1, axis2, units):
         """Calculate the projection workspace AND return a python handle to it"""
-        workspace = get_workspace_handle(input_workspace_name)
+        workspace = get_workspace_handle(input_workspace)
         if not workspace.is_PSD:
             raise RuntimeError('Cannot calculate projections for non-PSD workspaces')
 
@@ -36,10 +36,10 @@ class MantidProjectionCalculator(ProjectionCalculator):
             raise NotImplementedError("Must have a '%s' axis" % DELTA_E_LABEL)
         if (axis1 == MOD_Q_LABEL or axis2 == MOD_Q_LABEL):
             projection_type='QE'
-            output_workspace_name = input_workspace_name + ('_QE' if axis1 == MOD_Q_LABEL else '_EQ')
+            output_workspace_name = workspace.name + ('_QE' if axis1 == MOD_Q_LABEL else '_EQ')
         elif (axis1 == THETA_LABEL or axis2 == THETA_LABEL):
             projection_type='Theta'
-            output_workspace_name = input_workspace_name + ('_ThE' if axis1 == THETA_LABEL else '_ETh')
+            output_workspace_name = workspace.name + ('_ThE' if axis1 == THETA_LABEL else '_ETh')
         else:
             raise NotImplementedError(" Axis '%s' not recognised. Must be '|Q|' or '2Theta'." % (axis1 if
                                       axis1 != DELTA_E_LABEL else axis2))

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -9,7 +9,7 @@ from scipy import constants
 from mslice.models.alg_workspace_ops import get_number_of_steps
 from mslice.models.workspacemanager.workspace_algorithms import propagate_properties
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
-from mslice.util.mantid import mantid_algorithms
+from mslice.util.mantid.mantid_algorithms import Slice, LoadCIF
 
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.workspace import Workspace
@@ -25,7 +25,7 @@ crystal_structure = {'Copper': ['3.6149 3.6149 3.6149', 'F m -3 m', 'Cu 0 0 0 1.
 
 def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one):
     workspace = get_workspace_handle(selected_workspace)
-    slice =  mantid_algorithms.Slice(OutputWorkspace = '__' + workspace.name, InputWorkspace=workspace,
+    slice =  Slice(OutputWorkspace = '__' + workspace.name, InputWorkspace=workspace,
                                      XAxis=x_axis.to_dict(), YAxis=y_axis.to_dict(), PSD=workspace.is_PSD,
                                      EMode=workspace.e_mode, NormToOne=norm_to_one)
     plot_data = plot_data_from_slice(workspace, slice, x_axis, workspace.is_PSD)

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -233,7 +233,7 @@ def _compute_powder_line_momentum(ws_name, q_axis, element, cif_file):
 def _crystal_structure(ws_name, element, cif_file):
     if cif_file:
         ws = get_workspace_handle(ws_name).raw_ws
-        run_algorithm('LoadCIF', store=False, InputWorkspace=ws, InputFile=cif_file)
+        LoadCIF(InputWorkspace=ws, InputFile=cif_file)
         return ws.sample().getCrystalStructure()
     else:
         return CrystalStructure(crystal_structure[element][0], crystal_structure[element][1],

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -9,7 +9,8 @@ from scipy import constants
 from mslice.models.alg_workspace_ops import get_number_of_steps
 from mslice.models.workspacemanager.workspace_algorithms import propagate_properties
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
-from mslice.util.mantid.mantid_algorithms import Slice, LoadCIF
+from mslice.util.mantid.mantid_algorithms import LoadCIF
+from mslice.util.mantid import mantid_algorithms
 
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.workspace import Workspace
@@ -25,7 +26,7 @@ crystal_structure = {'Copper': ['3.6149 3.6149 3.6149', 'F m -3 m', 'Cu 0 0 0 1.
 
 def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one):
     workspace = get_workspace_handle(selected_workspace)
-    slice =  Slice(OutputWorkspace = '__' + workspace.name, InputWorkspace=workspace,
+    slice =  mantid_algorithms.Slice(OutputWorkspace = '__' + workspace.name, InputWorkspace=workspace,
                                      XAxis=x_axis.to_dict(), YAxis=y_axis.to_dict(), PSD=workspace.is_PSD,
                                      EMode=workspace.e_mode, NormToOne=norm_to_one)
     plot_data = plot_data_from_slice(workspace, slice, x_axis, workspace.is_PSD)

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -13,7 +13,7 @@ from scipy import constants
 
 from mslice.models.axis import Axis
 
-from mslice.util.mantid.algorithm_wrapper import wrap_in_ads
+from mslice.util.mantid.algorithm_wrapper import add_to_ads, wrap_in_ads
 from mslice.models.workspacemanager.workspace_provider import (get_workspace_handle, get_workspace_name,
                                                                remove_workspace, add_workspace)
 from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -43,7 +43,7 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
 
     def _display_slice(self):
         try:
-            selected_workspace = validate(self._selected_workspace, self._slice_view.error_select_one_workspace)
+            selected_workspaces = validate(self._selected_workspace, self._slice_view.error_select_one_workspace)
             x_axis = validate(self._x_axis, self._slice_view.error_invalid_x_params)
             y_axis = validate(self._y_axis, self._slice_view.error_invalid_y_params)
             intensity_start, intensity_end = validate(self._intensity, self._slice_view.error_invalid_intensity_params)

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -43,7 +43,7 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
 
     def _display_slice(self):
         try:
-            selected_workspaces = validate(self._selected_workspace, self._slice_view.error_select_one_workspace)
+            selected_workspace = validate(self._selected_workspace, self._slice_view.error_select_one_workspace)
             x_axis = validate(self._x_axis, self._slice_view.error_invalid_x_params)
             y_axis = validate(self._y_axis, self._slice_view.error_invalid_y_params)
             intensity_start, intensity_end = validate(self._intensity, self._slice_view.error_invalid_intensity_params)
@@ -51,9 +51,8 @@ class SlicePlotterPresenter(PresenterUtility, SlicePlotterPresenterInterface):
         except ValueError:
             return
 
-        selected_workspace = selected_workspaces[0]
-        axes = self.validate_axes()
-        if (not axes):
+        if x_axis.units == y_axis.units:
+            self._slice_view.error_invalid_plot_parameters()
             return
 
         norm_to_one = bool(self._slice_view.get_slice_is_norm_to_one())

--- a/mslice/tests/slice_functions_test.py
+++ b/mslice/tests/slice_functions_test.py
@@ -13,7 +13,6 @@ from mslice.models.slice.slice_functions import (compute_slice, compute_boltzman
                                                  compute_chi_magnetic, compute_d2sigma, compute_symmetrised,
                                                  compute_gdos, compute_powder_line, compute_recoil_line)
 from mslice.util.mantid.algorithm_wrapper import wrap_algorithm
-from mslice.util.mantid.init_mantid import initialize_mantid
 from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace
 
 def invert_axes(matrix):

--- a/mslice/tests/slice_functions_test.py
+++ b/mslice/tests/slice_functions_test.py
@@ -13,7 +13,7 @@ from mslice.models.slice.slice_functions import (compute_slice, compute_boltzman
                                                  compute_chi_magnetic, compute_d2sigma, compute_symmetrised,
                                                  compute_gdos, compute_powder_line, compute_recoil_line)
 from mslice.util.mantid.algorithm_wrapper import wrap_algorithm
-from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace, LoadCIF
+from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace
 
 def invert_axes(matrix):
     return np.rot90(np.flipud(matrix))

--- a/mslice/tests/slice_functions_test.py
+++ b/mslice/tests/slice_functions_test.py
@@ -13,7 +13,7 @@ from mslice.models.slice.slice_functions import (compute_slice, compute_boltzman
                                                  compute_chi_magnetic, compute_d2sigma, compute_symmetrised,
                                                  compute_gdos, compute_powder_line, compute_recoil_line)
 from mslice.util.mantid.algorithm_wrapper import wrap_algorithm
-from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace
+from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace, LoadCIF
 
 def invert_axes(matrix):
     return np.rot90(np.flipud(matrix))


### PR DESCRIPTION
The workspace passed into calculateProjection was being treated as a
workspace name when it might also be a workspace object. It now supports either.

Also fixes a problem when plotting multiple PSD workspaces #356 

**To test:**
```
ws = Load("...")
MakeProjection(ws, Axis1='|Q|', Axis2='DeltaE')
```

Fixes #353
Fixes #356