### PR TITLE
Minor bug fixes

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -3,7 +3,9 @@ and entry points.
 """
 import mslice.util.mantid.init_mantid # noqa: F401
 from mslice.util.mantid import in_mantidplot
+from mslice.util.qt import QT_VERSION
 from mslice.util.qt.qapp import create_qapp_if_required
+
 
 # Module-level reference to keep main window alive after show_gui has returned
 MAIN_WINDOW = None
@@ -18,6 +20,8 @@ def main():
     """Start the application.
     """
     qapp_ref = create_qapp_if_required()
+    import matplotlib as mpl
+    mpl.use('Qt{}Agg'.format(QT_VERSION[0]))
     show_gui()
     return qapp_ref.exec_()
 

--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -78,13 +78,20 @@ def Load(Filename, OutputWorkspace=None):
 
     if not isinstance(Filename, string_types):
         raise RuntimeError('path given to load must be a string')
+    merge = False
     if not ospath.exists(Filename):
-        raise RuntimeError('could not find the path %s' % Filename)
+        if all([ospath.exists(f) for f in Filename.split('+')]):
+            merge = True
+        else:
+            raise RuntimeError('could not find the path %s' % Filename)
 
-    get_dataloader_presenter().load_workspace([Filename])
+    get_dataloader_presenter().load_workspace([Filename], merge)
     name = ospath.splitext(ospath.basename(Filename))[0]
     if OutputWorkspace is not None:
-        name = rename_workspace(workspace=ospath.splitext(ospath.basename(Filename))[0], new_name=OutputWorkspace).name
+        old_name = ospath.splitext(ospath.basename(Filename))[0]
+        if merge:
+            old_name = old_name + '_merged'
+        name = rename_workspace(workspace=old_name, new_name=OutputWorkspace).name
 
     return get_workspace_handle(name)
 

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -68,11 +68,23 @@ class CommandLineTest(unittest.TestCase):
     @mock.patch('mslice.app.presenters.get_dataloader_presenter')
     @mock.patch('mslice.cli._mslice_commands.ospath.exists')
     def test_load(self, ospath_mock, get_dlp, get_workspace_mock):
-        ospath_mock.exists.return_value = True
+        ospath_mock.return_value = True
         path = 'made_up_path'
         Load(path)
 
-        get_dlp().load_workspace.assert_called_once_with([path])
+        get_dlp().load_workspace.assert_called_once_with([path], False)
+        get_workspace_mock.assert_called_with(path)
+
+    @mock.patch('mslice.cli._mslice_commands.get_workspace_handle')
+    @mock.patch('mslice.app.presenters.get_dataloader_presenter')
+    @mock.patch('mslice.cli._mslice_commands.ospath')
+    def test_load_merge(self, ospath_mock, get_dlp, get_workspace_mock):
+        path = 'made_up_path+another_made_up_path'
+        ospath_mock.exists.side_effect = [False, True, True]
+        ospath_mock.splitext.return_value = [path]
+        Load(path)
+
+        get_dlp().load_workspace.assert_called_once_with([path], True)
         get_workspace_mock.assert_called_with(path)
 
     @mock.patch('mslice.app.presenters.get_powder_presenter')

--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -29,8 +29,10 @@ def wrap_algorithm(algorithm):
             result = wrap_workspace(result, output_name)
             if store:
                 add_workspace(result, output_name)
-                from mslice.app.presenters import get_slice_plotter_presenter
-                get_slice_plotter_presenter().update_displayed_workspaces()
+                from mslice.app import is_gui
+                if is_gui():
+                    from mslice.app.presenters import get_slice_plotter_presenter
+                    get_slice_plotter_presenter().update_displayed_workspaces()
         return result
     return alg_wrapper
 

--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -19,12 +19,18 @@ def wrap_algorithm(algorithm):
         if 'OutputWorkspace' in kwargs:
             output_name = kwargs['OutputWorkspace']
         store = kwargs.pop('store', True)
+        for ws in [k for k in kwargs.keys() if isinstance(kwargs[k], MsliceWorkspace)]:
+            if 'Input' not in ws and 'Output' not in ws:
+                kwargs[ws] = _name_or_wrapper_to_workspace(kwargs[ws])
+        args = tuple([_name_or_wrapper_to_workspace(arg) if isinstance(arg, MsliceWorkspace) else arg for arg in args])
 
         result = algorithm(*args, StoreInADS=False, **kwargs)
         if isinstance(result, Workspace):
             result = wrap_workspace(result, output_name)
             if store:
                 add_workspace(result, output_name)
+                from mslice.app.presenters import get_slice_plotter_presenter
+                get_slice_plotter_presenter().update_displayed_workspaces()
         return result
     return alg_wrapper
 

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -24,6 +24,7 @@ class DataLoaderWidget(QWidget):  # and some view interface
         load_ui(__file__, 'dataloader.ui', self)
 
         self.directory = QDir(os.path.expanduser('~'))
+        self._sort_column = 0
         self.reload_model()
         self.txtpath.setText(self.directory.absolutePath())
         self._presenter = DataLoaderPresenter(self)
@@ -79,6 +80,7 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self.table_view.setColumnHidden(2, True)  # Hide type column
         self.table_view.setColumnWidth(3, 140)    # Show date modified
         self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.sort_files(self._sort_column)
 
     def _update_from_path(self):
         new_path = self.directory.absolutePath()
@@ -101,6 +103,7 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self._presenter.load_workspace(self.get_selected_file_paths(), merge)
 
     def sort_files(self, column):
+        self._sort_column = column
         self.table_view.sortByColumn(column, column % 2)  # descending order for size/modified, ascending for name/type
 
     def go_to_home(self):

--- a/mslice/workspace/workspace_mixin.py
+++ b/mslice/workspace/workspace_mixin.py
@@ -112,6 +112,9 @@ class WorkspaceMixin(object):
     def __mul__(self, other):
         return self._binary_op(operator.mul, other)
 
+    def __div__(self, other):
+        return self._binary_op(operator.div, other)
+
     def __truediv__(self, other):
         return self._binary_op(operator.truediv, other)
 


### PR DESCRIPTION
This PR fixes some minor bugs identified during user beta-testing as reported in #439

**To test:**

1. Run the following script (the datafile is in the MSlice dropbox folder) and checks that it runs without errors and produces the following workspaces: `MAR22012_Ei10.00meV`, `MAR22017_Ei10.00meV`, `MAR22017_sum`, `MAR22017_sum2`,  and a slice plot.

```python
# Python Script Generated by Mslice on 2019-02-19 01:42:15
import mslice.cli as mc
import mslice.plotting.pyplot as plt
import mslice.util.mantid.mantid_algorithms as s
ws1 = mc.Load(Filename='MAR22012_Ei10.00meV.nxspe+MAR22013_Ei10.00meV.nxspe', OutputWorkspace='MAR22012_Ei10.00meV')
ws2 = mc.Load(Filename='MAR22017_Ei10.00meV.nxspe', OutputWorkspace='MAR22017_Ei10.00meV')
ws3 = s.Plus(ws1, ws2, OutputWorkspace='MAR22017_sum')
ws4 = s.Plus(LHSWorkspace=ws1, RHSWorkspace=ws2, OutputWorkspace='MAR22017_sum2')

ws3 = ws3 / 10

fig = plt.gcf()
ax = fig.add_subplot(111, projection="mslice")
slice_ws = mc.Slice(ws3, Axis1="|Q|,0.11216,4.68231,0.01914", Axis2="DeltaE,-7.0,9.7,0.1", NormToOne=False)

mesh = ax.pcolormesh(slice_ws, cmap="viridis")
mesh.set_clim(0.0, 50)
cb = plt.colorbar(mesh, ax=ax)
cb.set_label('Intensity (arb. units)', labelpad=20, rotation=270, picker=5)
ax.set_title('MAR22017_sum')
mc.Show()
```

2. In a particular folder in the `Dataloader` select a none default sorting option (e.g. not `Name`). Then click refresh. Confirm that the file order does not change.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #439
