### PR TITLE
Prevent closed interactive cut from reopening

### DIFF
--- a/mslice/plotting/globalfiguremanager.py
+++ b/mslice/plotting/globalfiguremanager.py
@@ -161,6 +161,10 @@ class GlobalFigureManager(object):
         return cls._figures[cls._active_figure]
 
     @classmethod
+    def active_cut_figure_exists(cls):
+        return cls._category_current_figures[CATEGORY_CUT] is not None
+
+    @classmethod
     def activate_category(cls, category):
         """Sets the active category to the supplied argument. Do not call this function directly, instead use supplied
         decorator below 'activate_category' """

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -1,4 +1,4 @@
-from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut
+from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.cut.cut import Cut
 from mslice.models.labels import generate_legend
@@ -72,7 +72,8 @@ class CutPlotterPresenter(PresenterUtility):
     def set_is_icut(self, workspace_name, is_icut):
         if not is_icut:
             self._cut_cache[workspace_name].icut = None
-        plt.gcf().canvas.manager.is_icut(is_icut)
+        if cut_figure_exists():
+            plt.gcf().canvas.manager.is_icut(is_icut)
 
     def get_icut(self, workspace_name):
         return self._cut_cache[workspace_name].icut

--- a/mslice/views/cut_plotter.py
+++ b/mslice/views/cut_plotter.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import mslice.plotting.pyplot as plt
 from mslice.models.workspacemanager.workspace_algorithms import get_comment
 from mslice.models.labels import get_display_name, CUT_INTENSITY_LABEL
+from mslice.plotting.globalfiguremanager import GlobalFigureManager
 
 
 PICKER_TOL_PTS = 3
@@ -58,3 +59,6 @@ def _create_cut():
     canvas.figure.gca().xaxis.set_visible(True)
     canvas.figure.gca().yaxis.set_visible(True)
     canvas.draw()
+
+def cut_figure_exists():
+    return GlobalFigureManager.active_cut_figure_exists()


### PR DESCRIPTION
There was a bug caused by recent changes where a closed interactive cut that was labelled as 'current' would reopen again. This is because `plt.gcf()` was being called after the figure had been closed.

This checks if the figure still exists before calling `plt.gcf()`.

**To test:**
- Plot an interactive cut
- Turn interactive cuts mode off on the slice plot
- Mark the cut as 'keep'.
- Plot another interactive cut.
- Mark first plot window as make current.
- Move the rectangle and check that the current plot window is updated.
- Close the current cut window
- Close the kept cut window
- Check no cuts reopen automatically and interactive cuts is off.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
_No associated issue_
