### PR TITLE
Put mslice-wrapped Mantid algorithms into mslice.cli namespace

### DIFF
--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -20,6 +20,11 @@ from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.app.presenters import cli_slice_plotter_presenter
 from mslice.app.presenters import cli_cut_plotter_presenter
 
+from mslice.util.mantid import in_mantidplot
+
+if in_mantidplot():
+    from mslice.util.mantid.mantid_algorithms import *
+
 # -----------------------------------------------------------------------------
 # Command functions
 # -----------------------------------------------------------------------------

--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -23,7 +23,7 @@ from mslice.app.presenters import cli_cut_plotter_presenter
 from mslice.util.mantid import in_mantidplot
 
 if in_mantidplot():
-    from mslice.util.mantid.mantid_algorithms import *
+    from mslice.util.mantid.mantid_algorithms import *  # noqa: F401
 
 # -----------------------------------------------------------------------------
 # Command functions

--- a/mslice/widgets/ipythonconsole/ipython_widget.py
+++ b/mslice/widgets/ipythonconsole/ipython_widget.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division,
                         print_function)
 
 import warnings
+from mslice.util.mantid import in_mantidplot
 
 # Ignore Jupyter/IPython deprecation warnings that we can't do anything about
 warnings.filterwarnings('ignore', category=DeprecationWarning, module='IPython.*')
@@ -37,5 +38,8 @@ class IPythonWidget(RichIPythonWidget):
 
         self.kernel_manager = kernel_manager
         self.kernel_client = kernel_client
-        self.execute('from mslice.util.mantid.mantid_algorithms import *', hidden=True)
-        self.execute('from mslice.cli import *', hidden=True)
+        if not in_mantidplot():
+            self.execute('from mslice.util.mantid.mantid_algorithms import *', hidden=True)
+            self.execute('from mslice.cli import *', hidden=True)
+        else:
+            self.execute('import mslice.cli as mc')


### PR DESCRIPTION
Changes the IPython console initialisation to not do `import *` on MSlice-wrapped algorithms if we are running in MantidPlot as this will overwrite the `simpleapi` versions of the algorithms in the base namespace (for all Python sessions, including the MantidPlot default IPython console and also the script windows). Instead if running in MantidPlot we import the MSlice-wrapped algorithms into `mslice.cli` and alias it to `mc`.

**To test:**

- Run MSlice in MantidPlot (copy the `mslice/mslice` folder to `<MantidInstall>/scripts/ExternalInterfaces`). 
- Start the MSlice interface.
- In a MantidPlot Python session load a workspace using e.g. `Load('MAR21335_Ei60.00meV.nxs', OutputWorkspace='ws')` - this should now work with MSlice master (because the MSlice `Load` now accepts `OutputWorkspace`) but no workspace (should be named `ws`) will show up in the ADS (because MSlice hides it). You could also run it with `Load('MAR21335_Ei60.00meV.nxs', OutputWorkspace='ws', StoreInADS=True)` which will fail with a `TypeError` in MSlice master.
- Check that with this PR changes, the above actions work as expected (`StoreInADS` does not give an error, and the workspace appears in the ADS). 

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #416 .
