### PR TITLE
added functionality to close interactive cuts

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -49,7 +49,9 @@ class CutPlot(IPlot):
 
     def window_closing(self):
         self._canvas.figure.clf()
-        self._cut_plotter.get_icut().slice_plot.icut_window_closing()
+        icut = self._cut_plotter.get_icut()
+        if icut is not None:
+            icut.window_closing()
 
     def plot_options(self):
         new_config = CutPlotOptionsPresenter(CutPlotOptions(), self).get_new_config()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -49,6 +49,7 @@ class CutPlot(IPlot):
 
     def window_closing(self):
         self._canvas.figure.clf()
+        self._cut_plotter.get_icut().slice_plot.icut_window_closing()
 
     def plot_options(self):
         new_config = CutPlotOptionsPresenter(CutPlotOptions(), self).get_new_config()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -19,7 +19,7 @@ class InteractiveCut(object):
         self._rect_pos_cache = [0, 0, 0, 0, 0, 0]
         self.rect = RectangleSelector(self._canvas.figure.gca(), self.plot_from_mouse_event,
                                       drawtype='box', useblit=True,
-                                      button=[1,3], spancoords='pixels', interactive=True)
+                                      button=[1, 3], spancoords='pixels', interactive=True)
         self._canvas.draw()
 
     def plot_from_mouse_event(self, eclick, erelease):
@@ -82,3 +82,9 @@ class InteractiveCut(object):
     def flip_axis(self):
         self.horizontal = not self.horizontal
         self.plot_cut(*self.rect.extents)
+
+    # def window_closing(self):
+    #     self.clear()
+    #     slice_plot = self._cut_plotter.get_icut().slice_plot
+    #     slice_plot.icut_window_closing()
+

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -82,3 +82,7 @@ class InteractiveCut(object):
     def flip_axis(self):
         self.horizontal = not self.horizontal
         self.plot_cut(*self.rect.extents)
+
+    def window_closing(self):
+        self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
+        self.slice_plot.toggle_icut()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -82,9 +82,3 @@ class InteractiveCut(object):
     def flip_axis(self):
         self.horizontal = not self.horizontal
         self.plot_cut(*self.rect.extents)
-
-    # def window_closing(self):
-    #     self.clear()
-    #     slice_plot = self._cut_plotter.get_icut().slice_plot
-    #     slice_plot.icut_window_closing()
-

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -106,6 +106,7 @@ class PlotWindow(QtWidgets.QMainWindow):
                                           icon_name='fa.search-minus', checkable=False)
         self.action_toggle_legends = add_action(toolbar, self, "Legends", checkable=True,
                                                 checked=True)
+        toolbar.addSeparator()
         self.action_keep = add_action(toolbar, self,  "Keep", checkable=True)
         self.action_make_current = add_action(toolbar, self,  "Make Current",
                                               checkable=True, checked=True)

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -106,7 +106,6 @@ class PlotWindow(QtWidgets.QMainWindow):
                                           icon_name='fa.search-minus', checkable=False)
         self.action_toggle_legends = add_action(toolbar, self, "Legends", checkable=True,
                                                 checked=True)
-        toolbar.addSeparator()
         self.action_keep = add_action(toolbar, self,  "Keep", checkable=True)
         self.action_make_current = add_action(toolbar, self,  "Make Current",
                                               checkable=True, checked=True)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -376,9 +376,8 @@ class SlicePlot(IPlot):
         self._slice_plotter.update_displayed_workspaces()
 
     def icut_window_closing(self):
-        self.plot_window.action_interactive_cuts.toggle()
-        self.icut.clear()
-        self.icut = None
+        self.plot_window.action_interactive_cuts.setChecked(False)
+        self.toggle_icut()
 
     @property
     def colorbar_label(self):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -1,7 +1,6 @@
 from functools import partial
 import six
 
-from mslice.util.qt import QtWidgets
 from mslice.util.qt.QtCore import Qt
 
 import os.path as path
@@ -375,6 +374,10 @@ class SlicePlot(IPlot):
     def update_workspaces(self):
         self._slice_plotter.update_displayed_workspaces()
 
+    def icut_window_closing(self):
+        self.plot_window.action_interactive_cuts.toggle()
+        self.icut.clear()
+        self.icut = None
 
     @property
     def colorbar_label(self):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -1,6 +1,7 @@
 from functools import partial
 import six
 
+from mslice.util.qt import QtWidgets
 from mslice.util.qt.QtCore import Qt
 
 import os.path as path

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -375,10 +375,6 @@ class SlicePlot(IPlot):
     def update_workspaces(self):
         self._slice_plotter.update_displayed_workspaces()
 
-    def icut_window_closing(self):
-        self.plot_window.action_interactive_cuts.setChecked(False)
-        self.toggle_icut()
-
     @property
     def colorbar_label(self):
         return self._canvas.figure.get_axes()[1].get_ylabel()


### PR DESCRIPTION
Description of work.
Added functionality to deselect `interactive_cuts` when `cut_plot` window is closed.

**To test:**

<!-- Instructions for testing. -->
Open up mslice
Load data then display it
Click interactive cuts and select a rectangle on the plot
When the cut window opens, close it
Observe that the `interactive_cuts` button in now deselected

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #364 