### PR TITLE
#370 can now modify the log range

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -100,16 +100,14 @@ class CutPlot(IPlot):
     def change_axis_scale(self, xy_config):
         current_axis = self._canvas.figure.gca()
         if xy_config['x_log']:
-            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
-            xmin = get_min(xdata, absolute_minimum=0.)
+            xmin = xy_config['x_range'][0]
             current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(xmin))))
             if xmin > 0:
                 xy_config['x_range'] = (xmin, xy_config['x_range'][1])
         else:
             current_axis.set_xscale('linear')
         if xy_config['y_log']:
-            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
-            ymin = get_min(ydata, absolute_minimum=0.)
+            ymin = xy_config['y_range'][0]
             current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(ymin))))
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -101,14 +101,18 @@ class CutPlot(IPlot):
         current_axis = self._canvas.figure.gca()
         if xy_config['x_log']:
             xmin = xy_config['x_range'][0]
-            current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(xmin))))
+            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            min = get_min(xdata, absolute_minimum=0.)
+            current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(min))))
             if xmin > 0:
                 xy_config['x_range'] = (xmin, xy_config['x_range'][1])
         else:
             current_axis.set_xscale('linear')
         if xy_config['y_log']:
             ymin = xy_config['y_range'][0]
-            current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(ymin))))
+            ydata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            min = get_min(ydata, absolute_minimum=0.)
+            current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(min))))
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])
         else:

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -4,7 +4,7 @@ from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLab
 
 
 def quick_options(target, model, has_logarithmic=None):
-    '''Find which quick_options to use based on type of target'''
+    """Find which quick_options to use based on type of target"""
     if isinstance(target, text.Text):
         quick_label_options(target)
     elif isinstance(target, string_types):

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -45,7 +45,7 @@ class CutPlotTest(unittest.TestCase):
         xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
 
         self.cut_plot.change_axis_scale(xy_config)
-        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
+        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=0.0)
         self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
         self.assertEqual(self.cut_plot.x_range, (12, 20))
         self.assertEqual(self.cut_plot.y_range, (1, 7))


### PR DESCRIPTION
Description of work.
Removed bug that prevents user from modifying the lower bound in the log scale in interactive cuts
**To test:**

<!-- Instructions for testing. -->
Perform a cut in mslice, change the scale to logarithmic. The lower bound of the range can be modified
<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #370 .