### PR TITLE
Fix issues when running with matplotlib > 2.1

### DIFF
--- a/mslice/models/colors.py
+++ b/mslice/models/colors.py
@@ -1,0 +1,106 @@
+"""
+Handles mapping between color representations and their english
+names. For example we want to populate dialogs
+with pretty names for matplotlib colors of the current color cyle
+but we need to translate between their names and matplotlib
+representations.
+
+A slight complication exists for supporting the syntax for the basic
+colors in matplotib < v2. Translating to hex colors doesn't yield
+the same value as the equivalent CSS name in all cases, for example
+
+basic 'c' = rgb(0, 0.75, 0.75) => #00bfbf
+yet 'cyan' is defined in css colors as #00ffff
+
+In this case we accept that a 1->many mapping if names
+to hex values and both #00bfbf and #00ffff will return
+the string cyan
+"""
+from __future__ import (absolute_import, division)
+
+from matplotlib import rcParams
+from six import iteritems
+try:
+    from matplotlib.colors import to_hex
+except ImportError:
+    from matplotlib.colors import colorConverter, rgb2hex
+
+    def to_hex(color):
+        return rgb2hex(colorConverter.to_rgb(color))
+try:
+    from matplotlib.colors import get_named_colors_mapping as mpl_named_colors
+except ImportError:
+    from matplotlib.colors import cnames
+
+    def mpl_named_colors():
+        return cnames
+
+_BASIC_COLORS_PRETTY_NAME = {'b': 'blue', 'g': 'green', 'r': 'red', 'c': 'cyan', 'm': 'magenta', 'y': 'yellow',
+                             'k': 'black', 'w': 'white'}
+_BASIC_COLORS_HEX_MAPPING = dict((k, to_hex(k)) for k, _ in iteritems(_BASIC_COLORS_PRETTY_NAME))
+
+
+def pretty_name(name):
+    """
+    Sanitize the color name, removing any prefixes
+    :param name: The mpl color name
+    :return: A sanitized version for display
+    """
+    try:
+        colon_idx = name.index(":")
+        return name[colon_idx+1:]
+    except ValueError:
+        return name
+
+
+def named_cycle_colors():
+    """
+    Retrieve a named list of colors for the current color cycle
+    :return: A list of colors as human-readable strings
+    """
+    axes_prop_cycler = rcParams['axes.prop_cycle']
+    try:
+        keys = axes_prop_cycler.by_key()
+    except AttributeError:
+        # cycler < 1 doesn't have by_key but _transpose is the same
+        # and depending on a private attribute is okay here as
+        # it is only for older versions that won't change
+        keys = axes_prop_cycler._transpose()
+    return [color_to_name(to_hex(color)) for color in keys['color']]
+
+
+def name_to_color(name):
+    """
+    Translate between a our string names and the mpl color
+    representation
+    :param name: One of our known string names
+    :return: The string identifier we have chosen
+    :raises: ValueError if the color is not known
+    """
+    try:
+        return mpl_named_colors()[name]
+    except KeyError:
+        try:
+            return _BASIC_COLORS_HEX_MAPPING[name]
+        except KeyError:
+            raise ValueError("Color name {} unknown".format(name))
+
+
+def color_to_name(color):
+    """
+    Translate between a matplotlib color representation
+    and our string names.
+    :param color: Any matplotlib color representation
+    :return: The string identifier we have chosen
+    :raises: ValueError if the color is not known
+    """
+    color_as_hex = to_hex(color)
+    for name, value in iteritems(mpl_named_colors()):
+        if color_as_hex == to_hex(value):
+            return pretty_name(name)
+    else:
+        for name, hexvalue in iteritems(_BASIC_COLORS_HEX_MAPPING):
+            if color_as_hex == hexvalue:
+                return name
+        else:
+            raise ValueError("matplotlib color {} unknown".format(color))

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -3,6 +3,7 @@ from matplotlib.legend import Legend
 import warnings
 import numpy as np
 
