### PR TITLE
#285 rectangle selector now persistent

### DIFF
--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -92,4 +92,3 @@ class InteractiveCut(object):
     def window_closing(self):
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
         self.slice_plot.toggle_icut()
-        self._canvas.mpl_disconnect(self.connect_event[3])

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -4,7 +4,7 @@ from mslice.models.axis import Axis
 from mslice.models.cut.cut_functions import output_workspace_name
 from mslice.models.workspacemanager.workspace_algorithms import (get_limits)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
-from mslice.presenters.cut_plotter_presenter import CutPlotterPresenter
+from mslice.widgets.cut.cut import CUT_PLOTTER
 
 
 class InteractiveCut(object):
@@ -14,8 +14,8 @@ class InteractiveCut(object):
         self._canvas = canvas
         self._ws_title = ws_title
         self.horizontal = None
-        self.connect_event = [None, None, None]
-        self._cut_plotter_presenter = CutPlotterPresenter()
+        self.connect_event = [None, None, None, None]
+        self._cut_plotter = CUT_PLOTTER
         self._rect_pos_cache = [0, 0, 0, 0, 0, 0]
         self.rect = RectangleSelector(self._canvas.figure.gca(), self.plot_from_mouse_event,
                                       drawtype='box', useblit=True,
@@ -30,7 +30,8 @@ class InteractiveCut(object):
         if rectangle_changed:
             self.horizontal = abs(erelease.x - eclick.x) > abs(erelease.y - eclick.y)
         self.plot_cut(eclick.xdata, erelease.xdata, eclick.ydata, erelease.ydata)
-        self._cut_plotter_presenter.store_icut(self._ws_title, self)
+        self.connect_event[3] = self._canvas.mpl_connect('draw_event', self.callback)
+        self._cut_plotter.set_icut(self)
         self.connect_event[2] = self._canvas.mpl_connect('button_press_event', self.clicked)
         self._rect_pos_cache = rect_pos
 
@@ -40,7 +41,7 @@ class InteractiveCut(object):
             units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
                 self._canvas.figure.gca().get_xaxis().units
             integration_axis = Axis(units, integration_start, integration_end, 0)
-            self._cut_plotter_presenter.plot_interactive_cut(str(self._ws_title), ax, integration_axis, store)
+            self._cut_plotter.plot_cut(str(self._ws_title), ax, integration_axis, False, None, None, False, store)
 
     def get_cut_parameters(self, pos1, pos2):
         start = pos1[not self.horizontal]
@@ -52,6 +53,11 @@ class InteractiveCut(object):
         integration_start = pos1[self.horizontal]
         integration_end = pos2[self.horizontal]
         return ax, integration_start, integration_end
+
+    def callback(self, event):
+        if self.rect.active:
+            print('thing was done')
+            self.rect.update()
 
     def clicked(self, event):
         self.connect_event[0] = self._canvas.mpl_connect('motion_notify_event',
@@ -73,7 +79,7 @@ class InteractiveCut(object):
         self.slice_plot.update_workspaces()
 
     def clear(self):
-        self._cut_plotter_presenter.set_is_icut(self._ws_title, False)
+        self._cut_plotter.set_icut(None)
         self.rect.set_active(False)
         for event in self.connect_event:
             self._canvas.mpl_disconnect(event)

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -56,7 +56,6 @@ class InteractiveCut(object):
 
     def callback(self, event):
         if self.rect.active:
-            print('thing was done')
             self.rect.update()
 
     def clicked(self, event):

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -21,7 +21,7 @@ class InteractiveCut(object):
                                       drawtype='box', useblit=True,
                                       button=[1, 3], spancoords='pixels', interactive=True)
 
-        self.connect_event[3] = self._canvas.mpl_connect('draw_event', self.callback)
+        self.connect_event[3] = self._canvas.mpl_connect('draw_event', self.redraw_rectangle)
         self._canvas.draw()
 
     def plot_from_mouse_event(self, eclick, erelease):
@@ -64,7 +64,7 @@ class InteractiveCut(object):
         self._canvas.mpl_disconnect(self.connect_event[0])
         self._canvas.mpl_disconnect(self.connect_event[1])
 
-    def callback(self, event):
+    def redraw_rectangle(self, event):
         if self.rect.active:
             self.rect.update()
 

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -20,6 +20,8 @@ class InteractiveCut(object):
         self.rect = RectangleSelector(self._canvas.figure.gca(), self.plot_from_mouse_event,
                                       drawtype='box', useblit=True,
                                       button=[1, 3], spancoords='pixels', interactive=True)
+
+        self.connect_event[3] = self._canvas.mpl_connect('draw_event', self.callback)
         self._canvas.draw()
 
     def plot_from_mouse_event(self, eclick, erelease):
@@ -30,7 +32,6 @@ class InteractiveCut(object):
         if rectangle_changed:
             self.horizontal = abs(erelease.x - eclick.x) > abs(erelease.y - eclick.y)
         self.plot_cut(eclick.xdata, erelease.xdata, eclick.ydata, erelease.ydata)
-        self.connect_event[3] = self._canvas.mpl_connect('draw_event', self.callback)
         self._cut_plotter_presenter.store_icut(self._ws_title, self)
         self.connect_event[2] = self._canvas.mpl_connect('button_press_event', self.clicked)
         self._rect_pos_cache = rect_pos
@@ -91,3 +92,4 @@ class InteractiveCut(object):
     def window_closing(self):
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
         self.slice_plot.toggle_icut()
+        self._canvas.mpl_disconnect(self.connect_event[3])


### PR DESCRIPTION
Description of work.
Added a `callback` method to redraw the rectangle selector whenever the canvas is redrawn.
**To test:**
<!-- Instructions for testing. -->
Open mslice, perform a slice cut and an interactive cut, click the settings gear, click "Ok" and observe that the rectangle persists.
<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #285
