### PR TITLE
Fix plotting saved cuts bug

### DIFF
--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -68,11 +68,12 @@ class CutPlotterPresenter(PresenterUtility):
             self.plot_cut_from_workspace(workspace_name, plot_over)
             plot_over = True  # plot over if multiple workspaces selected
 
-    def plot_cut_from_workspace(self, workspace, intensity_range=None, plot_over=False):
+    def plot_cut_from_workspace(self, workspace, plot_over=False, intensity_range=None):
 
         workspace = get_workspace_handle(workspace)
         lines = plot_cut_impl(workspace, workspace.raw_ws.getDimension(0).getUnits(),
                               intensity_range=intensity_range, plot_over=plot_over)
+        self.set_is_icut(workspace.name, False)
         return lines
 
     def plot_interactive_cut(self, workspace, cut_axis, integration_axis, store):


### PR DESCRIPTION
This PR puts in some omitted lines which prevent the plotting of a saved cuts

**To test:**

1. Load a workspace and make a cut or several cuts (e.g. with the `width` parameter).
2. Click on the `MDHisto` workspace and select one of the saved cuts - click `Plot` and check that it plots ok (and also check that if no cut plot window exists that a new cut plot window appears). Click `Plot Over` and check that another curve is overplotted.
3. In the plot window select "File->Generate Script" and check that the generate python file accurately reproduces the plot.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #434
