### PR TITLE
Changes dataloader root if users goes up a level.

### DIFF
--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -25,6 +25,7 @@ class DataLoaderWidget(QWidget): # and some view interface
         self.file_system = QFileSystemModel()
         self.directory = QDir(os.path.expanduser('~'))
         path = self.directory.absolutePath()
+        self.root_path = path
         self.file_system.setRootPath(path)
         self.file_system.setNameFilters(MSLICE_EXTENSIONS)
         self.file_system.setNameFilterDisables(False)
@@ -75,6 +76,9 @@ class DataLoaderWidget(QWidget): # and some view interface
 
     def _update_from_path(self):
         new_path = self.directory.absolutePath()
+        if os.path.relpath(new_path, self.root_path).startswith('..'):
+            self.file_system.setRootPath(new_path)
+            self.root_path = new_path
         self.table_view.setRootIndex(self.file_system.index(new_path))
         self.txtpath.setText(new_path)
         self._clear_displayed_error()


### PR DESCRIPTION
This changes the dataloader `QFileSystemModel` root path from the current (or default) if the user goes a level above it. At present, the file system model only monitors files within the user's home directory. This means that when the user goes "above" this (e.g. to the root directory), the items are listed but are not sorted because they are not indexed by the `QFileSystemWatcher`. 

This might cause issues on large filesystems if the file system model root is set to the real root...

**To test:**

Run MSlice, and click `Back` in the data loader tab. Check that the items are correctly sorted.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #387 
