### PR TITLE
Hide error bars in cuts correctly

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -87,7 +87,7 @@ class CutPlot(IPlot):
                 if self.legend_visible(i):
                     labels_to_show.append(label)
                     handles_to_show.append(handle)
-                i+=1
+                i += 1
         else:
             containers = axes.containers
             for i in range(len(containers)):
@@ -181,13 +181,12 @@ class CutPlot(IPlot):
         icut = self._cut_plotter.get_icut()
         icut.flip_axis()
 
-
     def _get_line_index(self, line):
-        '''
+        """
         Checks if line index is cached, and if not finds the index by iterating over the axes' containers.
         :param line: Line to find the index of
         :return: Index of line
-        '''
+        """
         try:
             container = self._lines[line]
         except KeyError:
@@ -197,11 +196,11 @@ class CutPlot(IPlot):
         for c in self._canvas.figure.gca().containers:
             if container == c:
                 return i
-            i+=1
+            i += 1
 
     def calc_figure_boundaries(self):
         fig_x, fig_y = self._canvas.figure.get_size_inches() * self._canvas.figure.dpi
-        bounds = {}
+        bounds = dict()
         bounds['y_label'] = fig_x * 0.07
         bounds['y_range'] = fig_x * 0.12
         bounds['title'] = fig_y * 0.9
@@ -212,12 +211,11 @@ class CutPlot(IPlot):
     def xy_config(self):
         return {'x_log': self.x_log, 'y_log': self.y_log, 'x_range': self.x_range, 'y_range': self.y_range}
 
-
     def _has_errorbars(self):
-        """True current axes has visible errorbars,
-         False if current axes has hidden errorbars"""
+        """True if current axes has visible error bars,
+         False if current axes has hidden error bars"""
         current_axis = self._canvas.figure.gca()
-        # If all the error bars have alpha= 0 they are all transparent (hidden)
+        # If all the error bars have alpha = 0 they are all transparent (hidden)
         containers = [x for x in current_axis.containers if isinstance(x, ErrorbarContainer)]
         line_components = [x.get_children() for x in containers]
         # drop the first element of each container because it is the the actual line
@@ -233,16 +231,20 @@ class CutPlot(IPlot):
         return has_errorbars
 
     def _set_errorbars_shown_state(self, state):
-        """Show errrorbar if state = 1, hide if state = 0"""
+        """Show errror bar if state = 1, hide if state = 0"""
         current_axis = self._canvas.figure.gca()
         if state:
             alpha = 1
         else:
-            alpha = 0.
+            alpha = 0
         for i in range(len(current_axis.containers)):
             if isinstance(current_axis.containers[i], ErrorbarContainer):
                 elements = current_axis.containers[i].get_children()
                 if self.get_line_visible(i):
+                    # elements[0] is the actual line, the others are the bits of the error bar
+                    # [elements[i].set_alpha(alpha) for i in range(1, len(elements))]
+                    #elements[2].set_alpha(alpha)
+                    elements[3].set_alpha(alpha)
                     elements[1].set_alpha(alpha)  # elements[0] is the actual line, elements[1] is error bars
 
     def _toggle_errorbars(self):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -242,10 +242,8 @@ class CutPlot(IPlot):
                 elements = current_axis.containers[i].get_children()
                 if self.get_line_visible(i):
                     # elements[0] is the actual line, the others are the bits of the error bar
-                    # [elements[i].set_alpha(alpha) for i in range(1, len(elements))]
-                    #elements[2].set_alpha(alpha)
-                    elements[3].set_alpha(alpha)
-                    elements[1].set_alpha(alpha)  # elements[0] is the actual line, elements[1] is error bars
+                    for element in range(1, len(elements)):
+                        elements[element].set_alpha(alpha)
 
     def _toggle_errorbars(self):
         state = self._has_errorbars()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -166,7 +166,7 @@ class CutPlot(IPlot):
     def set_line_options_by_index(self, line_index, line_options):
         container = self._canvas.figure.gca().containers[line_index]
         container.set_label(line_options['label'])
-        main_line, error_bar_elements = container.get_children()[0], container.get_children()[1:]
+        main_line = container.get_children()[0]
         main_line.set_linestyle(line_options['style'])
         main_line.set_marker(line_options['marker'])
 

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -244,6 +244,16 @@ class CutPlot(IPlot):
                     # elements[0] is the actual line, the others are the bits of the error bar
                     for element in range(1, len(elements)):
                         elements[element].set_alpha(alpha)
+        self.toggle_errobars_in_legend(current_axis)
+
+    def toggle_errobars_in_legend(self, current_axis):
+        if not self._has_errorbars():
+            handles, labels = current_axis.get_legend_handles_labels()
+            handles = [h[0] for h in handles]
+            current_axis.legend(handles, labels)
+        else:
+            handles, labels = current_axis.get_legend_handles_labels()
+            current_axis.legend(handles, labels)
 
     def _toggle_errorbars(self):
         state = self._has_errorbars()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -207,7 +207,7 @@ class CutPlot(IPlot):
 
     def calc_figure_boundaries(self):
         fig_x, fig_y = self._canvas.figure.get_size_inches() * self._canvas.figure.dpi
-        bounds = dict()
+        bounds = {}
         bounds['y_label'] = fig_x * 0.07
         bounds['y_range'] = fig_x * 0.12
         bounds['title'] = fig_y * 0.9
@@ -228,11 +228,7 @@ class CutPlot(IPlot):
         alpha = [x.get_alpha() for x in errorbar]
         # replace None with 1(None indicates default which is 1)
         alpha = [x if x is not None else 1 for x in alpha]
-        if sum(alpha) == 0:
-            has_errorbars = False
-        else:
-            has_errorbars = True
-        return has_errorbars
+        return sum(alpha) != 0
 
     def legend_visible(self, index):
         try:

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -140,7 +140,7 @@ class PlotFigureManagerQT(QtCore.QObject):
             page_size = printer.pageRect()
             pixmap_image = pixmap_image.scaled(page_size.width(), page_size.height(), Qt.KeepAspectRatio)
             painter = QtGui.QPainter(printer)
-            painter.drawPixmap(0,0,pixmap_image)
+            painter.drawPixmap(0, 0, pixmap_image)
             painter.end()
 
     def save_plot(self):

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -249,7 +249,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     def __init__(self, line_options, color_validator):
         super(LegendAndLineOptionsSetter, self).__init__()
-        self.line_options = line_options
 
         self.legend_text_label = QtWidgets.QLabel("Plot")
         self.legendText = QtWidgets.QLineEdit(self)

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -303,7 +303,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         row3.addWidget(self.marker_label)
         row3.addWidget(self.line_marker)
 
-        self.error_bar_checkbox = QtWidgets.QCheckBox("Show Line Error Bars")
+        self.error_bar_checkbox = QtWidgets.QCheckBox("Show Error Bars")
         self.error_bar_checkbox.setChecked(line_options['error_bar'])
 
         row4 = QtWidgets.QHBoxLayout()

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -9,7 +9,6 @@ from mslice.util.qt import load_ui
 
 class PlotOptionsDialog(QtWidgets.QDialog):
 
-
     titleEdited = Signal()
     xLabelEdited = Signal()
     yLabelEdited = Signal()
@@ -111,7 +110,6 @@ class PlotOptionsDialog(QtWidgets.QDialog):
         self.chkYGrid.setChecked(value)
 
 
-
 class SlicePlotOptions(PlotOptionsDialog):
 
     cRangeEdited = Signal()
@@ -180,7 +178,7 @@ class CutPlotOptions(PlotOptionsDialog):
         all_line_options = []
         for line_widget in self._line_widgets:
             line_options = {}
-            for option in ['shown', 'color', 'style', 'width', 'marker', 'legend', 'label']:
+            for option in ['shown', 'color', 'style', 'width', 'marker', 'legend', 'label', 'error_bar']:
                 line_options[option] = getattr(line_widget, option)
             all_line_options.append(line_options)
         return all_line_options
@@ -214,14 +212,6 @@ class CutPlotOptions(PlotOptionsDialog):
     @y_log.setter
     def y_log(self, value):
         self.chkYLog.setChecked(value)
-
-    @property
-    def error_bars(self):
-        return self.chkShowErrorBars.isChecked()
-
-    @error_bars.setter
-    def error_bars(self, value):
-        self.chkShowErrorBars.setChecked(value)
 
     @property
     def show_legends(self):
@@ -259,6 +249,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     def __init__(self, line_options, color_validator):
         super(LegendAndLineOptionsSetter, self).__init__()
+        self.legend_text_label = QtWidgets.QLabel("Plot")
         self.legendText = QtWidgets.QLineEdit(self)
         self.legendText.setText(line_options['label'])
         self.color_validator = color_validator
@@ -281,7 +272,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         self.width_label = QtWidgets.QLabel(self)
         self.width_label.setText("Width:")
         self.line_width = QtWidgets.QComboBox(self)
-        self.line_width.addItems([str(x+1) for x in range(10)])
+        self.line_width.addItems([str(x + 1) for x in range(10)])
         self.line_width.setCurrentIndex(self.line_width.findText(line_options['width']))
 
         self.marker_label = QtWidgets.QLabel(self)
@@ -300,8 +291,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         layout.addLayout(row2)
         row3 = QtWidgets.QHBoxLayout()
         layout.addLayout(row3)
-        layout.addStretch()
 
+        row1.addWidget(self.legend_text_label)
         row1.addWidget(self.legendText)
         row2.addWidget(self.color_label)
         row2.addWidget(self.line_color)
@@ -312,24 +303,27 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         row3.addWidget(self.marker_label)
         row3.addWidget(self.line_marker)
 
+        self.error_bar_checkbox = QtWidgets.QCheckBox("Show Line Error Bars")
+        self.error_bar_checkbox.setChecked(line_options['error_bar'])
+
+        row4 = QtWidgets.QHBoxLayout()
+        layout.addLayout(row4)
+
+        row4.addWidget(self.error_bar_checkbox)
+
         if line_options['shown'] is not None and line_options['legend'] is not None:
-            self.show_line_label = QtWidgets.QLabel(self)
-            self.show_line_label.setText("Show: ")
-            self.show_line = QtWidgets.QCheckBox(self)
+            self.show_line = QtWidgets.QCheckBox("Show Line")
             self.show_line.setChecked(line_options['shown'])
 
-            self.show_legend_label = QtWidgets.QLabel(self)
-            self.show_legend_label.setText("Show legend: ")
-            self.show_legend = QtWidgets.QCheckBox(self)
+            self.show_legend = QtWidgets.QCheckBox("Show Legend")
             self.show_legend.setChecked(line_options['legend'])
+
             self.show_legend.setEnabled(line_options['shown'])
 
-            row4 = QtWidgets.QHBoxLayout()
-            layout.addLayout(row4)
+            row5 = QtWidgets.QHBoxLayout()
+            layout.addLayout(row5)
 
-            row4.addWidget(self.show_line_label)
-            row4.addWidget(self.show_line)
-            row4.addWidget(self.show_legend_label)
+            row5.addWidget(self.show_line)
             row4.addWidget(self.show_legend)
 
             self.show_line.stateChanged.connect(lambda state: self.show_line_changed(state))
@@ -339,6 +333,11 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
+
+        separator = QtWidgets.QFrame()
+        separator.setFrameShape(QtWidgets.QFrame.HLine)
+        separator.setFrameShadow(QtWidgets.QFrame.Sunken)
+        layout.addWidget(separator)
 
     def color_valid(self, index):
         if self.color_validator is None:
@@ -353,8 +352,15 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         self.show_legend.setEnabled(state)
         self.show_legend.setChecked(state)
 
+        self.error_bar_checkbox.setEnabled(state)
+        self.error_bar_checkbox.setChecked(state)
+
     def get_color_index(self):
         return self.line_color.currentIndex()
+
+    @property
+    def error_bar(self):
+        return self.error_bar_checkbox.isChecked()
 
     @property
     def legend(self):

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -249,6 +249,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     def __init__(self, line_options, color_validator):
         super(LegendAndLineOptionsSetter, self).__init__()
+        self.line_options = line_options
+
         self.legend_text_label = QtWidgets.QLabel("Plot")
         self.legendText = QtWidgets.QLineEdit(self)
         self.legendText.setText(line_options['label'])
@@ -333,6 +335,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
+
+        self.error_bar_checkbox.setEnabled(line_options['shown'])
 
         separator = QtWidgets.QFrame()
         separator.setFrameShape(QtWidgets.QFrame.HLine)

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -312,7 +312,7 @@
               <x>0</x>
               <y>0</y>
               <width>341</width>
-              <height>355</height>
+              <height>378</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_legend">
@@ -336,19 +336,6 @@
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="chkShowErrorBars">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Show Error Bars</string>
-        </property>
        </widget>
       </item>
      </layout>

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -1,4 +1,3 @@
-
 from mslice.plotting.plot_window.plot_options import LegendAndLineOptionsSetter
 
 from mslice.util.qt import QtWidgets
@@ -66,6 +65,7 @@ class QuickAxisOptions(QuickOptions):
     def grid_state(self):
         return self.grid.checkState()
 
+
 class QuickLabelOptions(QuickOptions):
 
     ok_clicked = Signal()
@@ -98,6 +98,10 @@ class QuickLineOptions(QuickOptions):
         self.layout.addLayout(self.button_row)
 
         self.line_widget.show()
+
+    @property
+    def error_bar(self):
+        return self.line_widget.error_bar
 
     @property
     def color(self):

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -44,6 +44,7 @@ class CutPresenter(PresenterUtility):
             elif command == Command.AxisChanged:
                 self._cut_axis_changed()
 
+
     def _cut(self, output_method, plot_over=False):
         selected_workspaces = self._main_presenter.get_selected_workspaces()
         try:

--- a/mslice/presenters/cut_presenter.py
+++ b/mslice/presenters/cut_presenter.py
@@ -44,7 +44,6 @@ class CutPresenter(PresenterUtility):
             elif command == Command.AxisChanged:
                 self._cut_axis_changed()
 
-
     def _cut(self, output_method, plot_over=False):
         selected_workspaces = self._main_presenter.get_selected_workspaces()
         try:

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -3,6 +3,7 @@ from functools import partial
 
 
 class PlotOptionsPresenter(object):
+
     def __init__(self, plot_options_dialog, plot_handler):
         self._model = plot_handler
         self._view = plot_options_dialog
@@ -79,7 +80,7 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
 
     def set_properties(self):
         properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'x_log', 'y_log',
-                      'x_grid', 'y_grid', 'error_bars', 'show_legends']
+                      'x_grid', 'y_grid', 'show_legends']
         for p in properties:
             setattr(self._view, p, getattr(self._model, p))
 
@@ -93,5 +94,4 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
             setattr(self._model, key, value)
         line_options = self._view.get_line_options()
         self._model.set_all_line_options(line_options)
-        self._model.error_bars = self._view.error_bars
         return True

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -53,7 +53,7 @@ def _set_label(view, target):
 
 def _set_line_options(view, model, line):
     line_options = {}
-    values = ['color', 'style', 'width', 'marker', 'label', 'shown', 'legend']
+    values = ['error_bar', 'color', 'style', 'width', 'marker', 'label', 'shown', 'legend']
     for value in values:
         line_options[value] = getattr(view, value)
     model.set_line_options(line, line_options)

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -187,27 +187,9 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.model.change_axis_scale.assert_called_once_with({'x_range': (1, 2), 'y_range': (3, 4), 'modified': True,
                                                               'x_log': False,    'y_log': True})
 
-    def test_show_error_bars(self):
-        view_error_bars_mock = PropertyMock()
-        model_error_bars_mock = PropertyMock(return_value=True)
-        type(self.view).error_bars = view_error_bars_mock
-        type(self.model).error_bars = model_error_bars_mock
-
-        # model -> view
-        self.presenter = CutPlotOptionsPresenter(self.view, self.model)
-        model_error_bars_mock.assert_called_once_with()
-        view_error_bars_mock.assert_called_once_with(True)
-
-        # view -> model
-        model_error_bars_mock.reset_mock()
-        view_error_bars_mock.return_value = False
-        self.presenter.get_new_config()
-
-        model_error_bars_mock.assert_called_once_with(False)
-
     def test_line_options(self):
         #  model -> view
-        line_options = [{'color': 'k', 'style': '-', 'width': '10', 'marker': '*'}]
+        line_options = [{'color': 'k', 'style': '-', 'width': '10', 'marker': '*', 'error_bars': True}]
         legends = {'label': 'legend1', 'visible': True}
         line_data = list(zip(legends, line_options))
         self.model.get_all_line_options = Mock(return_value=line_data)
@@ -217,7 +199,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.view.set_line_options.assert_called_once_with(line_data)
 
         #  view -> model
-        line_options2 = [{'color': 'b', 'style': '-', 'width': '10', 'marker': 'o'}]
+        line_options2 = [{'color': 'b', 'style': '-', 'width': '10', 'marker': 'o', 'error_bars': False}]
         legends2 = {'label': 'legend1', 'visible': False}
         line_data2 = list(zip(legends2, line_options2))
 

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -92,11 +92,11 @@ class QuickOptionsTest(unittest.TestCase):
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
             {'shown': True, 'color': 'red', 'label': u'label1', 'style': '-', 'width': '3',
-             'marker': 'o', 'legend': True})
+             'marker': 'o', 'legend': True, 'error_bar': True})
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
                              {'shown': True, 'color': 'blue', 'label': u'label2',
-                              'style': '--', 'width': '5', 'marker': '.', 'legend': True})
+                              'style': '--', 'width': '5', 'marker': '.', 'legend': True, 'error_bar': False})
 
     @patch.object(QuickAxisOptions, '__init__', lambda v, w, x, y, z: None)
     @patch.object(QuickAxisOptions, 'exec_', lambda x: True)
@@ -217,7 +217,8 @@ class QuickLineTest(unittest.TestCase):
         type(self.view).legend = legend
         self.view.exec_ = MagicMock(return_value=True)
         quick_options(self.target, self.model)
-        values = {'color': 1, 'style': 2, 'width': 3, 'marker': 4, 'label': 5, 'shown': False, 'legend': False}
+        values = {'color': 1, 'style': 2, 'width': 3, 'marker': 4, 'label': 5, 'shown': False, 'legend': False,
+                  'error_bar': True}
         self.model.set_line_options.assert_called_once_with(self.target, values)
 
     def test_reject(self, quick_line_options_view):

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -4,7 +4,7 @@ import unittest
 
 from matplotlib import text
 from matplotlib.lines import Line2D
-from matplotlib.container import Container, ErrorbarContainer
+from matplotlib.container import ErrorbarContainer
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.cut_plot import CutPlot
 from mslice.presenters.quick_options_presenter import quick_options, quick_axis_options

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -1,9 +1,10 @@
 from mock import MagicMock, PropertyMock, Mock, patch
 import unittest
 
+
 from matplotlib import text
 from matplotlib.lines import Line2D
-from matplotlib.container import Container
+from matplotlib.container import Container, ErrorbarContainer
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.cut_plot import CutPlot
 from mslice.presenters.quick_options_presenter import quick_options, quick_axis_options
@@ -18,6 +19,7 @@ def setup_line_values(qlo_mock):
     type(quick_line_options).style = PropertyMock(return_value='--')
     type(quick_line_options).width = PropertyMock(return_value='5')
     type(quick_line_options).label = PropertyMock(return_value='label2')
+    type(quick_line_options).shown = PropertyMock(return_value=True)
     target = Line2D([], [], 3, '-', 'red', 'o', label='label1')
     return qlo_mock, target
 
@@ -82,7 +84,7 @@ class QuickOptionsTest(unittest.TestCase):
         model = CutPlot(plot_figure, cut_plotter, 'workspace')
         qlo_mock, target = setup_line_values(qlo_mock)
 
-        container = Container([target], label='label1')
+        container = ErrorbarContainer([target], has_yerr=True, label='label1')
         model._lines[target] = container
         container_mock = MagicMock()
         container_mock.containers = [container]
@@ -92,7 +94,7 @@ class QuickOptionsTest(unittest.TestCase):
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
             {'shown': True, 'color': 'red', 'label': u'label1', 'style': '-', 'width': '3',
-             'marker': 'o', 'legend': True, 'error_bar': True})
+             'marker': 'o', 'legend': True, 'error_bar': False})
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
                              {'shown': True, 'color': 'blue', 'label': u'label2',
@@ -107,6 +109,7 @@ class QuickOptionsTest(unittest.TestCase):
         self.target = 'y_range'
         quick_options(self.target, self.model)
         self.assertEquals(self.model.y_grid, True)
+
 
 @patch('mslice.presenters.quick_options_presenter.QuickAxisOptions')
 class QuickAxisTest(unittest.TestCase):
@@ -125,14 +128,12 @@ class QuickAxisTest(unittest.TestCase):
         grid_state = PropertyMock(return_value=True)
         type(self.view).grid_state = grid_state
 
-
     def test_accept(self, quick_axis_options_view):
         quick_axis_options_view.return_value = self.view
         self.view.exec_ = MagicMock(return_value=True)
         quick_axis_options('x_range', self.model)
         self.assertEquals(self.model.x_range, (5, 10))
         self.assertEquals(self.model.x_grid, True)
-
 
     def test_reject(self, quick_axis_options_view):
         quick_axis_options_view.return_value = self.view
@@ -141,7 +142,6 @@ class QuickAxisTest(unittest.TestCase):
         quick_axis_options('x_range', self.model)
         self.view.set_range.assert_not_called()
         self.view.set_grid.assert_not_called()
-
 
     def test_colorbar(self, quick_axis_options_view):
         quick_axis_options_view.return_value = self.view
@@ -152,6 +152,7 @@ class QuickAxisTest(unittest.TestCase):
         quick_axis_options('colorbar_range', self.model, True)
         self.view.log_scale.isChecked.assert_called_once()
         colorbar_log.assert_called_once()
+
 
 @patch('mslice.presenters.quick_options_presenter.QuickLabelOptions')
 class QuickLabelTest(unittest.TestCase):
@@ -176,6 +177,7 @@ class QuickLabelTest(unittest.TestCase):
         quick_options(self.target, self.model)
         self.target.set_text.assert_not_called()
 
+
 @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
 class QuickLineTest(unittest.TestCase):
 
@@ -199,6 +201,8 @@ class QuickLineTest(unittest.TestCase):
         type(self.view).marker = marker
         label = PropertyMock(return_value=5)
         type(self.view).label = label
+        error_bar = PropertyMock(return_value=True)
+        type(self.view).error_bar = error_bar
 
     def test_accept(self, quick_line_options_view):
         quick_line_options_view.return_value = self.view
@@ -206,6 +210,8 @@ class QuickLineTest(unittest.TestCase):
         type(self.view).shown = shown
         legend = PropertyMock(return_value=True)
         type(self.view).legend = legend
+        error_bar = PropertyMock(return_value=True)
+        type(self.view).error_bar = error_bar
         self.view.exec_ = MagicMock(return_value=True)
         quick_options(self.target, self.model)
 


### PR DESCRIPTION
Description of work.
Added functionality to hide error bars in the plot options menu and the quick options menu
**To test:**

<!-- Instructions for testing. -->
Open up mslice 
Load some data
Perform a cut plot
1. Open up the plot options menu and uncheck/check the error bars options for the relevant plot
2. Double-click a plot and uncheck/check the error bars option for the plot

The error bars should now be hidden from the legend and the actual plot

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #372
