### PR TITLE
moved rename_workspace tests to workspace_provider_test.py

### DIFF
--- a/mslice/models/workspacemanager/workspace_provider.py
+++ b/mslice/models/workspacemanager/workspace_provider.py
@@ -4,6 +4,7 @@ from mslice.workspace.base import WorkspaceBase as Workspace
 
 _loaded_workspaces = {}
 
+
 def get_workspace_handle(workspace_name):
     """"Return handle to workspace given workspace_name_as_string"""
     # if passed a workspace handle return the handle

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -47,7 +47,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 self._broadcast_selected_workspaces()
             elif command == Command.Add:
                 self._add_workspaces()
-            elif command  == Command.Subtract:
+            elif command == Command.Subtract:
                 self._subtract_workspace()
             elif command == Command.SaveToADS:
                 self._save_to_ads()

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -74,7 +74,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
     @patch('mslice.presenters.workspace_manager_presenter.get_visible_workspace_names')
-    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
+    def test_that_rename_workspace_works_as_expected(self, get_ws_names_mock, rename_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
         # name on call to get_workspace_new_name

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
+import mock
 from mock import patch
 import unittest
 from mslice.models.workspacemanager.workspace_algorithms import (subtract, add_workspace_runs, combine_workspace,
@@ -8,13 +9,16 @@ from mslice.models.workspacemanager.workspace_provider import (get_workspace_han
                                                                delete_workspace, rename_workspace)
 from mslice.models.workspacemanager.workspace_algorithms import processEfixed
 from mslice.util.mantid.mantid_algorithms import ConvertToMD, CloneWorkspace, CreateSimulationWorkspace
-
+from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
+from mslice.widgets.workspacemanager.command import Command
 from mantid.simpleapi import AddSampleLog
+from mslice.views.interfaces.workspace_view import WorkspaceView
 
 
 class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def setUp(self):
+        self.view = mock.create_autospec(spec=WorkspaceView)
         self.test_ws_2d = CreateSimulationWorkspace(OutputWorkspace='test_ws_2d', Instrument='MAR',
                                                     BinParams=[-10, 1, 10], UnitX='DeltaE')
         AddSampleLog(Workspace=self.test_ws_2d.raw_ws, LogName='Ei', LogText='50.',
@@ -67,6 +71,48 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         new_ws = get_workspace_handle('newname')
         self.assertFalse(new_ws.ef_defined)
         self.assertEqual(new_ws.limits['DeltaE'], [0, 2, 1])
+
+    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    @patch('mslice.presenters.workspace_manager_presenter.get_visible_workspace_names')
+    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
+        # name on call to get_workspace_new_name
+        old_workspace_name = 'file1'
+        new_workspace_name = 'new_name'
+        self.view.get_workspace_selected = mock.Mock(return_value=[old_workspace_name])
+        self.view.get_workspace_new_name = mock.Mock(return_value=new_workspace_name)
+        self.view.display_loaded_workspaces = mock.Mock()
+        get_ws_names_mock.return_value = ['file1', 'file2', 'file3']
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.get_workspace_new_name.assert_called_once_with()
+        rename_ws_mock.assert_called_once_with('file1', 'new_name')
+        self.view.display_loaded_workspaces.assert_called_once()
+
+    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
+        selected_workspaces = ['ws1', 'ws2']
+        self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.error_select_only_one_workspace.assert_called_once_with()
+        rename_ws_mock.assert_not_called()
+
+    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
+        self.view.get_workspace_selected = mock.Mock(return_value=[])
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.error_select_one_workspace.assert_called_once_with()
+        rename_ws_mock.assert_not_called()
 
     def test_propagate_properties(self):
         ws_2 = CreateSimulationWorkspace(OutputWorkspace='test_ws_2', Instrument='MAR', BinParams=[-1, 1, 20],

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -72,7 +72,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         self.assertFalse(new_ws.ef_defined)
         self.assertEqual(new_ws.limits['DeltaE'], [0, 2, 1])
 
-    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
     @patch('mslice.presenters.workspace_manager_presenter.get_visible_workspace_names')
     def test_that_rename_workspace_works_as_expected(self, get_ws_names_mock, rename_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
@@ -91,7 +91,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         rename_ws_mock.assert_called_once_with('file1', 'new_name')
         self.view.display_loaded_workspaces.assert_called_once()
 
-    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
     def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
@@ -103,7 +103,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         self.view.error_select_only_one_workspace.assert_called_once_with()
         rename_ws_mock.assert_not_called()
 
-    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
     def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
         self.presenter = WorkspaceManagerPresenter(self.view)
         # Create a view that reports that no workspaces are selected on calls to get_workspace_selected

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
+import mock
 from mock import patch
 import unittest
 from mslice.models.workspacemanager.workspace_algorithms import (subtract, add_workspace_runs, combine_workspace,
@@ -8,8 +9,10 @@ from mslice.models.workspacemanager.workspace_provider import (get_workspace_han
                                                                delete_workspace, rename_workspace)
 from mslice.models.workspacemanager.workspace_algorithms import processEfixed
 from mslice.util.mantid.mantid_algorithms import ConvertToMD, CloneWorkspace, CreateSimulationWorkspace
-
+from mslice.widgets.workspacemanager.command import Command
 from mantid.simpleapi import AddSampleLog
+from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
+
 
 class MantidWorkspaceProviderTest(unittest.TestCase):
 
@@ -66,6 +69,48 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         new_ws = get_workspace_handle('newname')
         self.assertFalse(new_ws.ef_defined)
         self.assertEqual(new_ws.limits['DeltaE'], [0, 2, 1])
+
+    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    @patch('mslice.models.workspacemanager.workspace_provider.get_visible_workspace_names')
+    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
+        # name on call to get_workspace_new_name
+        old_workspace_name = 'file1'
+        new_workspace_name = 'new_name'
+        self.view.get_workspace_selected = mock.Mock(return_value=[old_workspace_name])
+        self.view.get_workspace_new_name = mock.Mock(return_value=new_workspace_name)
+        self.view.display_loaded_workspaces = mock.Mock()
+        get_ws_names_mock.return_value = ['file1', 'file2', 'file3']
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.get_workspace_new_name.assert_called_once_with()
+        rename_ws_mock.assert_called_once_with('file1', 'new_name')
+        self.view.display_loaded_workspaces.assert_called_once()
+
+    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
+        selected_workspaces = ['ws1', 'ws2']
+        self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.error_select_only_one_workspace.assert_called_once_with()
+        rename_ws_mock.assert_not_called()
+
+    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
+    def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
+        self.view.get_workspace_selected = mock.Mock(return_value=[])
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.error_select_one_workspace.assert_called_once_with()
+        rename_ws_mock.assert_not_called()
 
     def test_propagate_properties(self):
         ws_2 = CreateSimulationWorkspace(OutputWorkspace='test_ws_2', Instrument='MAR', BinParams=[-1, 1, 20],

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
-import mock
 from mock import patch
 import unittest
 from mslice.models.workspacemanager.workspace_algorithms import (subtract, add_workspace_runs, combine_workspace,
@@ -9,9 +8,8 @@ from mslice.models.workspacemanager.workspace_provider import (get_workspace_han
                                                                delete_workspace, rename_workspace)
 from mslice.models.workspacemanager.workspace_algorithms import processEfixed
 from mslice.util.mantid.mantid_algorithms import ConvertToMD, CloneWorkspace, CreateSimulationWorkspace
-from mslice.widgets.workspacemanager.command import Command
+
 from mantid.simpleapi import AddSampleLog
-from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 
 
 class MantidWorkspaceProviderTest(unittest.TestCase):
@@ -69,48 +67,6 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         new_ws = get_workspace_handle('newname')
         self.assertFalse(new_ws.ef_defined)
         self.assertEqual(new_ws.limits['DeltaE'], [0, 2, 1])
-
-    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
-    @patch('mslice.models.workspacemanager.workspace_provider.get_visible_workspace_names')
-    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
-        # name on call to get_workspace_new_name
-        old_workspace_name = 'file1'
-        new_workspace_name = 'new_name'
-        self.view.get_workspace_selected = mock.Mock(return_value=[old_workspace_name])
-        self.view.get_workspace_new_name = mock.Mock(return_value=new_workspace_name)
-        self.view.display_loaded_workspaces = mock.Mock()
-        get_ws_names_mock.return_value = ['file1', 'file2', 'file3']
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.get_workspace_new_name.assert_called_once_with()
-        rename_ws_mock.assert_called_once_with('file1', 'new_name')
-        self.view.display_loaded_workspaces.assert_called_once()
-
-    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
-    def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
-        selected_workspaces = ['ws1', 'ws2']
-        self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.error_select_only_one_workspace.assert_called_once_with()
-        rename_ws_mock.assert_not_called()
-
-    @patch('mslice.models.workspacemanager.workspace_provider.rename_workspace')
-    def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
-        self.view.get_workspace_selected = mock.Mock(return_value=[])
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.error_select_one_workspace.assert_called_once_with()
-        rename_ws_mock.assert_not_called()
 
     def test_propagate_properties(self):
         ws_2 = CreateSimulationWorkspace(OutputWorkspace='test_ws_2', Instrument='MAR', BinParams=[-1, 1, 20],

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -49,48 +49,6 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         workspace_presenter = WorkspaceManagerPresenter(self.view)
         self.assertRaises(AssertionError, workspace_presenter.register_master, 3)
 
-    @patch('mslice.presenters.workspace_manager_presenter._rename_workspace')
-    @patch('mslice.presenters.workspace_manager_presenter.get_visible_workspace_names')
-    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
-        # name on call to get_workspace_new_name
-        old_workspace_name = 'file1'
-        new_workspace_name = 'new_name'
-        self.view.get_workspace_selected = mock.Mock(return_value=[old_workspace_name])
-        self.view.get_workspace_new_name = mock.Mock(return_value=new_workspace_name)
-        self.view.display_loaded_workspaces = mock.Mock()
-        get_ws_names_mock.return_value = ['file1', 'file2', 'file3']
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.get_workspace_new_name.assert_called_once_with()
-        rename_ws_mock.assert_called_once_with('file1', 'new_name')
-        self.view.display_loaded_workspaces.assert_called_once()
-
-    @patch('mslice.presenters.workspace_manager_presenter._rename_workspace')
-    def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
-        selected_workspaces = ['ws1', 'ws2']
-        self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.error_select_only_one_workspace.assert_called_once_with()
-        rename_ws_mock.assert_not_called()
-
-    @patch('mslice.presenters.workspace_manager_presenter._rename_workspace')
-    def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
-        self.view.get_workspace_selected = mock.Mock(return_value=[])
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.error_select_one_workspace.assert_called_once_with()
-        rename_ws_mock.assert_not_called()
-
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
     def test_save_workspace(self, save_ws_mock, save_dir_mock):

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -49,48 +49,6 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         workspace_presenter = WorkspaceManagerPresenter(self.view)
         self.assertRaises(AssertionError, workspace_presenter.register_master, 3)
 
-    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
-    @patch('mslice.presenters.workspace_manager_presenter.get_visible_workspace_names')
-    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
-        # name on call to get_workspace_new_name
-        old_workspace_name = 'file1'
-        new_workspace_name = 'new_name'
-        self.view.get_workspace_selected = mock.Mock(return_value=[old_workspace_name])
-        self.view.get_workspace_new_name = mock.Mock(return_value=new_workspace_name)
-        self.view.display_loaded_workspaces = mock.Mock()
-        get_ws_names_mock.return_value = ['file1', 'file2', 'file3']
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.get_workspace_new_name.assert_called_once_with()
-        rename_ws_mock.assert_called_once_with('file1', 'new_name')
-        self.view.display_loaded_workspaces.assert_called_once()
-
-    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
-    def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
-        selected_workspaces = ['ws1', 'ws2']
-        self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.error_select_only_one_workspace.assert_called_once_with()
-        rename_ws_mock.assert_not_called()
-
-    @patch('mslice.presenters.workspace_manager_presenter.rename_workspace')
-    def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
-        self.presenter = WorkspaceManagerPresenter(self.view)
-        # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
-        self.view.get_workspace_selected = mock.Mock(return_value=[])
-
-        self.presenter.notify(Command.RenameWorkspace)
-        self.view.get_workspace_selected.assert_called_once_with()
-        self.view.error_select_one_workspace.assert_called_once_with()
-        rename_ws_mock.assert_not_called()
-
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
     def test_save_workspace(self, save_ws_mock, save_dir_mock):

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -49,6 +49,48 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         workspace_presenter = WorkspaceManagerPresenter(self.view)
         self.assertRaises(AssertionError, workspace_presenter.register_master, 3)
 
+    @patch('mslice.presenters.workspace_manager_presenter._rename_workspace')
+    @patch('mslice.presenters.workspace_manager_presenter.get_visible_workspace_names')
+    def test_rename_workspace(self, get_ws_names_mock, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that will return a single selected workspace on call to get_workspace_selected and supply a
+        # name on call to get_workspace_new_name
+        old_workspace_name = 'file1'
+        new_workspace_name = 'new_name'
+        self.view.get_workspace_selected = mock.Mock(return_value=[old_workspace_name])
+        self.view.get_workspace_new_name = mock.Mock(return_value=new_workspace_name)
+        self.view.display_loaded_workspaces = mock.Mock()
+        get_ws_names_mock.return_value = ['file1', 'file2', 'file3']
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.get_workspace_new_name.assert_called_once_with()
+        rename_ws_mock.assert_called_once_with('file1', 'new_name')
+        self.view.display_loaded_workspaces.assert_called_once()
+
+    @patch('mslice.presenters.workspace_manager_presenter._rename_workspace')
+    def test_rename_workspace_multiple_workspace_selected_prompt_user(self, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that reports multiple selected workspaces on calls to get_workspace_selected
+        selected_workspaces = ['ws1', 'ws2']
+        self.view.get_workspace_selected = mock.Mock(return_value=selected_workspaces)
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.error_select_only_one_workspace.assert_called_once_with()
+        rename_ws_mock.assert_not_called()
+
+    @patch('mslice.presenters.workspace_manager_presenter._rename_workspace')
+    def test_rename_workspace_non_selected_prompt_user(self, rename_ws_mock):
+        self.presenter = WorkspaceManagerPresenter(self.view)
+        # Create a view that reports that no workspaces are selected on calls to get_workspace_selected
+        self.view.get_workspace_selected = mock.Mock(return_value=[])
+
+        self.presenter.notify(Command.RenameWorkspace)
+        self.view.get_workspace_selected.assert_called_once_with()
+        self.view.error_select_one_workspace.assert_called_once_with()
+        rename_ws_mock.assert_not_called()
+
     @patch('mslice.presenters.workspace_manager_presenter.get_save_directory')
     @patch('mslice.presenters.workspace_manager_presenter.save_workspaces')
     def test_save_workspace(self, save_ws_mock, save_dir_mock):


### PR DESCRIPTION
Description of work.
The rename_workspace tests were moved to the workspace_provider_test.py file as they are now implemented there.
**To test:**

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #362 .
