### PR TITLE
369 bugs in arbitrary nuclei option

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -8,12 +8,14 @@ from mslice.util.mantid import initialize_mantid
 # Module-level reference to keep main window alive after show_gui has returned
 MAIN_WINDOW = None
 
+
 def main():
     """Start the application.
     """
     qapp_ref = QApplication([])
     show_gui()
     return qapp_ref.exec_()
+
 
 def show_gui():
     """Display the top-level main window.

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -87,7 +87,7 @@ class CutPlot(IPlot):
                 if self.legend_visible(i):
                     labels_to_show.append(label)
                     handles_to_show.append(handle)
-                i+=1
+                i += 1
         else:
             containers = axes.containers
             for i in range(len(containers)):
@@ -110,7 +110,7 @@ class CutPlot(IPlot):
             current_axis.set_xscale('linear')
         if xy_config['y_log']:
             ymin = xy_config['y_range'][0]
-            ydata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
             min = get_min(ydata, absolute_minimum=0.)
             current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(min))))
             if ymin > 0:
@@ -183,13 +183,11 @@ class CutPlot(IPlot):
         icut = self._cut_plotter_presenter.get_icut(self.ws_name)
         icut.flip_axis()
 
-
     def _get_line_index(self, line):
-        '''
-        Checks if line index is cached, and if not finds the index by iterating over the axes' containers.
+        """Checks if line index is cached, and if not finds the index by iterating over the axes' containers.
         :param line: Line to find the index of
         :return: Index of line
-        '''
+        """
         try:
             container = self._lines[line]
         except KeyError:
@@ -199,7 +197,7 @@ class CutPlot(IPlot):
         for c in self._canvas.figure.gca().containers:
             if container == c:
                 return i
-            i+=1
+            i += 1
 
     def calc_figure_boundaries(self):
         fig_x, fig_y = self._canvas.figure.get_size_inches() * self._canvas.figure.dpi
@@ -213,7 +211,6 @@ class CutPlot(IPlot):
 
     def xy_config(self):
         return {'x_log': self.x_log, 'y_log': self.y_log, 'x_range': self.x_range, 'y_range': self.y_range}
-
 
     def _has_errorbars(self):
         """True current axes has visible errorbars,
@@ -262,7 +259,7 @@ class CutPlot(IPlot):
         return v
 
     def line_containers(self):
-        '''build dictionary of lines and their containers'''
+        """build dictionary of lines and their containers"""
         line_containers = {}
         containers = self._canvas.figure.gca().containers
         for container in containers:

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -87,7 +87,7 @@ class CutPlot(IPlot):
                 if self.legend_visible(i):
                     labels_to_show.append(label)
                     handles_to_show.append(handle)
-                i += 1
+                i+=1
         else:
             containers = axes.containers
             for i in range(len(containers)):
@@ -183,11 +183,13 @@ class CutPlot(IPlot):
         icut = self._cut_plotter_presenter.get_icut(self.ws_name)
         icut.flip_axis()
 
+
     def _get_line_index(self, line):
-        """Checks if line index is cached, and if not finds the index by iterating over the axes' containers.
+        '''
+        Checks if line index is cached, and if not finds the index by iterating over the axes' containers.
         :param line: Line to find the index of
         :return: Index of line
-        """
+        '''
         try:
             container = self._lines[line]
         except KeyError:
@@ -197,7 +199,7 @@ class CutPlot(IPlot):
         for c in self._canvas.figure.gca().containers:
             if container == c:
                 return i
-            i += 1
+            i+=1
 
     def calc_figure_boundaries(self):
         fig_x, fig_y = self._canvas.figure.get_size_inches() * self._canvas.figure.dpi
@@ -211,6 +213,7 @@ class CutPlot(IPlot):
 
     def xy_config(self):
         return {'x_log': self.x_log, 'y_log': self.y_log, 'x_range': self.x_range, 'y_range': self.y_range}
+
 
     def _has_errorbars(self):
         """True current axes has visible errorbars,
@@ -259,7 +262,7 @@ class CutPlot(IPlot):
         return v
 
     def line_containers(self):
-        """build dictionary of lines and their containers"""
+        '''build dictionary of lines and their containers'''
         line_containers = {}
         containers = self._canvas.figure.gca().containers
         for container in containers:

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -100,16 +100,14 @@ class CutPlot(IPlot):
     def change_axis_scale(self, xy_config):
         current_axis = self._canvas.figure.gca()
         if xy_config['x_log']:
-            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
-            xmin = get_min(xdata, absolute_minimum=0.)
+            xmin = xy_config['x_range'][0]
             current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(xmin))))
             if xmin > 0:
                 xy_config['x_range'] = (xmin, xy_config['x_range'][1])
         else:
             current_axis.set_xscale('linear')
         if xy_config['y_log']:
-            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
-            ymin = get_min(ydata, absolute_minimum=0.)
+            ymin = xy_config['y_range'][0]
             current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(ymin))))
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -101,14 +101,18 @@ class CutPlot(IPlot):
         current_axis = self._canvas.figure.gca()
         if xy_config['x_log']:
             xmin = xy_config['x_range'][0]
-            current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(xmin))))
+            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            min = get_min(xdata, absolute_minimum=0.)
+            current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(min))))
             if xmin > 0:
                 xy_config['x_range'] = (xmin, xy_config['x_range'][1])
         else:
             current_axis.set_xscale('linear')
         if xy_config['y_log']:
             ymin = xy_config['y_range'][0]