+from mslice.models.colors import to_hex
 from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options
 from mslice.plotting.plot_window.plot_options import CutPlotOptions
@@ -153,17 +154,18 @@ class CutPlot(IPlot):
         return sum(alpha) != 0
 
     def get_line_options_by_index(self, line_index):
-        line_options = {}
         container = self._canvas.figure.gca().containers[line_index]
         line = container.get_children()[0]
-        line_options['label'] = container.get_label()
-        line_options['legend'] = self.legend_visible(line_index)
-        line_options['shown'] = self.get_line_visible(line_index)
-        line_options['color'] = line.get_color()
-        line_options['style'] = line.get_linestyle()
-        line_options['width'] = str(int(line.get_linewidth()))
-        line_options['marker'] = line.get_marker()
-        line_options['error_bar'] = self._single_line_has_error_bars(line_index)
+        line_options = {
+            'label': container.get_label(),
+            'legend': self.legend_visible(line_index),
+            'shown': self.get_line_visible(line_index),
+            'color': to_hex(line.get_color()),
+            'style': line.get_linestyle(),
+            'width': str(int(line.get_linewidth())),
+            'marker': line.get_marker(),
+            'error_bar': self._single_line_has_error_bars(line_index)
+        }
         return line_options
 
     def set_line_options_by_index(self, line_index, line_options):

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -1,9 +1,10 @@
 from __future__ import (absolute_import, division, print_function)
 
-import mslice.util.qt.QtWidgets as QtWidgets
-from mslice.util.qt.QtCore import Signal
 from six import iteritems
 
+import mslice.util.qt.QtWidgets as QtWidgets
+from mslice.models.colors import named_cycle_colors, color_to_name
+from mslice.util.qt.QtCore import Signal
 from mslice.util.qt import load_ui
 
 
@@ -226,15 +227,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
     """This is a widget that has various legend and line controls for each line of a plot"""
 
     # dictionaries used to convert from matplotlib arguments to UI selection and vice versa
-    import matplotlib
-    if matplotlib.__version__.startswith('1'):
-        colors = {'b': 'Blue', 'g': 'Green', 'r': 'Red', 'c': 'Cyan', 'm': 'Magenta', 'y': 'Yellow',
-                  'k': 'Black', 'w': 'White'}
-    else:
-        colors = {'#1f77b4': 'Blue', '#ff7f0e': 'Orange', '#2ca02c': 'Green', '#d62728': 'Red',
-                  '#9467bd': 'Purple', '#8c564b': 'Brown', '#e377c2': 'Pink', '#7f7f7f': 'Grey',
-                  '#bcbd22': 'Olive', '#17becf': 'Cyan'}
-
     styles = {'-': 'Solid', '--': 'Dashed', '-.': 'Dashdot', ':': 'Dotted'}
 
     markers = {'o': 'Circle', ',': 'Pixel', '.': 'Point', 'v': 'Triangle down', '^': 'Triangle up',
@@ -243,7 +235,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
                     '*': 'Star', 'h': 'Hexagon 1', 'H': 'Hexagon 2', '+': 'Plus', 'x': 'X', 'D': 'Diamond',
                     'd': 'Diamond (thin)', '|': 'Vertical line', '_': 'Horizontal line', 'None': 'None'}
 
-    inverse_colors = {v: k for k, v in iteritems(colors)}
     inverse_styles = {v: k for k, v in iteritems(styles)}
     inverse_markers = {v: k for k, v in iteritems(markers)}
 
@@ -258,9 +249,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         self.color_label = QtWidgets.QLabel(self)
         self.color_label.setText("Color:")
         self.line_color = QtWidgets.QComboBox(self)
-        self.line_color.addItems(list(self.colors.values()))
-        chosen_color_as_string = self.colors[line_options['color'].lower()]
-        self.line_color.setCurrentIndex(self.line_color.findText(chosen_color_as_string))
+        self.line_color.addItems(named_cycle_colors())
+        self.line_color.setCurrentIndex(self.line_color.findText(color_to_name(line_options['color'])))
         self.previous_color = self.line_color.currentIndex()
 
         self.style_label = QtWidgets.QLabel(self)
