### PR TITLE
Script generations now accounts for multiple workspaces used in cuts

### DIFF
--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -89,7 +89,7 @@ def GenerateScript(InputWorkspace, filename):
     _check_workspace_name(InputWorkspace)
     workspace_name = get_workspace_handle(InputWorkspace).name[2:]
     plot_handler = GlobalFigureManager.get_active_figure().plot_handler
-    generate_script(ws_name=workspace_name, plot_handler=plot_handler, filename=filename)
+    generate_script(ws_name=workspace_name, filename=filename, plot_handler=plot_handler)
 
 
 def MakeProjection(InputWorkspace, Axis1, Axis2, Units='meV'):
@@ -162,7 +162,7 @@ def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False):
 
     # Create the cut for use by the plot window in a generated script
     if not is_gui():
-        _update_cache(get_cut_plotter_presenter(), CutAxis, IntegrationAxis, NormToOne)
+        _update_cache(get_cut_plotter_presenter(), workspace.name, CutAxis, IntegrationAxis, NormToOne)
 
     return cut
 

--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -38,26 +38,31 @@ _intensity_to_workspace = {
 }
 
 
-def _update_cache(cut_presenter, CutAxis, IntegrationAxis, NormToOne):
+def _update_cache(cut_presenter, ws_name, CutAxis, IntegrationAxis, NormToOne):
     """Creates a list of all cuts used to create a particular cut. This is required when plot over is used."""
     cut_list = cut_presenter._cut_cache_list
+    cut_cache = cut_presenter._cut_cache
     int_axis = Axis(*IntegrationAxis.split(','))
     cut_axis = Axis(*CutAxis.split(','))
     width = None if int_axis.end - int_axis.start == 0 else str(int_axis.end - int_axis.start)
     if len(cut_list) == 0:
         cut = Cut(cut_axis, int_axis, None, None, NormToOne, width)
+        cut.workspace_name = ws_name
         cut_list.append(cut)
+        cut_cache[ws_name] = cut
     else:
         for cut in cut_list:
-            if str(cut.cut_axis) == str(cut_axis) and cut.width == float(width) and cut.norm_to_one == NormToOne:
+            if str(cut.cut_axis) == str(cut_axis) and cut.width == float(width) and cut.norm_to_one == NormToOne\
+                    and cut.workspace_name == ws_name:
                 if cut.integration_axis.start > int_axis.start:
                     cut.integration_axis = int_axis.start
                 if cut.integration_axis.end < int_axis.end:
                     cut.integration_axis.end = int_axis.end
-            else:
-                cut = Cut(cut_axis, int_axis, None, None, NormToOne, width)
-                cut_list.append(cut)
-
+                return
+    cut = Cut(cut_axis, int_axis, None, None, NormToOne, width)
+    cut.workspace_name = ws_name
+    cut_list.append(cut)
+    cut_cache[ws_name] = cut
 
 def _update_legend():
     plot_handler = GlobalFigureManager.get_active_figure().plot_handler

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -1,4 +1,3 @@
-
 class Cut(object):
     """Groups parameters needed to cut and validates them"""
 
@@ -14,10 +13,19 @@ class Cut(object):
         self.start = integration_axis.start
         self.end = integration_axis.end
         self.width = width
+        self.workspace_name = 'None'
 
     def reset_integration_axis(self, start, end):
         self.integration_axis.start = start
         self.integration_axis.end = end
+
+    @property
+    def workspace_name(self):
+        return self._workspace_name
+
+    @workspace_name.setter
+    def workspace_name(self, ws_name):
+        self._workspace_name = ws_name.replace(".", "_")
 
     @property
     def cut_axis(self):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -59,7 +59,7 @@ class CutPlot(IPlot):
         plot_window.action_save_cut.triggered.connect(self.save_icut)
         plot_window.action_flip_axis.setVisible(False)
         plot_window.action_flip_axis.triggered.connect(self.flip_icut)
