### PR TITLE
Fix deletion of renamed workspaces

### DIFF
--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -14,7 +14,7 @@ from scipy import constants
 from mslice.models.axis import Axis
 from mslice.util.mantid import add_to_ads, wrap_in_ads, run_algorithm
 from mslice.models.workspacemanager.workspace_provider import (get_workspace_handle, get_workspace_name,
-                                                               remove_workspace, add_workspace)
+                                                               remove_workspace, rename_workspace, add_workspace)
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
@@ -158,13 +158,6 @@ def load(filename, output_workspace):
     if workspace.e_mode == 'Indirect':
         processEfixed(workspace)
     _processLoadedWSLimits(workspace)
-    return workspace
-
-
-def rename_workspace(selected_workspace, new_name):
-    workspace = get_workspace_handle(selected_workspace)
-    remove_workspace(workspace)
-    add_workspace(workspace, new_name)
     return workspace
 
 

--- a/mslice/models/workspacemanager/workspace_provider.py
+++ b/mslice/models/workspacemanager/workspace_provider.py
@@ -17,10 +17,18 @@ def add_workspace(workspace, name):
 
 
 def remove_workspace(workspace):
-    del _loaded_workspaces[get_workspace_name(workspace)]
+    workspace = get_workspace_handle(workspace)
+    del _loaded_workspaces[workspace.name]
 
 
-def get_workspace_names():
+def rename_workspace(workspace, new_name):
+    workspace = get_workspace_handle(workspace)
+    _loaded_workspaces[new_name] = _loaded_workspaces.pop(workspace.name)
+    workspace.name = new_name
+    return workspace
+
+
+def get_visible_workspace_names():
     return [key for key in iterkeys(_loaded_workspaces) if key[:2] != '__']
 
 

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -4,7 +4,7 @@ import os
 
 from .busy import show_busy
 from mslice.models.workspacemanager.workspace_algorithms import load
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_names
+from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_visible_workspace_names
 from mslice.presenters.interfaces.data_loader_presenter import DataLoaderPresenterInterface
 from mslice.presenters.presenter_utility import PresenterUtility
 from mslice.models.workspacemanager.file_io import load_from_ascii
@@ -75,7 +75,7 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
             return allChecked
 
     def _confirm_workspace_overwrite(self, ws_name):
-        if ws_name in get_workspace_names():
+        if ws_name in get_visible_workspace_names():
             return self._view.confirm_overwrite_workspace()
         else:
             return True

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -9,8 +9,8 @@ from mslice.models.workspacemanager.workspace_algorithms import (save_workspaces
                                                                  rename_workspace, subtract,
                                                                  is_pixel_workspace, combine_workspace,
                                                                  add_workspace_runs)
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_names, \
-    get_workspace_name, delete_workspace
+from mslice.models.workspacemanager.workspace_provider import (get_workspace_handle, get_visible_workspace_names,
+                                                               get_workspace_name, delete_workspace, rename_workspace)
 from .interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
 from .interfaces.main_presenter import MainPresenterInterface
 from .validation_decorators import require_main_presenter
@@ -80,7 +80,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 self._psd = False
 
     def _confirm_workspace_overwrite(self, ws_name):
-        if ws_name in get_workspace_names():
+        if ws_name in get_visible_workspace_names():
             return self._workspace_manager_view.confirm_overwrite_workspace()
         else:
             return True
@@ -204,7 +204,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         This function must be called by the main presenter if any other
         presenter does any operation that changes the name or type of any existing workspace or creates or removes a
         workspace"""
-        self._workspace_manager_view.display_loaded_workspaces(get_workspace_names())
+        self._workspace_manager_view.display_loaded_workspaces(get_visible_workspace_names())
 
     def _clear_displayed_error(self):
         self._workspace_manager_view.clear_displayed_error()

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -6,7 +6,7 @@ from mslice.models.workspacemanager.workspace_algorithms import (subtract,
                                                                  add_workspace_runs,
                                                                  combine_workspace, rename_workspace,
                                                                  propagate_properties, get_limits, run_algorithm)
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_names, \
+from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_visible_workspace_names, \
     delete_workspace
 from mslice.models.workspacemanager.workspace_algorithms import processEfixed
 
@@ -28,14 +28,14 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def test_delete_workspace(self):
         delete_workspace('test_ws_md')
-        self.assertFalse('test_ws_md' in get_workspace_names())
+        self.assertFalse('test_ws_md' in get_visible_workspace_names())
 
     def test_subtract_workspace(self):
         subtract(['test_ws_2d'], 'test_ws_2d', 0.95)
         result = get_workspace_handle('test_ws_2d_subtracted')
         np.testing.assert_array_almost_equal(result.raw_ws.dataY(0), [0.05] * 20)
         np.testing.assert_array_almost_equal(self.test_ws_2d.raw_ws.dataY(0), [1] * 20)
-        self.assertFalse('scaled_bg_ws' in get_workspace_names())
+        self.assertFalse('scaled_bg_ws' in get_visible_workspace_names())
 
     def test_add_workspace(self):
         add_workspace_runs(['test_ws_2d', 'test_ws_2d'])
@@ -59,8 +59,8 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def test_rename_workspace(self):
         rename_workspace('test_ws_md', 'newname')
-        self.assertTrue('newname' in get_workspace_names())
-        self.assertFalse('test_ws_md' in get_workspace_names())
+        self.assertTrue('newname' in get_visible_workspace_names())
+        self.assertFalse('test_ws_md' in get_visible_workspace_names())
         new_ws = get_workspace_handle('newname')
         self.assertFalse(new_ws.ef_defined)
         self.assertEqual(new_ws.limits['DeltaE'], [0, 2, 1])


### PR DESCRIPTION
Workspaces could not be deleted after they were renamed because
the workspace.name property was not updated correctly.

Also moved method that handles renaming to _workspace_provider
(from workspace_algorithms) to simplify calls.

**To test:**
- Load workspace
- Rename workspace
- Delete workspace

Fixes #343
