### PR TITLE
Cuts and slices made to be repositioned with respect to the window center

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -103,7 +103,7 @@ class MainWindow(MainView, QMainWindow):
         if tab_to_show:
             self.tabWidget_2.setCurrentIndex(tab_to_show[0])
             for tab_index in tab_to_show:
-                    self.tabWidget_2.setTabEnabled(tab_index, True)
+                self.tabWidget_2.setTabEnabled(tab_index, True)
         else:
             self.tabWidget_2.hide()
 

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -4,15 +4,13 @@ import weakref
 import six
 from mslice.util.qt.QtCore import Qt
 from mslice.util.qt import QtCore, QtGui, QtWidgets
-from mslice.util.qt.qapp import create_qapp_if_required
-
+from mslice.util.qt.qapp import create_qapp_if_required, QAppThreadCall
 from mslice.models.workspacemanager.file_io import get_save_directory
 from mslice.models.workspacemanager.workspace_algorithms import save_workspaces
 from mslice.plotting.plot_window.plot_window import PlotWindow
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.cut_plot import CutPlot
 import mslice.plotting.pyplot as plt
-from mslice.util.qt.qapp import QAppThreadCall
 
 
 class PlotFigureManagerQT(QtCore.QObject):
@@ -87,14 +85,14 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def add_slice_plot(self, slice_plotter_presenter, workspace):
         if self._plot_handler is None:
-            self.move_window(-self.window.width() / 2, 0)
+            self.move_window(self.window.width() * 1.05, self.window.height() / 2)
         else:
             self._plot_handler.disconnect(self.window)
         self._plot_handler = SlicePlot(self, slice_plotter_presenter, workspace)
 
     def add_cut_plot(self, cut_plotter_presenter, workspace):
         if self._plot_handler is None:
-            self.move_window(self.window.width() / 2, 0)
+            self.move_window(self.window.width() * -0.05, self.window.height() / 2)
         else:
             self._plot_handler.disconnect(self.window)
         self._plot_handler = CutPlot(self, cut_plotter_presenter, workspace)
@@ -194,8 +192,8 @@ class PlotFigureManagerQT(QtCore.QObject):
             self.canvas.figure.gca().grid(True, axis='y')
 
     def move_window(self, x, y):
-        window = self.window
-        window.move(window.pos().x() + x, window.pos().y() + y)
+        center = QtWidgets.QDesktopWidget().screenGeometry().center()
+        self.window.move(center.x() - x, center.y() - y)
 
     def get_window_title(self):
         return six.text_type(self.window.windowTitle())

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -85,6 +85,8 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def add_slice_plot(self, slice_plotter_presenter, workspace):
         if self._plot_handler is None:
+            # Move the top right corner of all slice plot windows to the left of the screen centre by 1.05
+            # the window width and above the screen center by half the window height
             self.move_window(self.window.width() * 1.05, self.window.height() / 2)
         else:
             self._plot_handler.disconnect(self.window)
@@ -92,6 +94,8 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def add_cut_plot(self, cut_plotter_presenter, workspace):
         if self._plot_handler is None:
+            # Move the top right corner of all cut plot windows to the left of the screen centre by 0.05
+            # the window width and above the screen center by half the window height
             self.move_window(self.window.width() * -0.05, self.window.height() / 2)
         else:
             self._plot_handler.disconnect(self.window)

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -86,7 +86,8 @@ class PlotFigureManagerQT(QtCore.QObject):
     def add_slice_plot(self, slice_plotter_presenter, workspace):
         if self._plot_handler is None:
             # Move the top right corner of all slice plot windows to the left of the screen centre by 1.05
-            # the window width and above the screen center by half the window height
+            # the window width and above the screen center by half the window height to prevent cuts/interactive cuts
+            # and slices from overlapping
             self.move_window(self.window.width() * 1.05, self.window.height() / 2)
         else:
             self._plot_handler.disconnect(self.window)
@@ -95,7 +96,8 @@ class PlotFigureManagerQT(QtCore.QObject):
     def add_cut_plot(self, cut_plotter_presenter, workspace):
         if self._plot_handler is None:
             # Move the top right corner of all cut plot windows to the left of the screen centre by 0.05
-            # the window width and above the screen center by half the window height
+            # the window width and above the screen center by half the window height to prevent cuts/interactive cuts
+            # and slices from overlapping
             self.move_window(self.window.width() * -0.05, self.window.height() / 2)
         else:
             self._plot_handler.disconnect(self.window)


### PR DESCRIPTION
Description of work.
The move window command now uses the screen centre to fix the position of cuts and slices
**To test:**
Open Mslice and plot a cut or slice. The windows open near the centre of the screen.
<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #418 .