-        plot_window.action_gen_history.triggered.connect(partial(generate_script, self.ws_name, self, None,
+        plot_window.action_gen_history.triggered.connect(partial(generate_script, self.ws_name, None, self,
                                                                  self.plot_window))
 
     def disconnect(self, plot_window):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -108,7 +108,7 @@ class SlicePlot(IPlot):
         plot_window.action_tantalum.triggered.connect(
             partial(self.toggle_overplot_line, 'Tantalum', False))
         plot_window.action_cif_file.triggered.connect(partial(self.cif_file_powder_line))
-        plot_window.action_gen_history.triggered.connect(partial(generate_script, self.ws_name, self, None,
+        plot_window.action_gen_history.triggered.connect(partial(generate_script, self.ws_name, None, self,
                                                                  self.plot_window))
 
     def disconnect(self, plot_window):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -16,6 +16,7 @@ class CutPlotterPresenter(PresenterUtility):
 
     def run_cut(self, workspace, cut, plot_over=False, save_only=False):
         workspace = get_workspace_handle(workspace)
+        cut.workspace_name = workspace.name
         self._cut_cache[workspace.name] = cut
 
         # If plot over is True you want to save all plotted cuts for use by the cli
@@ -31,6 +32,13 @@ class CutPlotterPresenter(PresenterUtility):
             self.save_cut_to_workspace(workspace, cut)
         else:
             self._plot_cut(workspace, cut, plot_over)
+
+    # def more_than_one_workspace_used_in_plot(self):
+    #     last_cut = self._cut_cache_list[0]
+    #     for cut in self._cut_cache_list[1:]:
+    #         if last_cut.workspace_name != cut.workspace_name:
+    #             return True
+    #     return False
 
     def _plot_cut(self, workspace, cut, plot_over, store=True, update_main=True):
         cut_axis = cut.cut_axis

--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -55,7 +55,7 @@ class CutWidgetPresenter(PresenterUtility):
             self._cut_view.display_error(str(e))
             return
         for workspace in selected_workspaces:
-            self._cut_plotter_presenter.run_cut(workspace, params, plot_over=plot_over, save_only=save_only)
+            self._cut_plotter_presenter.run_cut(workspace, Cut(*params), plot_over=plot_over, save_only=save_only)
             plot_over = True  # The first plot will respect which button the user pressed. The rest will over plot
 
     def _parse_step(self):
@@ -84,7 +84,7 @@ class CutWidgetPresenter(PresenterUtility):
 
         norm_to_one = bool(self._cut_view.get_intensity_is_norm_to_one())
         width = self._cut_view.get_integration_width()
-        return Cut(cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width)
+        return cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width
 
     def _set_minimum_step(self, workspace, axis):
         """Gets axes limits and then sets the minimumStep dictionary with those values"""

--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -2,9 +2,10 @@ from mantid.simpleapi import GeneratePythonScript
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.util.qt import QtWidgets
 from mslice.scripting.helperfunctions import add_plot_statements, cleanup
+from mslice.app.presenters import get_cut_plotter_presenter
 
 
-def generate_script(ws_name, plot_handler, filename=None, window=None):
+def generate_script(ws_name, filename=None, plot_handler=None, window=None):
     if filename is None:
         path = QtWidgets.QFileDialog.getSaveFileName(window, 'Save File')
         if not path:
@@ -13,9 +14,23 @@ def generate_script(ws_name, plot_handler, filename=None, window=None):
     else:
         filename = filename + '{}'.format('' if filename.endswith('.py') else '.py')
 
-    ws = get_workspace_handle(ws_name).raw_ws
-    script_lines = cleanup(GeneratePythonScript(ws).split('\n'))
+    script_lines = preprocess_lines(ws_name, plot_handler)
     script_lines = add_plot_statements(script_lines, plot_handler)
-
     with open(filename, 'w') as generated_script:
         generated_script.writelines(script_lines)
+
+
+def preprocess_lines(ws_name, plot_handler):
+    from mslice.plotting.plot_window.cut_plot import CutPlot
+
+    if isinstance(plot_handler, CutPlot) and len(get_cut_plotter_presenter()._cut_cache) > 1:
+        script_lines = []
+        for workspace_name in get_cut_plotter_presenter()._cut_cache:
+            ws = get_workspace_handle(workspace_name).raw_ws
+            script_lines += ["\nws_{} = mc.".format(workspace_name.replace(".", "_"))] + cleanup(
+                GeneratePythonScript(ws).split('\n'))
+    else:
+        ws = get_workspace_handle(ws_name).raw_ws
+        script_lines = ["\nws = mc."] + cleanup(GeneratePythonScript(ws).split('\n'))
+
+    return script_lines


### PR DESCRIPTION
Description of work.
Modified python script generation to account for multiple cuts from different workspaces.

**To test:**
Open Mslice. Load multiple workspaces. Using plot over, plot multiple cuts onto the same plot window. In the file options, click generate script.
<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #423 .
