### PR TITLE
Changed spin box to have more decimal places

### DIFF
--- a/mslice/widgets/workspacemanager/subtract_input_box.ui
+++ b/mslice/widgets/workspacemanager/subtract_input_box.ui
@@ -63,6 +63,9 @@
         <property name="singleStep">
          <double>0.010000000000000</double>
         </property>
+        <property name="decimals">
+         <number>16</number>
+        </property>
         <property name="value">
          <double>1.000000000000000</double>
         </property>


### PR DESCRIPTION
Changed the subtraction ui to allow more decimal places in the spin box for the self shielding factor.

**To test:**

Load a workspace, click on `Subtract` and in the dialog which pops up, check that you can type a value into the spin box which has more than 2 decimal places - e.g. `0.12345`; click on one of the up or down buttons and check that this value increases/decreases in steps of 0.02 as before (and that the last digits are not truncated as long as the values are between `0` and `1`).

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #373 