-            current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(ymin))))
+            ydata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            min = get_min(ydata, absolute_minimum=0.)
+            current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(min))))
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])
         else:

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -215,15 +215,18 @@ class SlicePlot(IPlot):
         checked = self.plot_window.action_arbitrary_nuclei.isChecked()
         if checked:
             self._arb_nuclei_rmm, confirm = QtWidgets.QInputDialog.getInt(
-                self.plot_window, 'Arbitrary Nuclei', 'Enter relative mass:')
+                self.plot_window, 'Arbitrary Nuclei', 'Enter relative mass:', min=1)
             if confirm:
                 self.toggle_overplot_line(self._arb_nuclei_rmm, recoil, checked)
+            else:
+                self.plot_window.action_arbitrary_nuclei.setChecked(not checked)
         else:
             self.toggle_overplot_line(self._arb_nuclei_rmm, recoil, checked)
 
     def cif_file_powder_line(self, checked):
         if checked:
-            cif_path = QtWidgets.QFileDialog().getOpenFileName(self.plot_window, 'Open CIF file', '/home', 'Files (*.cif)')
+            cif_path = QtWidgets.QFileDialog().getOpenFileName(self.plot_window, 'Open CIF file', '/home',
+                                                               'Files (*.cif)')
             cif_path = str(cif_path[0]) if isinstance(cif_path, tuple) else str(cif_path)
             key = path.basename(cif_path).rsplit('.')[0]
             self._cif_file = key
@@ -319,15 +322,15 @@ class SlicePlot(IPlot):
 
     def _update_lines(self):
         """ Updates the powder/recoil overplots lines when intensity type changes """
-        lines = {self.plot_window.action_hydrogen:[1, True, ''],
-                 self.plot_window.action_deuterium:[2, True, ''],
-                 self.plot_window.action_helium:[4, True, ''],
-                 self.plot_window.action_arbitrary_nuclei:[self._arb_nuclei_rmm, True, ''],
-                 self.plot_window.action_aluminium:['Aluminium', False, ''],
-                 self.plot_window.action_copper:['Copper', False, ''],
-                 self.plot_window.action_niobium:['Niobium', False, ''],
-                 self.plot_window.action_tantalum:['Tantalum', False, ''],
-                 self.plot_window.action_cif_file:[self._cif_file, False, self._cif_path]}
+        lines = {self.plot_window.action_hydrogen: [1, True, ''],
+                 self.plot_window.action_deuterium: [2, True, ''],
+                 self.plot_window.action_helium: [4, True, ''],
+                 self.plot_window.action_arbitrary_nuclei: [self._arb_nuclei_rmm, True, ''],
+                 self.plot_window.action_aluminium: ['Aluminium', False, ''],
+                 self.plot_window.action_copper: ['Copper', False, ''],
+                 self.plot_window.action_niobium: ['Niobium', False, ''],
+                 self.plot_window.action_tantalum: ['Tantalum', False, ''],
+                 self.plot_window.action_cif_file: [self._cif_file, False, self._cif_path]}
         for line in lines:
             if line.isChecked():
                 self._slice_plotter_presenter.add_overplot_line(self.ws_name, *lines[line])

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -4,7 +4,7 @@ from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLab
 
 
 def quick_options(target, model, has_logarithmic=None):
-    '''Find which quick_options to use based on type of target'''
+    """Find which quick_options to use based on type of target"""
     if isinstance(target, text.Text):
         quick_label_options(target)
     elif isinstance(target, string_types):

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -45,8 +45,8 @@ class CutPlotTest(unittest.TestCase):
         xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
 
         self.cut_plot.change_axis_scale(xy_config)
-        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=0.0)
-        self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
+        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=1.0)
+        self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=10.0)
         self.assertEqual(self.cut_plot.x_range, (12, 20))
         self.assertEqual(self.cut_plot.y_range, (1, 7))
 

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -47,7 +47,7 @@ class CutPlotTest(unittest.TestCase):
         self.cut_plot.change_axis_scale(xy_config)
         self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
         self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
-        self.assertEqual(self.cut_plot.x_range, (12, 20))
+        self.assertEqual(self.cut_plot.x_range, (0, 20))
         self.assertEqual(self.cut_plot.y_range, (1, 7))
 
     @patch('mslice.plotting.plot_window.cut_plot.quick_options')

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -45,7 +45,7 @@ class CutPlotTest(unittest.TestCase):
         xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
 
         self.cut_plot.change_axis_scale(xy_config)
-        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
+        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=0.0)
         self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
         self.assertEqual(self.cut_plot.x_range, (12, 20))
         self.assertEqual(self.cut_plot.y_range, (1, 7))

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -45,8 +45,8 @@ class CutPlotTest(unittest.TestCase):
         xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
 
         self.cut_plot.change_axis_scale(xy_config)
-        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=1.0)
-        self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=10.0)
+        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
+        self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
         self.assertEqual(self.cut_plot.x_range, (12, 20))
         self.assertEqual(self.cut_plot.y_range, (1, 7))
 


### PR DESCRIPTION
Description of work.
Restricted arbitrary nuclei option to integers greater than zero only. Selecting "cancel" in the input dialog now unchecks the arbitrary nuclei option.
**To test:**

<!-- Instructions for testing. -->
Perform a slice in mslice. Select Arbitrary nuclei in Information -> Recoil lines. You can only select values greater than 0. Selecting cancel leaves the Arbitrary nuclei option unchecked.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #369  .