@@ -304,13 +294,16 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         row3.addWidget(self.marker_label)
         row3.addWidget(self.line_marker)
 
-        self.error_bar_checkbox = QtWidgets.QCheckBox("Show Error Bars")
-        self.error_bar_checkbox.setChecked(line_options['error_bar'])
+        if line_options['error_bar'] is not None:
+            self.error_bar_checkbox = QtWidgets.QCheckBox("Show Error Bars")
+            self.error_bar_checkbox.setChecked(line_options['error_bar'])
+            self.error_bar_checkbox.setEnabled(line_options['shown'])
 
-        row4 = QtWidgets.QHBoxLayout()
-        layout.addLayout(row4)
-
-        row4.addWidget(self.error_bar_checkbox)
+            row4 = QtWidgets.QHBoxLayout()
+            layout.addLayout(row4)
+            row4.addWidget(self.error_bar_checkbox)
+        else:
+            self.error_bar_checkbox = None
 
         if line_options['shown'] is not None and line_options['legend'] is not None:
             self.show_line = QtWidgets.QCheckBox("Show Line")
@@ -334,8 +327,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
-
-        self.error_bar_checkbox.setEnabled(line_options['shown'])
 
         separator = QtWidgets.QFrame()
         separator.setFrameShape(QtWidgets.QFrame.HLine)
@@ -363,7 +354,10 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     @property
     def error_bar(self):
-        return self.error_bar_checkbox.isChecked()
+        if self.error_bar_checkbox is None:
+            return None
+        else:
+            return self.error_bar_checkbox.isChecked()
 
     @property
     def legend(self):
@@ -383,7 +377,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     @property
     def color(self):
-        return self.inverse_colors[str(self.line_color.currentText())]
+        return self.line_color.currentText()
 
     @property
     def style(self):

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -391,7 +391,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     @property
     def width(self):
-        return self.line_width.currentText()
+        return int(self.line_width.currentText())
 
     @property
     def marker(self):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -7,6 +7,7 @@ import os.path as path
 import matplotlib.colors as colors
 from matplotlib.lines import Line2D
 
+from mslice.models.colors import to_hex
 from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
@@ -178,14 +179,16 @@ class SlicePlot(IPlot):
             self.colorbar_label = label
 
     def get_line_options(self, target):
-        line_options = {}
-        line_options['label'] = target.get_label()
-        line_options['legend'] = None
-        line_options['shown'] = None
-        line_options['color'] = target.get_color()
-        line_options['style'] = target.get_linestyle()
-        line_options['width'] = str(int(target.get_linewidth()))
-        line_options['marker'] = target.get_marker()
+        line_options = {
+            'label': target.get_label(),
+            'legend': None,
+            'shown': None,
+            'color': to_hex(target.get_color()),
+            'style': target.get_linestyle(),
+            'width': str(int(target.get_linewidth())),
+            'marker': target.get_marker(),
+            'error_bar': None
+        }
         return line_options
 
     def set_line_options(self, line, line_options):

