### PR TITLE
Fix issue with cancelling arbitrary nuclei user input

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -8,12 +8,14 @@ from mslice.util.mantid import initialize_mantid
 # Module-level reference to keep main window alive after show_gui has returned
 MAIN_WINDOW = None
 
+
 def main():
     """Start the application.
     """
     qapp_ref = QApplication([])
     show_gui()
     return qapp_ref.exec_()
+
 
 def show_gui():
     """Display the top-level main window.

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -215,15 +215,18 @@ class SlicePlot(IPlot):
         checked = self.plot_window.action_arbitrary_nuclei.isChecked()
         if checked:
             self._arb_nuclei_rmm, confirm = QtWidgets.QInputDialog.getInt(
-                self.plot_window, 'Arbitrary Nuclei', 'Enter relative mass:')
+                self.plot_window, 'Arbitrary Nuclei', 'Enter relative mass:', min=1)
             if confirm:
                 self.toggle_overplot_line(self._arb_nuclei_rmm, recoil, checked)
+            else:
+                self.plot_window.action_arbitrary_nuclei.setChecked(not checked)
         else:
             self.toggle_overplot_line(self._arb_nuclei_rmm, recoil, checked)
 
     def cif_file_powder_line(self, checked):
         if checked:
-            cif_path = QtWidgets.QFileDialog().getOpenFileName(self.plot_window, 'Open CIF file', '/home', 'Files (*.cif)')
+            cif_path = QtWidgets.QFileDialog().getOpenFileName(self.plot_window, 'Open CIF file', '/home',
+                                                               'Files (*.cif)')
             cif_path = str(cif_path[0]) if isinstance(cif_path, tuple) else str(cif_path)
             key = path.basename(cif_path).rsplit('.')[0]
             self._cif_file = key
@@ -319,15 +322,15 @@ class SlicePlot(IPlot):
 
     def _update_lines(self):
         """ Updates the powder/recoil overplots lines when intensity type changes """
-        lines = {self.plot_window.action_hydrogen:[1, True, ''],
-                 self.plot_window.action_deuterium:[2, True, ''],
-                 self.plot_window.action_helium:[4, True, ''],
-                 self.plot_window.action_arbitrary_nuclei:[self._arb_nuclei_rmm, True, ''],
-                 self.plot_window.action_aluminium:['Aluminium', False, ''],
-                 self.plot_window.action_copper:['Copper', False, ''],
-                 self.plot_window.action_niobium:['Niobium', False, ''],
-                 self.plot_window.action_tantalum:['Tantalum', False, ''],
-                 self.plot_window.action_cif_file:[self._cif_file, False, self._cif_path]}
+        lines = {self.plot_window.action_hydrogen: [1, True, ''],
+                 self.plot_window.action_deuterium: [2, True, ''],
+                 self.plot_window.action_helium: [4, True, ''],
+                 self.plot_window.action_arbitrary_nuclei: [self._arb_nuclei_rmm, True, ''],
+                 self.plot_window.action_aluminium: ['Aluminium', False, ''],
+                 self.plot_window.action_copper: ['Copper', False, ''],
+                 self.plot_window.action_niobium: ['Niobium', False, ''],
+                 self.plot_window.action_tantalum: ['Tantalum', False, ''],
+                 self.plot_window.action_cif_file: [self._cif_file, False, self._cif_path]}
         for line in lines:
             if line.isChecked():
                 self._slice_plotter_presenter.add_overplot_line(self.ws_name, *lines[line])


### PR DESCRIPTION
Description of work.
Cancelling the arbitrary_nuclei dialog leaves the option deselected. One can now only select integer values greater than zero. 
**To test:**

<!-- Instructions for testing. -->
Perform a slice in mslice. Select "arbitrary nuclei" from the information -> recoil lines menu. Selecting cancel leaves the "arbitrary nuclei" options deselected. It is also only possible to choose integer values greater than 0.
<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #369 .
