### PR TITLE
Dataloader refresh

### DIFF
--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -49,6 +49,7 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self.btnhome.clicked.connect(self.go_to_home)
         self.btnload.clicked.connect(partial(self.load, False))
         self.btnmerge.clicked.connect(partial(self.load, True))
+        self.btnrefresh.clicked.connect(self.reload_model)
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Backspace:
@@ -74,6 +75,20 @@ class DataLoaderWidget(QWidget):  # and some view interface
             self._update_from_path()
         else:
             self._display_error("Invalid file path")
+
+    def reload_model(self):
+        # Redefines the QFileSystemModel - hopefully to refresh and changes not caught because of filesystem issues
+        self.file_system = QFileSystemModel()
+        self.root_path = self.directory.absolutePath()
+        self.file_system.setRootPath(self.root_path)
+        self.file_system.setNameFilters(MSLICE_EXTENSIONS)
+        self.file_system.setNameFilterDisables(False)
+        self.table_view.setModel(self.file_system)
+        self.table_view.setRootIndex(self.file_system.index(self.root_path))
+        self.table_view.setColumnWidth(0, 320)
+        self.table_view.setColumnWidth(1, 0)
+        self.table_view.setColumnWidth(3, 140)
+        self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
 
     def _update_from_path(self):
         new_path = self.directory.absolutePath()

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -23,20 +23,9 @@ class DataLoaderWidget(QWidget):  # and some view interface
         QWidget.__init__(self, parent)
         load_ui(__file__, 'dataloader.ui', self)
 
-        self.file_system = QFileSystemModel()
         self.directory = QDir(os.path.expanduser('~'))
-        path = self.directory.absolutePath()
-        self.root_path = path
-        self.file_system.setRootPath(path)
-        self.file_system.setNameFilters(MSLICE_EXTENSIONS)
-        self.file_system.setNameFilterDisables(False)
-        self.table_view.setModel(self.file_system)
-        self.table_view.setRootIndex(self.file_system.index(path))
-        self.txtpath.setText(path)
-        self.table_view.setColumnWidth(0, 320)
-        self.table_view.setColumnWidth(1, 0)
-        self.table_view.setColumnWidth(3, 140)
-        self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.reload_model()
+        self.txtpath.setText(self.directory.absolutePath())
         self._presenter = DataLoaderPresenter(self)
         self.btnload.setEnabled(False)
         self.btnmerge.setEnabled(False)
@@ -77,7 +66,7 @@ class DataLoaderWidget(QWidget):  # and some view interface
             self._display_error("Invalid file path")
 
     def reload_model(self):
-        # Redefines the QFileSystemModel - hopefully to refresh and changes not caught because of filesystem issues
+        # Redefines the QFileSystemModel - hopefully to refresh any changes not caught because of filesystem issues
         self.file_system = QFileSystemModel()
         self.root_path = self.directory.absolutePath()
         self.file_system.setRootPath(self.root_path)
@@ -85,9 +74,10 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self.file_system.setNameFilterDisables(False)
         self.table_view.setModel(self.file_system)
         self.table_view.setRootIndex(self.file_system.index(self.root_path))
-        self.table_view.setColumnWidth(0, 320)
-        self.table_view.setColumnWidth(1, 0)
-        self.table_view.setColumnWidth(3, 140)
+        self.table_view.setColumnWidth(0, 320)    # Make name wide
+        self.table_view.setColumnHidden(1, True)  # Hide size column
+        self.table_view.setColumnHidden(2, True)  # Hide type column
+        self.table_view.setColumnWidth(3, 140)    # Show date modified
         self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
 
     def _update_from_path(self):

--- a/mslice/widgets/dataloader/dataloader.ui
+++ b/mslice/widgets/dataloader/dataloader.ui
@@ -72,6 +72,13 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
          <item>
+          <widget class="QPushButton" name="btnrefresh">
+           <property name="text">
+            <string>Refresh</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QWidget" name="widget_2" native="true">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>


### PR DESCRIPTION
Adds a button to the `Dataloader` widget to re-initialise the `QFileSystemModel` used in the files/directories table. The model is supposed to watch for changes to the filesystem (new files created / existing files removed / modified) and automatically update the `QTableView` showing the files but for some filesystems this sometimes does not work.

In particular there seems to be a problem with the network file system used at SNS where if a file is created by another user (e.g. by the autoreduce system) it sometimes does not show up in the `Dataloader` or in certain mounts where even new files created after MSlice is started by the current user is not seen - this is an intermittent problem and the exact underlying cause is still not known but seems to be OS related (it was only observed in RHEL 7.6 with Qt 4.8.5) but not in all cases.

This work-around resets the model forcing it to look over the filesystem again to repopulate the table view, and appears to solve the problem.

**To test:**

This testing probably needs to be done on the SNS analysis cluster because the problem has not been reproduced elsewhere.

Go to a folder where the `Dataloader` was previously observed to not be updating as new files are created / current files deleted.

Create a new file and check that it does not appear in the `Dataloader`. Click `Refresh` and check that it now appears. Remove the file, and check that the `Dataloader` still shows it. Click `Refresh` again and check that it is also removed from the list.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #431 .