--- a/mslice/tests/colors_test.py
+++ b/mslice/tests/colors_test.py
@@ -1,0 +1,33 @@
+import unittest
+
+from mslice.models.colors import color_to_name, name_to_color, named_cycle_colors
+
+
+class ColorsTest(unittest.TestCase):
+
+    def test_colors_list_is_limited_in_size(self):
+        # checking that the list is not all of matplotlibs colors!
+        self.assertLess(len(named_cycle_colors()), 15)
+
+    def test_color_names_do_not_contain_prefixes(self):
+        for name in named_cycle_colors():
+            self.assertTrue(':' not in name)
+
+    def test_known_color_name_gives_expected_hex(self):
+        self.assertEqual("#008000", name_to_color("green"))
+
+    def test_known_hex_gives_expected_color_name(self):
+        self.assertEqual("green", color_to_name("#008000"))
+
+    def test_unknown_color_name_raises_valueerror(self):
+        self.assertRaises(ValueError, name_to_color, "NotAColorName")
+
+    def test_unknown_hex_color_raises_valueerror(self):
+        self.assertRaises(ValueError, color_to_name, "#12345")
+
+    def test_basic_color_is_known(self):
+        self.assertEqual('c', color_to_name('#00bfbf'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -66,12 +66,13 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, model)
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': None, 'color': 'red', 'label': u'label1', 'style': '-', 'width': '3',
-             'marker': 'o', 'legend': None})
+            {'shown': None, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
+             'marker': 'o', 'legend': None, 'error_bar': None})
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
-                             {'shown': None, 'color': 'blue', 'label': u'label2',
-                              'style': '--', 'width': '5', 'marker': '.', 'legend': None})
+                             {'shown': None, 'color': '#0000ff', 'label': u'label2',
+                              'style': '--', 'width': '5', 'marker': '.', 'legend': None,
+                              'error_bar': None})
 
     @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
     def test_line_cut(self, qlo_mock):
@@ -93,11 +94,11 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, model)
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': True, 'color': 'red', 'label': u'label1', 'style': '-', 'width': '3',
+            {'shown': True, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
              'marker': 'o', 'legend': True, 'error_bar': False})
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
-                             {'shown': True, 'color': 'blue', 'label': u'label2',
+                             {'shown': True, 'color': '#0000ff', 'label': u'label2',
                               'style': '--', 'width': '5', 'marker': '.', 'legend': True, 'error_bar': False})
 
     @patch.object(QuickAxisOptions, '__init__', lambda v, w, x, y, z: None)

--- a/mslice/views/cut_plotter.py
+++ b/mslice/views/cut_plotter.py
@@ -32,14 +32,19 @@ def draw_interactive_cut(workspace):
 
 @plt.set_category(plt.CATEGORY_CUT)
 def plot_cut_impl(workspace, presenter, x_units, intensity_range=None, plot_over=False, legend=None):
-    legend = workspace.name if legend is None else legend
-    if not plot_over:
-        plt.cla()
+    # get/create figure and ensure the axes are setup
     cur_fig = plt.gcf()
-    cur_canvas = cur_fig.canvas
-    ax = cur_fig.add_subplot(111, projection='mantid')
+    try:
+        ax = cur_fig.axes[0]
+        if not plot_over:
+            ax.cla()
+    except IndexError:
+        ax = cur_fig.add_subplot(1, 1, 1, projection='mantid')
+
+    legend = workspace.name if legend is None else legend
     ax.errorbar(workspace.raw_ws, 'o-', label=legend, picker=PICKER_TOL_PTS)
     ax.set_ylim(*intensity_range) if intensity_range is not None else ax.autoscale()
+    cur_canvas = cur_fig.canvas
     if cur_canvas.manager.window.action_toggle_legends.isChecked():
         leg = ax.legend(fontsize='medium')
         leg.draggable()

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -40,8 +40,8 @@ def _show_plot(slice_cache, workspace):
     # labels
     ax.set_xlabel(get_display_name(x_axis.units, comment), picker=PICKER_TOL_PTS)
     ax.set_ylabel(get_display_name(y_axis.units, comment), picker=PICKER_TOL_PTS)
-    ax.set_xlim(x_axis.start)
-    ax.set_ylim(y_axis.start)
+    ax.set_xlim(x_axis.start, x_axis.end)
+    ax.set_ylim(y_axis.start, y_axis.end)
     cb = plt.colorbar(image, ax=ax)
     cb.set_label('Intensity (arb. units)', labelpad=20, rotation=270, picker=PICKER_TOL_PTS)
 


### PR DESCRIPTION
Description of work.

Mantid is upgrading matplotlib on Windows and this causes a few issues in mslice. This fixes
them in a backward compatible manner. For more information see the commit messages.

A few things to test:

* double-click overplot line on slice plot and check you can change the options
* double click on cut and do the same as above
* use the settings button on cut window to change line styles
