### PR TITLE
Re #393 - fixed problem with propagating limits for Workspace

### DIFF
--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -27,4 +27,5 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
         new_ws.e_mode = self.e_mode
         new_ws.e_fixed = self.e_fixed
         new_ws.ef_defined = self.ef_defined
+        new_ws.limits = self.limits
         return new_ws


### PR DESCRIPTION
Fix for `rewrap` method of `Workspace` to so that limits are also propagated. Note that no checks are performed. For all current uses of `rewrap` (to propagate MSlice specific properties to child workspaces) such as binary and unary operators this is correct but if `rewrap` is later used for other algorithms, this might be cause errors...

**To test:**

Test that the script in the issue work without errors.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #393 .
