### PR TITLE
Added energy units

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -12,6 +12,8 @@ from mslice.widgets.workspacemanager import TAB_2D, TAB_EVENT, TAB_HISTO, TAB_NO
 from mslice.widgets.workspacemanager.command import Command as ws_command
 from mslice.widgets.cut.command import Command as cut_command
 
+from functools import partial
+
 TAB_SLICE = 1
 TAB_CUT = 2
 TAB_POWDER = 0
@@ -79,8 +81,8 @@ class MainWindow(MainView, QMainWindow):
         self.wgtPowder.busy.connect(self.show_busy)
         self.data_loading.busy.connect(self.show_busy)
         self.action_quit.triggered.connect(self.close)
-        self.actionmeV.triggered.connect(self.set_meV_default)
-        self.actioncm.triggered.connect(self.set_cm_default)
+        self.actionmeV.triggered.connect(partial(self.set_energy_default, self.actionmeV, self.actioncm))
+        self.actioncm.triggered.connect(partial(self.set_energy_default, self.actioncm, self.actionmeV))
 
     def setup_save(self):
         menu = QMenu()
@@ -177,12 +179,12 @@ class MainWindow(MainView, QMainWindow):
             return
         QApplication.processEvents()
 
-    def set_meV_default(self):
-        self.actioncm.setChecked(False)
-        self.wgtCut.set_energy_units_default('meV')
-        self.wgtSlice.set_units_default('meV')
+    def get_energy_default(self):
+        return 'meV' if self.actionmeV.isChecked() else 'cm-1'
 
-    def set_cm_default(self):
-        self.actionmeV.setChecked(False)
-        self.wgtCut.set_energy_units_default('cm-1')
-        self.wgtSlice.set_units_default('cm-1')
+    def set_energy_default(self, action_trigger, action_other):
+        if action_trigger.isChecked():
+            action_other.setChecked(False)
+        else:
+            action_other.setChecked(True)
+        self._presenter.set_energy_default(self.get_energy_default())

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from mslice.util.qt.QtWidgets import QApplication, QMainWindow, QLabel, QMenu
 
+from mslice.models.units import EnergyUnits
 from mslice.presenters.cut_plotter_presenter import CutPlotterPresenter
 from mslice.presenters.main_presenter import MainPresenter
 from mslice.presenters.slice_plotter_presenter import SlicePlotterPresenter
@@ -11,6 +12,7 @@ from mslice.widgets.ipythonconsole.ipython_widget import IPythonWidget
 from mslice.widgets.workspacemanager import TAB_2D, TAB_EVENT, TAB_HISTO, TAB_NONPSD
 from mslice.widgets.workspacemanager.command import Command as ws_command
 from mslice.widgets.cut.command import Command as cut_command
+from mslice.plotting.plot_window.plot_window import add_action
 
 from functools import partial
 
@@ -81,8 +83,13 @@ class MainWindow(MainView, QMainWindow):
         self.wgtPowder.busy.connect(self.show_busy)
         self.data_loading.busy.connect(self.show_busy)
         self.action_quit.triggered.connect(self.close)
-        self.actionmeV.triggered.connect(partial(self.set_energy_default, self.actionmeV, self.actioncm))
-        self.actioncm.triggered.connect(partial(self.set_energy_default, self.actioncm, self.actionmeV))
+
+        self._en_default_actions = []
+        for e_unit in EnergyUnits.get_all_units():
+            action = add_action(self.menuDefault_Energy_Units, self, e_unit, checkable=True)
+            action.triggered.connect(partial(self.set_energy_default, action))
+            self._en_default_actions.append(action)
+        self._en_default_actions[0].setChecked(True)
 
     def setup_save(self):
         menu = QMenu()
@@ -180,11 +187,20 @@ class MainWindow(MainView, QMainWindow):
         QApplication.processEvents()
 
     def get_energy_default(self):
-        return 'meV' if self.actionmeV.isChecked() else 'cm-1'
+        return [action.text() for action in self._en_default_actions if action.isChecked()][0]
 
-    def set_energy_default(self, action_trigger, action_other):
-        if action_trigger.isChecked():
-            action_other.setChecked(False)
+    def set_energy_default(self, this_action):
+        if this_action.isChecked():
+            for action in self._en_default_actions:
+                # Only one unit can be set as default at a time
+                if action == this_action:
+                    action.setChecked(True)
+                else:
+                    action.setChecked(False)
         else:
-            action_other.setChecked(True)
+            # User unchecked this action - either go back to first or set another action as default
+            if this_action == self._en_default_actions[0]:
+                self._en_default_actions[1].setChecked(True)
+            else:
+                self._en_default_actions[0].setChecked(True)
         self._presenter.set_energy_default(self.get_energy_default())

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -79,6 +79,8 @@ class MainWindow(MainView, QMainWindow):
         self.wgtPowder.busy.connect(self.show_busy)
         self.data_loading.busy.connect(self.show_busy)
         self.action_quit.triggered.connect(self.close)
+        self.actionmeV.triggered.connect(self.set_meV_default)
+        self.actioncm.triggered.connect(self.set_cm_default)
 
     def setup_save(self):
         menu = QMenu()
@@ -174,3 +176,13 @@ class MainWindow(MainView, QMainWindow):
         else:
             return
         QApplication.processEvents()
+
+    def set_meV_default(self):
+        self.actioncm.setChecked(False)
+        self.wgtCut.set_energy_units_default('meV')
+        self.wgtSlice.set_units_default('meV')
+
+    def set_cm_default(self):
+        self.actionmeV.setChecked(False)
+        self.wgtCut.set_energy_units_default('cm-1')
+        self.wgtSlice.set_units_default('cm-1')

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -310,11 +310,44 @@
     </property>
     <addaction name="action_quit"/>
    </widget>
+   <widget class="QMenu" name="menuOptions">
+    <property name="title">
+     <string>Options</string>
+    </property>
+    <widget class="QMenu" name="menuDefault_Energy_Units">
+     <property name="title">
+      <string>Default Energy Units</string>
+     </property>
+     <addaction name="actionmeV"/>
+     <addaction name="actioncm"/>
+    </widget>
+    <addaction name="menuDefault_Energy_Units"/>
+   </widget>
    <addaction name="menuFile"/>
+   <addaction name="menuOptions"/>
   </widget>
   <action name="action_quit">
    <property name="text">
     <string>Quit</string>
+   </property>
+  </action>
+  <action name="actionmeV">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>meV</string>
+   </property>
+  </action>
+  <action name="actioncm">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>cm-1</string>
    </property>
   </action>
  </widget>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -318,8 +318,6 @@
      <property name="title">
       <string>Default Energy Units</string>
      </property>
-     <addaction name="actionmeV"/>
-     <addaction name="actioncm"/>
     </widget>
     <addaction name="menuDefault_Energy_Units"/>
    </widget>
@@ -329,25 +327,6 @@
   <action name="action_quit">
    <property name="text">
     <string>Quit</string>
-   </property>
-  </action>
-  <action name="actionmeV">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>meV</string>
-   </property>
-  </action>
-  <action name="actioncm">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>cm-1</string>
    </property>
   </action>
  </widget>

--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -133,6 +133,8 @@ def Slice(InputWorkspace, Axis1=None, Axis2=None, NormToOne=False):
             Either a string in format '<name>, <start>, <end>, <step_size>' e.g.
             'DeltaE,0,100,5'  or just the name e.g. 'DeltaE'. In that case, the
             start and end will default to the range in the data.
+            Optionally you can also specify the energy unit at the end e.g.
+            '<name>, <start>, <end>, <step>, cm-1'. Recognised energy units are 'meV' (default) and 'cm-1'
     :param NormToOne: if True the slice will be normalized to one.
     :return:
     """
@@ -158,6 +160,9 @@ def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False):
             'DeltaE,0,100,5' (step_size may be omitted for the integration axis)
             or just the name e.g. 'DeltaE'. In that case, the start and end will
             default to the full range of the data.
+            Optionally you can also specify the energy unit at the end e.g.
+            '<name>, <start>, <end>, <step>, cm-1', or '<name>, <start>, <end>, meV'
+            Recognised energy units are 'meV' (default) and 'cm-1'
     :param NormToOne: if True the cut will be normalized to one.
     :return:
     """

--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -97,21 +97,22 @@ def _get_overplot_key(element, rmm):
 
 def _string_to_axis(string):
     axis = string.split(',')
-    if len(axis) != 4:
-        raise ValueError('axis should be specified in format <name>,<start>,<end>,<step_size>')
-    return Axis(axis[0], axis[1], axis[2], axis[3])
+    if len(axis) != 4 and len(axis) != 5:
+        raise ValueError('axis should be specified in format <name>,<start>,<end>,<step_size>(,<e_unit>)')
+    return Axis(axis[0], axis[1], axis[2], axis[3]) if len(axis) == 4 else Axis(*axis)
 
 
 def _string_to_integration_axis(string):
     """Allows step to be omitted and set to default value"""
     axis_str = string.split(',')
     if len(axis_str) < 3:
-        raise ValueError('axis should be specified in format <name>,<start>,<end>')
-    valid_axis = Axis(axis_str[0], axis_str[1], axis_str[2], 0)
-    try:
-        valid_axis.step = axis_str[3]
-    except IndexError:
-        valid_axis.step = valid_axis.end - valid_axis.start
+        raise ValueError('axis should be specified in format <name>,<start>,<end>(,<step>,<e_unit>)')
+    elif len(axis_str) == 3:
+        valid_axis = Axis(axis_str[0], axis_str[1], axis_str[2], str(float(axis_str[2]) - float(axis_str[1])))
+    elif len(axis_str) == 4:
+        valid_axis = Axis(axis_str[0], axis_str[1], axis_str[2], axis_str[3])
+    else:
+        valid_axis = Axis(axis_str[0], axis_str[1], axis_str[2], axis_str[3], axis_str[4])
     return valid_axis
 
 

--- a/mslice/cli/plotfunctions.py
+++ b/mslice/cli/plotfunctions.py
@@ -8,7 +8,6 @@ from mslice.cli.helperfunctions import _check_workspace_type, _check_workspace_n
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.app import is_gui
 from mslice.util.mantid.mantid_algorithms import Transpose
-from mslice.models.workspacemanager.workspace_algorithms import get_comment
 from mslice.models.labels import get_display_name, CUT_INTENSITY_LABEL
 from mantid.plots import plotfunctions
 from mslice.views.slice_plotter import create_slice_figure
@@ -35,7 +34,6 @@ def errorbar(axes, workspace, *args, **kwargs):
 
     plot_over = kwargs.pop('plot_over', True)
     intensity_range = kwargs.pop('intensity_range', (None, None))
-    x_units = kwargs.pop('x_units', 'None')
     label = kwargs.pop('label', None)
     label = workspace.name if label is None else label
 
@@ -45,7 +43,7 @@ def errorbar(axes, workspace, *args, **kwargs):
     if cur_canvas.manager.window.action_toggle_legends.isChecked():
         leg = axes.legend(fontsize='medium')
         leg.draggable()
-    axes.set_xlabel(get_display_name(x_units, get_comment(workspace)), picker=CUT_PICKER_TOL_PTS)
+    axes.set_xlabel(get_display_name(workspace.axes[0]), picker=CUT_PICKER_TOL_PTS)
     axes.set_ylabel(CUT_INTENSITY_LABEL, picker=CUT_PICKER_TOL_PTS)
     if not plot_over:
         cur_canvas.set_window_title(workspace.name)
@@ -108,12 +106,11 @@ def pcolormesh(axes, workspace, *args, **kwargs):
     axes.set_title(workspace.name[2:], picker=SLICE_PICKER_TOL_PTS)
     x_axis = slice_cache.energy_axis if slice_cache.rotated else slice_cache.momentum_axis
     y_axis = slice_cache.momentum_axis if slice_cache.rotated else slice_cache.energy_axis
-    comment = get_comment(str(workspace.name))
     axes.get_xaxis().set_units(x_axis.units)
     axes.get_yaxis().set_units(y_axis.units)
     # labels
-    axes.set_xlabel(get_display_name(x_axis.units, comment), picker=SLICE_PICKER_TOL_PTS)
-    axes.set_ylabel(get_display_name(y_axis.units, comment), picker=SLICE_PICKER_TOL_PTS)
+    axes.set_xlabel(get_display_name(x_axis), picker=SLICE_PICKER_TOL_PTS)
+    axes.set_ylabel(get_display_name(y_axis), picker=SLICE_PICKER_TOL_PTS)
     axes.set_xlim(x_axis.start, x_axis.end)
     axes.set_ylim(y_axis.start, y_axis.end)
     return axes.collections[0]  # Quadmesh object

--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -80,4 +80,3 @@ class Axis(object):
     @property
     def step_meV(self):
         return self._step * self.scale
-

--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -2,8 +2,8 @@ from mslice.models.units import EnergyUnits
 
 class Axis(object):
     def __init__(self, units, start, end, step, e_unit='meV'):
-        self.e_unit = str(e_unit)
-        self.scale = EnergyUnits(e_unit).factor_to_meV() if ('DeltaE' in units) else 1.
+        self.e_unit = str(e_unit).strip()
+        self.scale = EnergyUnits(self.e_unit).factor_to_meV() if ('DeltaE' in units) else 1.
         self.units = units
         self.start = float(start)
         self.end = float(end)
@@ -13,7 +13,8 @@ class Axis(object):
         return {'start': self.start, 'end': self.end, 'step': self.step, 'units': self.units, 'e_unit': self.e_unit}
 
     def __str__(self):
-        return "{},{},{},{}".format(self.units, self.start, self.end, self.step)
+        return "{},{},{},{}{}".format(self.units, self.start, self.end, self.step,
+                                      ",{}".format(self.e_unit) if self.not_meV else "")
 
     def __eq__(self, other):
         # This is required for Unit testing
@@ -22,7 +23,13 @@ class Axis(object):
 
     def __repr__(self):
         info = (self.units, self.start, self.end, self.step)
+        if self.not_meV:
+            info += (self.e_unit,)
         return "Axis(" + " ,".join(map(repr, info)) + ")"
+
+    @property
+    def not_meV(self):
+        return "DeltaE" in self.units and "meV" not in self.e_unit
 
     @property
     def start(self):

--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -2,6 +2,7 @@ from mslice.models.units import EnergyUnits
 
 class Axis(object):
     def __init__(self, units, start, end, step, e_unit='meV'):
+        self.e_unit = str(e_unit)
         self.scale = EnergyUnits(e_unit).factor_to_meV() if ('DeltaE' in units) else 1.
         self.units = units
         self.start = float(start)
@@ -9,7 +10,7 @@ class Axis(object):
         self.step = float(step)
 
     def to_dict(self):
-        return {'start': self.start, 'end': self.end, 'step': self.step, 'units': self.units}
+        return {'start': self.start, 'end': self.end, 'step': self.step, 'units': self.units, 'e_unit': self.e_unit}
 
     def __str__(self):
         return "{},{},{},{}".format(self.units, self.start, self.end, self.step)
@@ -25,7 +26,7 @@ class Axis(object):
 
     @property
     def start(self):
-        return self._start * self.scale
+        return self._start
 
     @start.setter
     def start(self, value):
@@ -40,7 +41,7 @@ class Axis(object):
 
     @property
     def end(self):
-        return self._end * self.scale
+        return self._end
 
     @end.setter
     def end(self, value):
@@ -59,7 +60,7 @@ class Axis(object):
 
     @property
     def step(self):
-        return self._step * self.scale
+        return self._step
 
     @step.setter
     def step(self, value):
@@ -67,3 +68,16 @@ class Axis(object):
             self._step = float(value)
         except ValueError:
             raise ValueError("Invalid axis parameter on {}: Step {} is not a valid float!".format(self.units, value))
+
+    @property
+    def start_meV(self):
+        return self._start * self.scale
+
+    @property
+    def end_meV(self):
+        return self._end * self.scale
+
+    @property
+    def step_meV(self):
+        return self._step * self.scale
+

--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -1,6 +1,8 @@
+from mslice.models.units import EnergyUnits
+
 class Axis(object):
     def __init__(self, units, start, end, step, e_unit='meV'):
-        self.scale = 8.06554 if ('cm' in e_unit and 'DeltaE' in units) else 1.
+        self.scale = EnergyUnits(e_unit).factor_to_meV() if ('DeltaE' in units) else 1.
         self.units = units
         self.start = float(start)
         self.end = float(end)
@@ -23,7 +25,7 @@ class Axis(object):
 
     @property
     def start(self):
-        return self._start / self.scale
+        return self._start * self.scale
 
     @start.setter
     def start(self, value):
@@ -38,7 +40,7 @@ class Axis(object):
 
     @property
     def end(self):
-        return self._end / self.scale
+        return self._end * self.scale
 
     @end.setter
     def end(self, value):
@@ -57,7 +59,7 @@ class Axis(object):
 
     @property
     def step(self):
-        return self._step / self.scale
+        return self._step * self.scale
 
     @step.setter
     def step(self, value):

--- a/mslice/models/axis.py
+++ b/mslice/models/axis.py
@@ -1,5 +1,6 @@
 class Axis(object):
-    def __init__(self, units, start, end, step):
+    def __init__(self, units, start, end, step, e_unit='meV'):
+        self.scale = 8.06554 if ('cm' in e_unit and 'DeltaE' in units) else 1.
         self.units = units
         self.start = float(start)
         self.end = float(end)
@@ -22,7 +23,7 @@ class Axis(object):
 
     @property
     def start(self):
-        return self._start
+        return self._start / self.scale
 
     @start.setter
     def start(self, value):
@@ -37,7 +38,7 @@ class Axis(object):
 
     @property
     def end(self):
-        return self._end
+        return self._end / self.scale
 
     @end.setter
     def end(self, value):
@@ -56,7 +57,7 @@ class Axis(object):
 
     @property
     def step(self):
-        return self._step
+        return self._step / self.scale
 
     @step.setter
     def step(self, value):

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -6,7 +6,7 @@ from mantid.simpleapi import BinMD, ConvertSpectrumAxis, CreateMDHistoWorkspace,
 from mslice.models.alg_workspace_ops import fill_in_missing_input, get_number_of_steps
 from mslice.models.axis import Axis
 from mslice.models.units import EnergyUnits
-from mslice.workspace.base import attribute_to_comment
+from mslice.workspace.helperfunctions import attribute_to_comment
 from .cut_normalisation import normalize_workspace
 
 

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -2,6 +2,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 from mslice.util import MPL_COMPAT
+from mslice.models.units import EnergyUnits
 
 CUT_INTENSITY_LABEL = 'Signal/#Events'
 recoil_labels = {1: 'Hydrogen', 2: 'Deuterium', 4: 'Helium'}
@@ -21,19 +22,16 @@ def get_recoil_key(label):
     return label
 
 
-def get_display_name(axisUnits, comment=None):
-    if 'DeltaE' in axisUnits:
+def get_display_name(axis):
+    if 'DeltaE' in axis.units:
+        return EnergyUnits(axis.e_unit).label()
+    elif 'MomentumTransfer' in axis.units or '|Q|' in axis.units:
         # Matplotlib 1.3 doesn't handle LaTeX very well. Sometimes no legend appears if we use LaTeX
-        if MPL_COMPAT:
-            return 'Energy Transfer ' + ('(cm-1)' if (comment and 'wavenumber' in comment) else '(meV)')
-        else:
-            return 'Energy Transfer ' + ('(cm$^{-1}$)' if (comment and 'wavenumber' in comment) else '(meV)')
-    elif 'MomentumTransfer' in axisUnits or '|Q|' in axisUnits:
         return '|Q| (recip. Ang.)' if MPL_COMPAT else r'$|Q|$ ($\mathrm{\AA}^{-1}$)'
-    elif '2Theta' in axisUnits:
+    elif '2Theta' in axis.units:
         return 'Scattering Angle (degrees)' if MPL_COMPAT else r'Scattering Angle 2$\theta$ ($^{\circ}$)'
     else:
-        return axisUnits
+        return axis.units
 
 
 def generate_legend(workspace_name, integrated_dim, integration_start, integration_end):

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -11,8 +11,6 @@ recoil_labels = {1: 'Hydrogen', 2: 'Deuterium', 4: 'Helium'}
 MOD_Q_LABEL = '|Q|'
 THETA_LABEL = '2Theta'
 DELTA_E_LABEL = 'DeltaE'
-MEV_LABEL = 'meV'
-WAVENUMBER_LABEL = 'cm-1'
 
 
 def get_recoil_key(label):

--- a/mslice/models/projection/powder/make_projection.py
+++ b/mslice/models/projection/powder/make_projection.py
@@ -2,9 +2,8 @@ from __future__ import (absolute_import, division, print_function)
 import uuid
 from mantid.api import PythonAlgorithm, MatrixWorkspaceProperty, IMDEventWorkspaceProperty
 from mantid.kernel import FloatArrayProperty, Direction, StringMandatoryValidator
-from mantid.simpleapi import (DeleteWorkspace, TransformMD, SliceMD, PreprocessDetectorsToMD, ConvertToMD, SofQW3,
-                              ConvertSpectrumAxis)
-from ...labels import DELTA_E_LABEL, MEV_LABEL, MOD_Q_LABEL, WAVENUMBER_LABEL, THETA_LABEL
+from mantid.simpleapi import (DeleteWorkspace, SliceMD, PreprocessDetectorsToMD, ConvertToMD, SofQW3, ConvertSpectrumAxis)
+from ...labels import DELTA_E_LABEL, MOD_Q_LABEL, THETA_LABEL
 
 class MakeProjection(PythonAlgorithm):
 
@@ -12,7 +11,6 @@ class MakeProjection(PythonAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty('InputWorkspace', "", direction=Direction.Input))
         self.declareProperty('Axis1', "", StringMandatoryValidator())
         self.declareProperty('Axis2', "", StringMandatoryValidator())
-        self.declareProperty('Units', "", StringMandatoryValidator())
         self.declareProperty(FloatArrayProperty('Limits', direction=Direction.Input))
         self.declareProperty('EMode', "Direct", StringMandatoryValidator())
         self.declareProperty('ProjectionType', "QE", StringMandatoryValidator(), doc='Q or Theta projection')
@@ -23,7 +21,6 @@ class MakeProjection(PythonAlgorithm):
         input_workspace  = self.getProperty('InputWorkspace').value
         axis1 = self.getProperty('Axis1').value
         axis2 = self.getProperty('Axis2').value
-        units = self.getProperty('Units').value
         emode = self.getProperty('EMode').value
         projection_type = self.getProperty('ProjectionType').value
 
@@ -31,13 +28,6 @@ class MakeProjection(PythonAlgorithm):
             new_ws = self._calcQEproj(input_workspace, emode, axis1, axis2)
         else:
             new_ws = self._calcThetaEproj(input_workspace, emode, axis1, axis2)
-        # Now scale the energy axis if required - ConvertToMD always gives DeltaE in meV
-        if units == WAVENUMBER_LABEL:
-            scale = [1, 8.06554] if axis2 == DELTA_E_LABEL else [8.06544, 1]
-            new_ws = TransformMD(InputWorkspace=new_ws, Scaling=scale)
-            new_ws.setComment('MSlice_in_wavenumber')
-        elif units != MEV_LABEL:
-            raise NotImplementedError("Unit %s not recognised. Only 'meV' and 'cm-1' implemented." % (units))
         self.setProperty('OutputWorkspace', new_ws)
 
 

--- a/mslice/models/projection/powder/mantid_projection_calculator.py
+++ b/mslice/models/projection/powder/mantid_projection_calculator.py
@@ -4,16 +4,13 @@ from mslice.models.workspacemanager.workspace_algorithms import propagate_proper
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.models.projection.powder.projection_calculator import ProjectionCalculator
 from mslice.util.mantid import mantid_algorithms
-from ...labels import DELTA_E_LABEL, MEV_LABEL, MOD_Q_LABEL, WAVENUMBER_LABEL, THETA_LABEL
+from ...labels import DELTA_E_LABEL, MOD_Q_LABEL, THETA_LABEL
 
 
 class MantidProjectionCalculator(ProjectionCalculator):
 
     def available_axes(self):
         return [MOD_Q_LABEL, THETA_LABEL, DELTA_E_LABEL]
-
-    def available_units(self):
-        return [MEV_LABEL, WAVENUMBER_LABEL]
 
     def validate_workspace(self, ws):
         workspace = get_workspace_handle(ws)
@@ -25,7 +22,7 @@ class MantidProjectionCalculator(ProjectionCalculator):
             raise TypeError('Input workspace for projection calculation must be a reduced '
                             'data workspace with a spectra and energy transfer axis.')
 
-    def calculate_projection(self, input_workspace, axis1, axis2, units):
+    def calculate_projection(self, input_workspace, axis1, axis2):
         """Calculate the projection workspace AND return a python handle to it"""
         workspace = get_workspace_handle(input_workspace)
         if not workspace.is_PSD:
@@ -43,11 +40,9 @@ class MantidProjectionCalculator(ProjectionCalculator):
         else:
             raise NotImplementedError(" Axis '%s' not recognised. Must be '|Q|' or '2Theta'." % (axis1 if
                                       axis1 != DELTA_E_LABEL else axis2))
-        if units == WAVENUMBER_LABEL:
-            output_workspace_name += '_cm'
 
         new_ws = mantid_algorithms.MakeProjection(OutputWorkspace=output_workspace_name, InputWorkspace=workspace,
-                                                  Axis1=axis1, Axis2=axis2, Units=units, EMode=workspace.e_mode,
+                                                  Axis1=axis1, Axis2=axis2, EMode=workspace.e_mode,
                                                   Limits=workspace.limits['MomentumTransfer'],
                                                   ProjectionType=projection_type)
         propagate_properties(workspace, new_ws)

--- a/mslice/models/projection/powder/projection_calculator.py
+++ b/mslice/models/projection/powder/projection_calculator.py
@@ -8,9 +8,5 @@ class ProjectionCalculator(object):
         pass
 
     @abc.abstractmethod
-    def available_units(self):
-        pass
-
-    @abc.abstractmethod
-    def calculate_projection(self, input_workspace, axis1, axis2, units):
+    def calculate_projection(self, input_workspace, axis1, axis2):
         pass

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -21,23 +21,31 @@ class Slice(PythonAlgorithm):
 
     def PyExec(self):
         workspace = self.getProperty('InputWorkspace').value
-        x_dict = self.getProperty('XAxis').value
-        x_axis = Axis(x_dict['units'].value, x_dict['start'].value, x_dict['end'].value, x_dict['step'].value)
-        y_dict = self.getProperty('YAxis').value
-        y_axis = Axis(y_dict['units'].value, y_dict['start'].value, y_dict['end'].value, y_dict['step'].value)
-        norm_to_one = self.getProperty('NormToOne')
         e_unit = self.getProperty('EnergyUnit').value
+        x_dict = self.getProperty('XAxis').value
+        x_axis = Axis(x_dict['units'].value, x_dict['start'].value, x_dict['end'].value, x_dict['step'].value, e_unit)
+        y_dict = self.getProperty('YAxis').value
+        y_axis = Axis(y_dict['units'].value, y_dict['start'].value, y_dict['end'].value, y_dict['step'].value, e_unit)
+        norm_to_one = self.getProperty('NormToOne')
         if self.getProperty('PSD').value:
-            slice = self._compute_slice_PSD(workspace, x_axis, y_axis, norm_to_one, e_unit)
+            slice = self._compute_slice_PSD(workspace, x_axis, y_axis, norm_to_one)
+            e_axis = 0 if 'DeltaE' in x_axis.units else (1 if 'DeltaE' in y_axis.units else None)
+            if 'cm' in e_unit and e_axis is not None:
+                scale = [1, 8.06554] if e_axis == 1 else [8.06544, 1]
+                slice = TransformMD(InputWorkspace=slice, Scaling=scale)
+                slice.setComment('MSlice_in_wavenumber')
         else:
             e_mode = self.getProperty('EMode').value
-            slice = self._compute_slice_nonPSD(workspace, x_axis, y_axis, e_mode, norm_to_one, e_unit)
+            slice = self._compute_slice_nonPSD(workspace, x_axis, y_axis, e_mode, norm_to_one)
+            if 'cm' in e_unit:
+                slice = ScaleX(InputWorkspace=slice, Factor=8.06554, Operation='Multiply', StoreInADS=False)
+                slice.setComment('MSlice_in_wavenumber')
         self.setProperty('OutputWorkspace', slice)
 
     def category(self):
         return 'MSlice'
 
-    def _compute_slice_PSD(self, workspace, x_axis, y_axis, norm_to_one, e_unit):
+    def _compute_slice_PSD(self, workspace, x_axis, y_axis, norm_to_one):
         assert isinstance(workspace, IMDEventWorkspace)
         n_x_bins = get_number_of_steps(x_axis)
         n_y_bins = get_number_of_steps(y_axis)
@@ -45,23 +53,10 @@ class Slice(PythonAlgorithm):
         y_dim_id = self.dimension_index(workspace, y_axis)
         x_dim = workspace.getDimension(x_dim_id)
         y_dim = workspace.getDimension(y_dim_id)
-        x_name = x_dim.getName()
-        y_name = y_dim.getName()
-        e_axis = 0 if 'DeltaE' in x_name else (1 if 'DeltaE' in y_name else None)
-        xbinning = x_name + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
-        ybinning = y_name + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
-        if 'cm' in e_unit and e_axis is not None:
-            if e_axis == 0:
-                xbinning = x_name + "," + str(x_axis.start / 8.06544) + "," + str(x_axis.end / 8.06544) + "," + str(n_x_bins)
-            else:
-                ybinning = y_name + "," + str(y_axis.start / 8.06544) + "," + str(y_axis.end / 8.06544) + "," + str(n_y_bins)
-        thisslice = BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
-                          StoreInADS=False)
-        if 'cm' in e_unit and e_axis is not None:
-            scale = [1, 8.06554] if 'DeltaE' in y_name else [8.06544, 1]
-            thisslice = TransformMD(InputWorkspace=thisslice, Scaling=scale)
-            thisslice.setComment('MSlice_in_wavenumber')
-        return thisslice
+        xbinning = x_dim.getName() + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
+        ybinning = y_dim.getName() + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
+        return BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
+                     StoreInADS=False)
 
     def dimension_index(self, workspace, axis):
         try:
@@ -72,7 +67,7 @@ class Slice(PythonAlgorithm):
             else:
                 raise e
 
-    def _compute_slice_nonPSD(self, workspace, x_axis, y_axis, e_mode, norm_to_one, e_unit):
+    def _compute_slice_nonPSD(self, workspace, x_axis, y_axis, e_mode, norm_to_one):
         axes = [x_axis, y_axis]
         if x_axis.units == 'DeltaE':
             e_axis = 0
@@ -81,10 +76,7 @@ class Slice(PythonAlgorithm):
         else:
             raise RuntimeError('Cannot calculate slices without an energy axis')
         q_axis = (e_axis + 1) % 2
-        if 'cm' in e_unit:
-            ebin = '%f, %f, %f' % (axes[e_axis].start / 8.06554, axes[e_axis].step / 8.06554, axes[e_axis].end / 8.06554)
-        else:
-            ebin = '%f, %f, %f' % (axes[e_axis].start, axes[e_axis].step, axes[e_axis].end)
+        ebin = '%f, %f, %f' % (axes[e_axis].start, axes[e_axis].step, axes[e_axis].end)
         qbin = '%f, %f, %f' % (axes[q_axis].start, axes[q_axis].step, axes[q_axis].end)
         if axes[q_axis].units == '|Q|':
             thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin, EMode=e_mode,
@@ -94,7 +86,4 @@ class Slice(PythonAlgorithm):
             thisslice = Rebin2D(InputWorkspace=thisslice, Axis1Binning=ebin, Axis2Binning=qbin, StoreInADS=False)
         else:
             raise RuntimeError("axis %s not recognised, must be '|Q|' or '2Theta'" % axes[q_axis].units)
-        if 'cm' in e_unit:
-            thisslice = ScaleX(InputWorkspace=thisslice, Factor=8.06554, Operation='Multiply', StoreInADS=False)
-            thisslice.setComment('MSlice_in_wavenumber')
         return thisslice

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -4,7 +4,7 @@ from mantid.simpleapi import BinMD, Rebin2D, ConvertSpectrumAxis, SofQW3, Transf
 from mslice.models.alg_workspace_ops import get_number_of_steps
 from mslice.models.axis import Axis
 from mslice.models.units import EnergyUnits
-from mslice.workspace.base import attribute_to_comment
+from mslice.workspace.helperfunctions import attribute_to_comment
 
 
 class Slice(PythonAlgorithm):

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -17,17 +17,15 @@ class Slice(PythonAlgorithm):
         self.declareProperty('EMode', 'Direct', StringMandatoryValidator())
         self.declareProperty('PSD', False)
         self.declareProperty('NormToOne', False)
-        self.declareProperty('EnergyUnit', 'meV')
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '', direction=Direction.Output))
 
     def PyExec(self):
         workspace = self.getProperty('InputWorkspace').value
-        e_unit = self.getProperty('EnergyUnit').value
-        e_scale = EnergyUnits(e_unit).factor_from_meV()
         x_dict = self.getProperty('XAxis').value
-        x_axis = Axis(x_dict['units'].value, x_dict['start'].value, x_dict['end'].value, x_dict['step'].value, e_unit)
+        x_axis = Axis(x_dict['units'].value, x_dict['start'].value, x_dict['end'].value, x_dict['step'].value, x_dict['e_unit'].value)
         y_dict = self.getProperty('YAxis').value
-        y_axis = Axis(y_dict['units'].value, y_dict['start'].value, y_dict['end'].value, y_dict['step'].value, e_unit)
+        y_axis = Axis(y_dict['units'].value, y_dict['start'].value, y_dict['end'].value, y_dict['step'].value, y_dict['e_unit'].value)
+        e_scale = EnergyUnits(x_axis.e_unit).factor_from_meV()
         norm_to_one = self.getProperty('NormToOne')
         if self.getProperty('PSD').value:
             slice = self._compute_slice_PSD(workspace, x_axis, y_axis, norm_to_one)
@@ -55,8 +53,8 @@ class Slice(PythonAlgorithm):
         y_dim_id = self.dimension_index(workspace, y_axis)
         x_dim = workspace.getDimension(x_dim_id)
         y_dim = workspace.getDimension(y_dim_id)
-        xbinning = x_dim.getName() + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
-        ybinning = y_dim.getName() + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
+        xbinning = x_dim.getName() + "," + str(x_axis.start_meV) + "," + str(x_axis.end_meV) + "," + str(n_x_bins)
+        ybinning = y_dim.getName() + "," + str(y_axis.start_meV) + "," + str(y_axis.end_meV) + "," + str(n_y_bins)
         return BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
                      StoreInADS=False)
 
@@ -78,8 +76,8 @@ class Slice(PythonAlgorithm):
         else:
             raise RuntimeError('Cannot calculate slices without an energy axis')
         q_axis = (e_axis + 1) % 2
-        ebin = '%f, %f, %f' % (axes[e_axis].start, axes[e_axis].step, axes[e_axis].end)
-        qbin = '%f, %f, %f' % (axes[q_axis].start, axes[q_axis].step, axes[q_axis].end)
+        ebin = '%f, %f, %f' % (axes[e_axis].start_meV, axes[e_axis].step_meV, axes[e_axis].end_meV)
+        qbin = '%f, %f, %f' % (axes[q_axis].start_meV, axes[q_axis].step_meV, axes[q_axis].end_meV)
         if axes[q_axis].units == '|Q|':
             thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin, EMode=e_mode,
                                StoreInADS=False)

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -1,6 +1,6 @@
 from mantid.api import PythonAlgorithm, WorkspaceProperty, IMDEventWorkspace
 from mantid.kernel import Direction, StringMandatoryValidator, PropertyManagerProperty
-from mantid.simpleapi import BinMD, Rebin2D, ConvertSpectrumAxis, SofQW3
+from mantid.simpleapi import BinMD, Rebin2D, ConvertSpectrumAxis, SofQW3, TransformMD, ScaleX
 from mslice.models.alg_workspace_ops import get_number_of_steps
 from mslice.models.axis import Axis
 
@@ -16,6 +16,7 @@ class Slice(PythonAlgorithm):
         self.declareProperty('EMode', 'Direct', StringMandatoryValidator())
         self.declareProperty('PSD', False)
         self.declareProperty('NormToOne', False)
+        self.declareProperty('EnergyUnit', 'meV')
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '', direction=Direction.Output))
 
     def PyExec(self):
@@ -25,17 +26,18 @@ class Slice(PythonAlgorithm):
         y_dict = self.getProperty('YAxis').value
         y_axis = Axis(y_dict['units'].value, y_dict['start'].value, y_dict['end'].value, y_dict['step'].value)
         norm_to_one = self.getProperty('NormToOne')
+        e_unit = self.getProperty('EnergyUnit').value
         if self.getProperty('PSD').value:
-            slice = self._compute_slice_PSD(workspace, x_axis, y_axis, norm_to_one)
+            slice = self._compute_slice_PSD(workspace, x_axis, y_axis, norm_to_one, e_unit)
         else:
             e_mode = self.getProperty('EMode').value
-            slice = self._compute_slice_nonPSD(workspace, x_axis, y_axis, e_mode, norm_to_one)
+            slice = self._compute_slice_nonPSD(workspace, x_axis, y_axis, e_mode, norm_to_one, e_unit)
         self.setProperty('OutputWorkspace', slice)
 
     def category(self):
         return 'MSlice'
 
-    def _compute_slice_PSD(self, workspace, x_axis, y_axis, norm_to_one):
+    def _compute_slice_PSD(self, workspace, x_axis, y_axis, norm_to_one, e_unit):
         assert isinstance(workspace, IMDEventWorkspace)
         n_x_bins = get_number_of_steps(x_axis)
         n_y_bins = get_number_of_steps(y_axis)
@@ -43,10 +45,23 @@ class Slice(PythonAlgorithm):
         y_dim_id = self.dimension_index(workspace, y_axis)
         x_dim = workspace.getDimension(x_dim_id)
         y_dim = workspace.getDimension(y_dim_id)
-        xbinning = x_dim.getName() + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
-        ybinning = y_dim.getName() + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
-        return BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
-                     StoreInADS=False)
+        x_name = x_dim.getName()
+        y_name = y_dim.getName()
+        e_axis = 0 if 'DeltaE' in x_name else (1 if 'DeltaE' in y_name else None)
+        xbinning = x_name + "," + str(x_axis.start) + "," + str(x_axis.end) + "," + str(n_x_bins)
+        ybinning = y_name + "," + str(y_axis.start) + "," + str(y_axis.end) + "," + str(n_y_bins)
+        if 'cm' in e_unit and e_axis is not None:
+            if e_axis == 0:
+                xbinning = x_name + "," + str(x_axis.start / 8.06544) + "," + str(x_axis.end / 8.06544) + "," + str(n_x_bins)
+            else:
+                ybinning = y_name + "," + str(y_axis.start / 8.06544) + "," + str(y_axis.end / 8.06544) + "," + str(n_y_bins)
+        thisslice = BinMD(InputWorkspace=workspace, AxisAligned="1", AlignedDim0=xbinning, AlignedDim1=ybinning,
+                          StoreInADS=False)
+        if 'cm' in e_unit and e_axis is not None:
+            scale = [1, 8.06554] if 'DeltaE' in y_name else [8.06544, 1]
+            thisslice = TransformMD(InputWorkspace=thisslice, Scaling=scale)
+            thisslice.setComment('MSlice_in_wavenumber')
+        return thisslice
 
     def dimension_index(self, workspace, axis):
         try:
@@ -57,7 +72,7 @@ class Slice(PythonAlgorithm):
             else:
                 raise e
 
-    def _compute_slice_nonPSD(self, workspace, x_axis, y_axis, e_mode, norm_to_one):
+    def _compute_slice_nonPSD(self, workspace, x_axis, y_axis, e_mode, norm_to_one, e_unit):
         axes = [x_axis, y_axis]
         if x_axis.units == 'DeltaE':
             e_axis = 0
@@ -66,7 +81,10 @@ class Slice(PythonAlgorithm):
         else:
             raise RuntimeError('Cannot calculate slices without an energy axis')
         q_axis = (e_axis + 1) % 2
-        ebin = '%f, %f, %f' % (axes[e_axis].start, axes[e_axis].step, axes[e_axis].end)
+        if 'cm' in e_unit:
+            ebin = '%f, %f, %f' % (axes[e_axis].start / 8.06554, axes[e_axis].step / 8.06554, axes[e_axis].end / 8.06554)
+        else:
+            ebin = '%f, %f, %f' % (axes[e_axis].start, axes[e_axis].step, axes[e_axis].end)
         qbin = '%f, %f, %f' % (axes[q_axis].start, axes[q_axis].step, axes[q_axis].end)
         if axes[q_axis].units == '|Q|':
             thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin, EMode=e_mode,
@@ -76,4 +94,7 @@ class Slice(PythonAlgorithm):
             thisslice = Rebin2D(InputWorkspace=thisslice, Axis1Binning=ebin, Axis2Binning=qbin, StoreInADS=False)
         else:
             raise RuntimeError("axis %s not recognised, must be '|Q|' or '2Theta'" % axes[q_axis].units)
+        if 'cm' in e_unit:
+            thisslice = ScaleX(InputWorkspace=thisslice, Factor=8.06554, Operation='Multiply', StoreInADS=False)
+            thisslice.setComment('MSlice_in_wavenumber')
         return thisslice

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -4,6 +4,7 @@ from mantid.simpleapi import BinMD, Rebin2D, ConvertSpectrumAxis, SofQW3, Transf
 from mslice.models.alg_workspace_ops import get_number_of_steps
 from mslice.models.axis import Axis
 from mslice.models.units import EnergyUnits
+from mslice.workspace.base import attribute_to_comment
 
 
 class Slice(PythonAlgorithm):
@@ -33,13 +34,12 @@ class Slice(PythonAlgorithm):
             if e_axis is not None and e_scale != 1.:
                 scale = [1., e_scale] if e_axis == 1 else [e_scale, 1.]
                 slice = TransformMD(InputWorkspace=slice, Scaling=scale)
-                slice.setComment('MSlice_in_wavenumber')
         else:
             e_mode = self.getProperty('EMode').value
             slice = self._compute_slice_nonPSD(workspace, x_axis, y_axis, e_mode, norm_to_one)
             if e_scale != 1.:
                 slice = ScaleX(InputWorkspace=slice, Factor=e_scale, Operation='Multiply', StoreInADS=False)
-                slice.setComment('MSlice_in_wavenumber')
+        attribute_to_comment({'axes': [x_axis, y_axis]}, slice)
         self.setProperty('OutputWorkspace', slice)
 
     def category(self):

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -39,7 +39,7 @@ def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one):
 
 def axis_values(axis):
     """Compute a numpy array of bins for the given axis values"""
-    return np.linspace(axis.start, axis.end, get_number_of_steps(axis))
+    return np.linspace(axis.start_meV, axis.end_meV, get_number_of_steps(axis))
 
 
 def compute_boltzmann_dist(sample_temp, delta_e):

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -26,11 +26,11 @@ crystal_structure = {'Copper': ['3.6149 3.6149 3.6149', 'F m -3 m', 'Cu 0 0 0 1.
                      'Tantalum': ['3.3013 3.3013 3.3013', 'I m -3 m', 'Ta 0 0 0 1.0 0.05']}
 
 
-def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one):
+def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one, e_units):
     workspace = get_workspace_handle(selected_workspace)
     slice = mantid_algorithms.Slice(OutputWorkspace='__' + workspace.name, InputWorkspace=workspace,
                                     XAxis=x_axis.to_dict(), YAxis=y_axis.to_dict(), PSD=workspace.is_PSD,
-                                    EMode=workspace.e_mode, NormToOne=norm_to_one)
+                                    EMode=workspace.e_mode, NormToOne=norm_to_one, EnergyUnit=e_units)
     propagate_properties(workspace, slice)
     if norm_to_one:
         slice = _norm_to_one(slice)

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -26,11 +26,11 @@ crystal_structure = {'Copper': ['3.6149 3.6149 3.6149', 'F m -3 m', 'Cu 0 0 0 1.
                      'Tantalum': ['3.3013 3.3013 3.3013', 'I m -3 m', 'Ta 0 0 0 1.0 0.05']}
 
 
-def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one, e_units):
+def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one):
     workspace = get_workspace_handle(selected_workspace)
     slice = mantid_algorithms.Slice(OutputWorkspace='__' + workspace.name, InputWorkspace=workspace,
                                     XAxis=x_axis.to_dict(), YAxis=y_axis.to_dict(), PSD=workspace.is_PSD,
-                                    EMode=workspace.e_mode, NormToOne=norm_to_one, EnergyUnit=e_units)
+                                    EMode=workspace.e_mode, NormToOne=norm_to_one)
     propagate_properties(workspace, slice)
     if norm_to_one:
         slice = _norm_to_one(slice)

--- a/mslice/models/units.py
+++ b/mslice/models/units.py
@@ -1,0 +1,71 @@
+"""
+Module for handling units.
+At present only the energy units "meV" ("DeltaE") and "cm-1" ("DeltaE_inWavenumber")
+are defined, but they are separated into a module for possible future expansion.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six import string_types
+
+class EnergyUnits(object):
+
+    _available_units = ['meV', 'cm-1']
+    _name_to_index = {'meV':0, 'cm-1':1, 'DeltaE':0, 'DeltaE_inWavenumber':1}
+    # The following is a conversion matrix between the different units e_to = m[from][to] * e_from
+    # E.g. meV = m[1][0] * cm; and cm = m[0][1] * meV
+    _conversion_factors = [[1.,    8.065544],
+                           [1./8.065544, 1.]]
+
+    def __init__(self, unit_name):
+        if unit_name not in self._name_to_index.keys():
+            raise ValueError("Unrecognised energy unit '{}'".format(unit_name))
+        self._unit = unit_name
+        self._index = self._name_to_index[self._unit]
+
+    def index(self):
+        return self._index
+
+    def factor_from_meV(self):
+        return self._conversion_factors[0][self._index]
+
+    def factor_to_meV(self):
+        return self._conversion_factors[self._index][0]
+
+    def from_meV(self, *args):
+        conv = (float(x) * self._conversion_factors[0][self._index] for x in args)
+        return ('{:.2f}'.format(s) for s in conv) if isinstance(args[0], string_types) else conv
+
+    def to_meV(self, *args):
+        conv = (float(x) * self._conversion_factors[self._index][0] for x in args)
+        return ('{:.2f}'.format(s) for s in conv) if isinstance(args[0], string_types) else conv
+
+    def factor_from(self, unit_from):
+        try:
+            return self._conversion_factors[self._name_to_index[unit_from]][self._index]
+        except KeyError:
+            raise ValueError("Unrecognised energy unit '{}'".format(unit_from))
+
+    def factor_to(self, unit_to):
+        try:
+            return self._conversion_factors[self._index][self._name_to_index[unit_to]]
+        except KeyError:
+            raise ValueError("Unrecognised energy unit '{}'".format(unit_to))
+
+    def convert_from(self, unit_from, *args):
+        conv = (float(x) * self.factor_from(unit_from) for x in args)
+        return ('{:.2f}'.format(s) for s in conv) if isinstance(args[0], string_types) else conv
+
+    def convert_to(self, unit_to, *args):
+        conv = (float(x) * self.factor_to(unit_to) for x in args)
+        return ('{:.2f}'.format(s) for s in conv) if isinstance(args[0], string_types) else conv
+
+    @classmethod
+    def get_index(cls, unit_name):
+        try:
+            return cls._name_to_index[unit_name]
+        except KeyError:
+            raise ValueError("Unrecognised energy unit '{}'".format(unit_name))
+
+    @classmethod
+    def get_all_units(cls):
+        return cls._available_units

--- a/mslice/models/units.py
+++ b/mslice/models/units.py
@@ -9,7 +9,7 @@ from mslice.util import MPL_COMPAT
 
 def _scale_string_or_float(value, scale):
     try:
-        return '{:.2f}'.format(float(value) * scale)
+        return '{:.5f}'.format(float(value) * scale)
     except (ValueError, TypeError):
         return value
 

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -5,6 +5,7 @@ from mslice.util.qt.QtWidgets import QFileDialog
 from mslice.util.mantid.mantid_algorithms import CreateMDHistoWorkspace, SaveAscii, SaveMD, SaveNexus
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.workspace.histogram_workspace import HistogramWorkspace
+from mslice.workspace.helperfunctions import WrapWorkspaceAttribute
 
 import numpy as np
 from scipy.io import savemat
@@ -46,11 +47,12 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
 def save_nexus(workspace, path, is_slice):
     if isinstance(workspace, HistogramWorkspace):
         if is_slice:
-            SaveMD(InputWorkspace=get_workspace_handle(workspace.name[2:]), Filename=path)
-        else:
-            SaveMD(InputWorkspace=workspace, Filename=path)
+            workspace = get_workspace_handle(workspace.name[2:])
+        save_alg = SaveMD
     else:
-        SaveNexus(InputWorkspace=workspace, Filename=path)
+        save_alg = SaveNexus
+    with WrapWorkspaceAttribute(workspace):
+        save_alg(InputWorkspace=workspace, Filename=path)
 
 
 def save_ascii(workspace, path, is_slice):

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -11,11 +11,13 @@ import os.path
 import numpy as np
 from scipy import constants
 
+from mantid.api import WorkspaceUnitValidator
+
 from mslice.models.axis import Axis
 
 from mslice.util.mantid.algorithm_wrapper import add_to_ads, wrap_in_ads
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_name
-from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus
+from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus, ConvertUnits
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
@@ -158,6 +160,8 @@ def load(filename, output_workspace):
     workspace.e_mode = get_EMode(workspace.raw_ws)
     if workspace.e_mode == 'Indirect':
         processEfixed(workspace)
+    if WorkspaceUnitValidator("DeltaE_inWavenumber").isValid(workspace.raw_ws) == '':
+        workspace = ConvertUnits(InputWorkspace=workspace, Target="DeltaE", OutputWorkspace=workspace.name)
     _processLoadedWSLimits(workspace)
     return workspace
 

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -12,6 +12,7 @@ import numpy as np
 from scipy import constants
 
 from mantid.api import WorkspaceUnitValidator
+from mantid.api import MatrixWorkspace
 
 from mslice.models.axis import Axis
 
@@ -20,7 +21,7 @@ from mslice.models.workspacemanager.workspace_provider import get_workspace_hand
 from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus, ConvertUnits
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.histogram_workspace import HistogramWorkspace
-from mslice.workspace.workspace import Workspace as MatrixWorkspace
+from mslice.workspace.workspace import Workspace
 
 # -----------------------------------------------------------------------------
 # Classes and functions
@@ -65,7 +66,7 @@ def _processLoadedWSLimits(workspace):
         return
     if isinstance(workspace, PixelWorkspace):
         process_limits_event(workspace)
-    elif isinstance(workspace, MatrixWorkspace):
+    elif isinstance(workspace, Workspace):
         process_limits(workspace)
 
 
@@ -160,8 +161,10 @@ def load(filename, output_workspace):
     workspace.e_mode = get_EMode(workspace.raw_ws)
     if workspace.e_mode == 'Indirect':
         processEfixed(workspace)
-    if WorkspaceUnitValidator("DeltaE_inWavenumber").isValid(workspace.raw_ws) == '':
-        workspace = ConvertUnits(InputWorkspace=workspace, Target="DeltaE", OutputWorkspace=workspace.name)
+    if (isinstance(workspace.raw_ws, MatrixWorkspace)
+            and WorkspaceUnitValidator("DeltaE_inWavenumber").isValid(workspace.raw_ws)) == '':
+        workspace = ConvertUnits(InputWorkspace=workspace, Target="DeltaE", EMode=workspace.e_mode,
+                                 OutputWorkspace=workspace.name)
     _processLoadedWSLimits(workspace)
     return workspace
 
@@ -244,7 +247,7 @@ def _save_single_ws(workspace, save_name, save_method, path, extension, slice_no
     save_as = save_name if save_name is not None else str(workspace) + extension
     full_path = os.path.join(str(path), save_as)
     workspace = get_workspace_handle(workspace)
-    non_psd_slice = slice_nonpsd and isinstance(workspace, MatrixWorkspace) and not workspace.is_PSD
+    non_psd_slice = slice_nonpsd and isinstance(workspace, Workspace) and not workspace.is_PSD
     if is_pixel_workspace(workspace) or non_psd_slice:
         slice = True
         workspace = _get_slice_mdhisto(workspace, get_workspace_name(workspace))

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -13,6 +13,7 @@ class InteractiveCut(object):
         self.slice_plot = slice_plot
         self._canvas = canvas
         self._ws_title = ws_title
+        self._en_unit = slice_plot.get_slice_cache().energy_axis.e_unit
 
         self.horizontal = None
         self.connect_event = [None, None, None, None]
@@ -41,7 +42,7 @@ class InteractiveCut(object):
             ax, integration_start, integration_end = self.get_cut_parameters((x1, y1), (x2, y2))
             units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
                 self._canvas.figure.gca().get_xaxis().units
-            integration_axis = Axis(units, integration_start, integration_end, 0)
+            integration_axis = Axis(units, integration_start, integration_end, 0, self._en_unit)
             self._cut_plotter_presenter.plot_interactive_cut(str(self._ws_title), ax, integration_axis, store)
             self._cut_plotter_presenter.store_icut(self._ws_title, self)
 
@@ -51,7 +52,7 @@ class InteractiveCut(object):
         units = self._canvas.figure.gca().get_xaxis().units if self.horizontal else \
             self._canvas.figure.gca().get_yaxis().units
         step = get_limits(get_workspace_handle(self._ws_title), units)[2]
-        ax = Axis(units, start, end, step)
+        ax = Axis(units, start, end, step, self._en_unit)
         integration_start = pos1[self.horizontal]
         integration_end = pos2[self.horizontal]
         return ax, integration_start, integration_end

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -442,6 +442,9 @@ class SlicePlot(IPlot):
     def flip_icut(self):
         self.icut.flip_axis()
 
+    def get_slice_cache(self):
+        return self._slice_plotter_presenter.get_slice_cache(self.ws_name)
+
     def update_workspaces(self):
         self._slice_plotter_presenter.update_displayed_workspaces()
 

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -39,7 +39,7 @@ class CutPlotterPresenter(PresenterUtility):
         cut_ws = compute_cut(workspace, cut_axis, integration_axis, cut.norm_to_one, store)
         legend = generate_legend(workspace.name, integration_axis.units, integration_axis.start,
                                  integration_axis.end)
-        plot_cut_impl(cut_ws, cut_axis.units, (cut.intensity_start, cut.intensity_end), plot_over, legend)
+        plot_cut_impl(cut_ws, (cut.intensity_start, cut.intensity_end), plot_over, legend)
         if update_main:
             self.set_is_icut(workspace.name, False)
             self.update_main_window()
@@ -71,8 +71,7 @@ class CutPlotterPresenter(PresenterUtility):
     def plot_cut_from_workspace(self, workspace, plot_over=False, intensity_range=None):
 
         workspace = get_workspace_handle(workspace)
-        lines = plot_cut_impl(workspace, workspace.raw_ws.getDimension(0).getUnits(),
-                              intensity_range=intensity_range, plot_over=plot_over)
+        lines = plot_cut_impl(workspace, intensity_range=intensity_range, plot_over=plot_over)
         self.set_is_icut(workspace.name, False)
         return lines
 

--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -25,6 +25,7 @@ class CutWidgetPresenter(PresenterUtility):
         self._previous_cut = None
         self._previous_axis = None
         self._minimumStep = dict()
+        self._en_default = 'meV'
 
     def set_cut_plotter_presenter(self, cut_plotter_presenter):
         self._cut_plotter_presenter = cut_plotter_presenter
@@ -73,11 +74,12 @@ class CutWidgetPresenter(PresenterUtility):
 
     def _parse_input(self):
         """Gets values entered by user. Validation is performed by the CutCache object."""
+        e_units = self._cut_view.get_energy_units()
         cut_axis = Axis(self._cut_view.get_cut_axis(), self._cut_view.get_cut_axis_start(),
-                        self._cut_view.get_cut_axis_end(), self._cut_view.get_cut_axis_step())
+                        self._cut_view.get_cut_axis_end(), self._cut_view.get_cut_axis_step(), e_units)
 
         integration_axis = Axis(self._cut_view.get_integration_axis(), self._cut_view.get_integration_start(),
-                                self._cut_view.get_integration_end(), 0.)
+                                self._cut_view.get_integration_end(), 0., e_units)
 
         intensity_start = self._cut_view.get_intensity_start()
         intensity_end = self._cut_view.get_intensity_end()
@@ -183,3 +185,8 @@ class CutWidgetPresenter(PresenterUtility):
         min_step = self._minimumStep[self._cut_view.get_cut_axis()]
         self._cut_view.set_minimum_step(min_step)
         self.update_integration_axis()
+
+    def set_energy_default(self, en_default):
+        self._en_default = en_default
+        self._cut_view.set_energy_units_default(en_default)
+        self._cut_view.set_energy_units(en_default)

--- a/mslice/presenters/interfaces/main_presenter.py
+++ b/mslice/presenters/interfaces/main_presenter.py
@@ -44,3 +44,8 @@ class MainPresenterInterface(object):
     @abc.abstractmethod
     def show_tab_for_workspace(self, ws):
         pass
+
+    @abc.abstractmethod
+    def subscribe_to_energy_default_monitor(self, client):
+        pass
+

--- a/mslice/presenters/interfaces/main_presenter.py
+++ b/mslice/presenters/interfaces/main_presenter.py
@@ -48,4 +48,3 @@ class MainPresenterInterface(object):
     @abc.abstractmethod
     def subscribe_to_energy_default_monitor(self, client):
         pass
-

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -8,6 +8,7 @@ class MainPresenter(MainPresenterInterface):
     def __init__(self, main_view, *subpresenters):
         self._mainView = main_view
         self._selected_workspace_listener = []
+        self._energy_default_listener = []
         for presenter in subpresenters:
             presenter.register_master(self)
 
@@ -53,10 +54,18 @@ class MainPresenter(MainPresenterInterface):
     def subscribe_to_workspace_selection_monitor(self, client):
         """Subcscribe a client to be notified when selected workspaces change
         client.workspace_selection_changed() will be called whenever the selected workspaces change"""
-        if isinstance(getattr(client, "workspace_selection_changed",None), collections.Callable):
+        if isinstance(getattr(client, "workspace_selection_changed", None), collections.Callable):
             self._selected_workspace_listener.append(client)
         else:
             raise TypeError("The client trying to subscribe does not implement the method 'workspace_selection_changed'")
 
     def register_workspace_selector(self, workspace_selector):
         self._workspace_presenter = workspace_selector
+
+    def subscribe_to_energy_default_monitor(self, client):
+        if isinstance(getattr(client, "set_energy_default", None), collections.Callable):
+            self._energy_default_listener.append(client)
+
+    def set_energy_default(self, en_default):
+        for listener in self._energy_default_listener:
+            listener.set_energy_default(en_default)

--- a/mslice/presenters/powder_projection_presenter.py
+++ b/mslice/presenters/powder_projection_presenter.py
@@ -20,11 +20,9 @@ class PowderProjectionPresenter(PresenterUtility, PowderProjectionPresenterInter
 
         #Add rest of options
         self._available_axes = projection_calculator.available_axes()
-        self._available_units = projection_calculator.available_units()
         self._powder_view.populate_powder_u1(self._available_axes)
         self._powder_view.populate_powder_u2(self._available_axes)
         self._powder_view.set_powder_u2(self._available_axes[-1])
-        self._powder_view.populate_powder_projection_units(self._available_units)
         self._main_presenter = None
 
     def notify(self, command):
@@ -48,14 +46,13 @@ class PowderProjectionPresenter(PresenterUtility, PowderProjectionPresenterInter
         if not selected_workspaces:
             self._powder_view.display_message_box("No workspace is selected")
             return
-        units = self._powder_view.get_powder_units()
         outws = []
         for workspace in selected_workspaces:
-            outws.append(self.calc_projection(workspace, axis1, axis2, units, quiet=True))
+            outws.append(self.calc_projection(workspace, axis1, axis2, quiet=True))
         self.after_projection(outws)
 
-    def calc_projection(self, workspace, axis1, axis2, units, quiet=False):
-        proj_ws = self._projection_calculator.calculate_projection(workspace, axis1, axis2, units)
+    def calc_projection(self, workspace, axis1, axis2, quiet=False):
+        proj_ws = self._projection_calculator.calculate_projection(workspace, axis1, axis2)
         if not quiet:
             self.after_projection([proj_ws])
         return proj_ws

--- a/mslice/presenters/presenter_utility.py
+++ b/mslice/presenters/presenter_utility.py
@@ -7,6 +7,7 @@ class PresenterUtility(object):
         assert (isinstance(main_presenter, MainPresenterInterface))
         self._main_presenter = main_presenter
         self._main_presenter.subscribe_to_workspace_selection_monitor(self)
+        self._main_presenter.subscribe_to_energy_default_monitor(self)
 
     def _to_float(self, x):
         return None if x == "" else float(x)

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -57,7 +57,7 @@ class SlicePlotterPresenter(PresenterUtility):
         self._slice_cache[slice.name[2:]] = Slice(slice, colourmap, norm, sample_temp, q_axis, e_axis, rotated)
 
     def get_slice_cache(self, workspace):
-        return self._slice_cache[workspace.name[2:]]
+        return self._slice_cache[workspace.name[2:] if hasattr(workspace, 'name') else workspace]
 
     def show_scattering_function(self, workspace_name):
         slice_cache = self._slice_cache[workspace_name]

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -96,6 +96,10 @@ class SlicePlotterPresenter(PresenterUtility):
             x, y = compute_recoil_line(workspace_name, cache.momentum_axis, key)
         else:
             x, y = compute_powder_line(workspace_name, cache.momentum_axis, key, cif_file=cif)
+        if 'meV' not in cache.energy_axis.e_unit:
+            from mslice.models.units import EnergyUnits
+            import numpy as np
+            y = np.array(y) * EnergyUnits(cache.energy_axis.e_unit).factor_from_meV()
         cache.overplot_lines[key] = plot_overplot_line(x, y, key, recoil, cache)
 
     def validate_intensity(self, intensity_start, intensity_end):

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -17,15 +17,15 @@ class SlicePlotterPresenter(PresenterUtility):
         self._slice_cache = {}
         self._sample_temp_fields = []
 
-    def plot_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap):
+    def plot_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap, e_units):
         workspace = get_workspace_handle(selected_ws)
-        self.create_slice(workspace, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap)
+        self.create_slice(workspace, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap, e_units)
         self.plot_from_cache(workspace)
 
-    def create_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap):
+    def create_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap, e_units):
         sample_temp = sample_temperature(selected_ws, self._sample_temp_fields)
         norm = Normalize(vmin=intensity_start, vmax=intensity_end)
-        slice = compute_slice(selected_ws, x_axis, y_axis, norm_to_one)
+        slice = compute_slice(selected_ws, x_axis, y_axis, norm_to_one, e_units)
         self._cache_slice(slice, colourmap, norm, sample_temp, x_axis, y_axis)
         self._slice_cache[selected_ws.name].norm_to_one = norm_to_one
         return slice

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -17,15 +17,15 @@ class SlicePlotterPresenter(PresenterUtility):
         self._slice_cache = {}
         self._sample_temp_fields = []
 
-    def plot_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap, e_units):
+    def plot_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap):
         workspace = get_workspace_handle(selected_ws)
-        self.create_slice(workspace, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap, e_units)
+        self.create_slice(workspace, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap)
         self.plot_from_cache(workspace)
 
-    def create_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap, e_units):
+    def create_slice(self, selected_ws, x_axis, y_axis, intensity_start, intensity_end, norm_to_one, colourmap):
         sample_temp = sample_temperature(selected_ws, self._sample_temp_fields)
         norm = Normalize(vmin=intensity_start, vmax=intensity_end)
-        slice = compute_slice(selected_ws, x_axis, y_axis, norm_to_one, e_units)
+        slice = compute_slice(selected_ws, x_axis, y_axis, norm_to_one)
         self._cache_slice(slice, colourmap, norm, sample_temp, x_axis, y_axis)
         self._slice_cache[selected_ws.name].norm_to_one = norm_to_one
         return slice

--- a/mslice/presenters/slice_widget_presenter.py
+++ b/mslice/presenters/slice_widget_presenter.py
@@ -111,7 +111,6 @@ class SliceWidgetPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             workspace_selection = workspace_selection[0]
 
             self._slice_view.enable()
-            self._slice_view.enable_units_choice(non_psd)
             axis = get_available_axes(get_workspace_handle(workspace_selection))
             self._slice_view.populate_slice_x_options(axis)
             self._slice_view.populate_slice_y_options(axis[::-1])

--- a/mslice/presenters/slice_widget_presenter.py
+++ b/mslice/presenters/slice_widget_presenter.py
@@ -130,9 +130,9 @@ class SliceWidgetPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             e_units = EnergyUnits(self._slice_view.get_units())
             if e_units.factor_from_meV() != 1.:
                 if 'DeltaE' in self._slice_view.get_slice_x_axis():
-                    x_min, x_max, x_step = e_units.from_meV(x_min, x_max, x_step)
+                    x_min, x_max, x_step = (float(v) for v in e_units.from_meV(x_min, x_max, x_step))
                 else:
-                    y_min, y_max, y_step = e_units.from_meV(y_min, y_max, y_step)
+                    y_min, y_max, y_step = (float(v) for v in e_units.from_meV(y_min, y_max, y_step))
             self._slice_view.enable()
             self._slice_view.populate_slice_x_params(*["%.5f" % x for x in (x_min, x_max, x_step)])
             self._slice_view.populate_slice_y_params(*["%.5f" % x for x in (y_min, y_max, y_step)])

--- a/mslice/presenters/slice_widget_presenter.py
+++ b/mslice/presenters/slice_widget_presenter.py
@@ -58,10 +58,9 @@ class SliceWidgetPresenter(PresenterUtility, SlicePlotterPresenterInterface):
 
         norm_to_one = bool(self._slice_view.get_slice_is_norm_to_one())
         colourmap = self._slice_view.get_slice_colourmap()
-        e_units = self._slice_view.get_units()
 
         self._plot_slice(selected_workspace, x_axis, y_axis, intensity_start, intensity_end,
-                         norm_to_one, colourmap, e_units)
+                         norm_to_one, colourmap)
 
     def _plot_slice(self, *args):
         try:
@@ -85,11 +84,13 @@ class SliceWidgetPresenter(PresenterUtility, SlicePlotterPresenterInterface):
 
     def _x_axis(self):
         return Axis(self._slice_view.get_slice_x_axis(), self._slice_view.get_slice_x_start(),
-                    self._slice_view.get_slice_x_end(), self._slice_view.get_slice_x_step())
+                    self._slice_view.get_slice_x_end(), self._slice_view.get_slice_x_step(),
+                    self._slice_view.get_units())
 
     def _y_axis(self):
         return Axis(self._slice_view.get_slice_y_axis(), self._slice_view.get_slice_y_start(),
-                    self._slice_view.get_slice_y_end(), self._slice_view.get_slice_y_step())
+                    self._slice_view.get_slice_y_end(), self._slice_view.get_slice_y_step(),
+                    self._slice_view.get_units())
 
     def _intensity(self):
         intensity_start = self._slice_view.get_slice_intensity_start()

--- a/mslice/presenters/slice_widget_presenter.py
+++ b/mslice/presenters/slice_widget_presenter.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 from .busy import show_busy
 from mslice.models.alg_workspace_ops import get_available_axes, get_axis_range
 from mslice.models.axis import Axis
+from mslice.models.units import EnergyUnits
 from mslice.models.cmap import ALLOWED_CMAPS
 from mslice.models.slice.slice_functions import is_sliceable
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
@@ -125,11 +126,12 @@ class SliceWidgetPresenter(PresenterUtility, SlicePlotterPresenterInterface):
             self._slice_view.clear_input_fields()
             self._slice_view.disable()
         else:
-            if 'cm' in self._slice_view.get_units():
+            e_units = EnergyUnits(self._slice_view.get_units())
+            if e_units.factor_from_meV() != 1.:
                 if 'DeltaE' in self._slice_view.get_slice_x_axis():
-                    x_min, x_max, x_step = (x * 8.06554 for x in (x_min, x_max, x_step))
+                    x_min, x_max, x_step = e_units.from_meV(x_min, x_max, x_step)
                 else:
-                    y_min, y_max, y_step = (x * 8.06554 for x in (y_min, y_max, y_step))
+                    y_min, y_max, y_step = e_units.from_meV(y_min, y_max, y_step)
             self._slice_view.enable()
             self._slice_view.populate_slice_x_params(*["%.5f" % x for x in (x_min, x_max, x_step)])
             self._slice_view.populate_slice_y_params(*["%.5f" % x for x in (y_min, y_max, y_step)])

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -136,7 +136,7 @@ def add_cut_plot_statements(script_lines, plot_handler):
         default_opts["xmin"]) if plot_handler.is_changed("x_log") else "")
 
     script_lines.append("ax.set_yscale('symlog', linthreshx=pow(10, np.floor(np.log10({}))))\n".format(
-        default_opts["ymin"]) if plot_handler.is_changed("x_log") else "")
+        default_opts["ymin"]) if plot_handler.is_changed("y_log") else "")
 
 
 def add_cut_lines(script_lines, plot_handler):

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -153,7 +153,6 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts):
         integration_end = cut.integration_axis.end
         cut_start, cut_end = integration_start, min(integration_start + cut.width, integration_end)
         intensity_range = (cut.intensity_start, cut.intensity_end)
-        axis_units = cut.cut_axis.units
         norm_to_one = cut.norm_to_one
 
         while cut_start != cut_end and index < len(errorbars):
@@ -175,13 +174,13 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts):
 
             if intensity_range != (None, None):
                 script_lines.append(
-                    'ax.errorbar(cut_ws_{}, x_units="{}", label="{}", color="{}", marker="{}", ls="{}", '
-                    'lw={}, intensity_range={})\n\n'.format(index, axis_units, label, colour, marker, style, width,
+                    'ax.errorbar(cut_ws_{}, label="{}", color="{}", marker="{}", ls="{}", '
+                    'lw={}, intensity_range={})\n\n'.format(index, label, colour, marker, style, width,
                                                             intensity_range))
             else:
                 script_lines.append(
-                    'ax.errorbar(cut_ws_{}, x_units="{}", label="{}", color="{}", marker="{}", ls="{}", '
-                    'lw={})\n\n'.format(index, axis_units, label, colour, marker, style, width))
+                    'ax.errorbar(cut_ws_{}, label="{}", color="{}", marker="{}", ls="{}", '
+                    'lw={})\n\n'.format(index, label, colour, marker, style, width))
 
             cut_start, cut_end = cut_end, min(cut_end + cut.width, integration_end)
             index += 1

--- a/mslice/tests/axis_test.py
+++ b/mslice/tests/axis_test.py
@@ -36,3 +36,12 @@ class AxisTest(unittest.TestCase):
     def test_invalid_start_greater_than_end(self):
         with self.assertRaises(ValueError):
             Axis('x', '1', '0', '.1')
+
+    def test_energy_units(self):
+        with self.assertRaises(ValueError):
+            Axis('DeltaE', '0', '5', '1', 'not_an_energy')
+        axis = Axis('DeltaE', '0', '5', '1', 'cm-1')
+        self.assertNotEqual(axis.scale, 1)
+        self.assertAlmostEqual(axis.start_meV, axis.start * axis.scale, 3)
+        self.assertAlmostEqual(axis.end_meV, axis.end * axis.scale, 3)
+        self.assertAlmostEqual(axis.step_meV, axis.step * axis.scale, 3)

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -228,7 +228,8 @@ class CommandLineTest(unittest.TestCase):
 
     @mock.patch('mslice.cli._mslice_commands.is_gui')
     @mock.patch('mslice.cli._mslice_commands.GlobalFigureManager')
-    def test_that_make_current_works_on_figure_number(self, gfm, is_gui):
+    @mock.patch('mslice.cli._mslice_commands.cli_cut_plotter_presenter')
+    def test_that_make_current_works_on_figure_number(self, cpp, gfm, is_gui):
         is_gui.return_value = True
         gfm.set_figure_as_current = mock.Mock()
         workspace = self.create_workspace('test_make_current')

--- a/mslice/tests/cut_widget_presenter_test.py
+++ b/mslice/tests/cut_widget_presenter_test.py
@@ -260,3 +260,9 @@ class CutWidgetPresenterTest(unittest.TestCase):
             call(selected_workspaces[1], mock.ANY, save_only=False, plot_over=True),
         ]
         cut_plotter_presenter.run_cut.assert_has_calls(call_list)
+
+    def test_set_energy_default(self):
+        cut_widget_presenter = CutWidgetPresenter(self.view)
+        cut_widget_presenter.set_energy_default("meV")
+        self.view.set_energy_units.assert_called_once()
+        self.view.set_energy_units_default.assert_called_once()

--- a/mslice/tests/energy_units_test.py
+++ b/mslice/tests/energy_units_test.py
@@ -1,0 +1,22 @@
+import unittest
+from mslice.models.units import EnergyUnits
+from six import string_types
+
+class EnergyUnitsTest(unittest.TestCase):
+
+    def test_success(self):
+        en_unit = EnergyUnits('meV')
+        # the "meV" unit *must* be defined by this class as it is used in 
+        # all algorithms used by MSlice. Other units may be defined as desired
+        self.assertEqual(en_unit.factor_from_meV(), 1.)
+        self.assertEqual(en_unit.factor_to_meV(), 1.)
+        val = list(en_unit.convert_from('meV',1.))[0]
+        assert(isinstance(val, string_types))
+        self.assertAlmostEqual(float(val),  1., 3)
+        val = list(en_unit.convert_to('meV',1.))[0]
+        assert(isinstance(val, string_types))
+        self.assertAlmostEqual(float(val),  1., 3)
+
+    def test_invalid(self):
+        with self.assertRaises(ValueError):
+            EnergyUnits('not_an_energy_unit')

--- a/mslice/tests/energy_units_test.py
+++ b/mslice/tests/energy_units_test.py
@@ -6,7 +6,7 @@ class EnergyUnitsTest(unittest.TestCase):
 
     def test_success(self):
         en_unit = EnergyUnits('meV')
-        # the "meV" unit *must* be defined by this class as it is used in 
+        # the "meV" unit *must* be defined by this class as it is used in
         # all algorithms used by MSlice. Other units may be defined as desired
         self.assertEqual(en_unit.factor_from_meV(), 1.)
         self.assertEqual(en_unit.factor_to_meV(), 1.)

--- a/mslice/tests/histogram_workspace_test.py
+++ b/mslice/tests/histogram_workspace_test.py
@@ -61,3 +61,8 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
     def test_add_invalid_list(self):
         invalid_list = np.linspace(0, -6, 3)
         self.assertRaises(RuntimeError, lambda: self.workspace + invalid_list)
+
+    def test_attribute_propagation(self):
+        self.set_attribute()
+        new_workspace = HistogramWorkspace(self.workspace.raw_ws, 'new')
+        self.check_attribute_propagation(new_workspace)

--- a/mslice/tests/main_presenter_test.py
+++ b/mslice/tests/main_presenter_test.py
@@ -15,7 +15,7 @@ class MainPresenterTests(unittest.TestCase):
         self.workspace_presenter = mock.create_autospec(WorkspaceManagerPresenterInterface)
         self.workspace_presenter.get_selected_workspaces = mock.Mock(return_value=SELECTED_WORKSPACES)
 
-    def test_consturctor_sucess(self):
+    def test_constructor_sucess(self):
         subpresenters = [mock.Mock() for i in range(10)]
         main_presenter = MainPresenter(self.mainview, *subpresenters)
         for presenter in subpresenters:
@@ -60,3 +60,22 @@ class MainPresenterTests(unittest.TestCase):
         main_presenter.register_workspace_selector(self.workspace_presenter)
         main_presenter.update_displayed_workspaces()
         self.workspace_presenter.update_displayed_workspaces.assert_called_with()
+
+    def test_set_energy_default(self):
+        main_presenter = MainPresenter(self.mainview)
+        clients = [[mock.Mock(), True], [mock.Mock(), False], [mock.Mock(), True]]
+        for client, enable in clients:
+            if not enable:
+                client.set_energy_default = mock.NonCallableMagicMock()
+            main_presenter.subscribe_to_energy_default_monitor(client)
+        
+        for client, enable in clients:
+            client.set_energy_default.assert_not_called()
+
+        main_presenter.set_energy_default('meV')
+        for client, enable in clients:
+            if enable:
+                client.set_energy_default.assert_called_once()
+            else:
+                client.set_energy_default.assert_not_called()
+

--- a/mslice/tests/main_presenter_test.py
+++ b/mslice/tests/main_presenter_test.py
@@ -68,7 +68,7 @@ class MainPresenterTests(unittest.TestCase):
             if not enable:
                 client.set_energy_default = mock.NonCallableMagicMock()
             main_presenter.subscribe_to_energy_default_monitor(client)
-        
+
         for client, enable in clients:
             client.set_energy_default.assert_not_called()
 
@@ -78,4 +78,3 @@ class MainPresenterTests(unittest.TestCase):
                 client.set_energy_default.assert_called_once()
             else:
                 client.set_energy_default.assert_not_called()
-

--- a/mslice/tests/pixel_workspace_test.py
+++ b/mslice/tests/pixel_workspace_test.py
@@ -84,4 +84,3 @@ class PixelWorkspaceTest(unittest.TestCase):
         new_workspace = PixelWorkspace(self.workspace.raw_ws, 'new')
         assert (hasattr(new_workspace, 'axes'))
         assert (new_workspace.axes == self.attr['axes'])
-

--- a/mslice/tests/pixel_workspace_test.py
+++ b/mslice/tests/pixel_workspace_test.py
@@ -76,3 +76,12 @@ class PixelWorkspaceTest(unittest.TestCase):
         self.assertAlmostEqual(0, result[0][0], 8)
         self.assertAlmostEqual(13, result[1][47], 8)
         self.assertAlmostEqual(35, result[3][52], 8)
+
+    def test_attribute_propagation(self):
+        from mslice.workspace.base import attribute_to_comment
+        self.attr = {'axes':[1, object]}
+        attribute_to_comment(self.attr, self.workspace.raw_ws)
+        new_workspace = PixelWorkspace(self.workspace.raw_ws, 'new')
+        assert (hasattr(new_workspace, 'axes'))
+        assert (new_workspace.axes == self.attr['axes'])
+

--- a/mslice/tests/pixel_workspace_test.py
+++ b/mslice/tests/pixel_workspace_test.py
@@ -78,7 +78,7 @@ class PixelWorkspaceTest(unittest.TestCase):
         self.assertAlmostEqual(35, result[3][52], 8)
 
     def test_attribute_propagation(self):
-        from mslice.workspace.base import attribute_to_comment
+        from mslice.workspace.helperfunctions import attribute_to_comment
         self.attr = {'axes':[1, object]}
         attribute_to_comment(self.attr, self.workspace.raw_ws)
         new_workspace = PixelWorkspace(self.workspace.raw_ws, 'new')

--- a/mslice/tests/powder_projection_presenter_test.py
+++ b/mslice/tests/powder_projection_presenter_test.py
@@ -16,7 +16,6 @@ class PowderProjectionPresenterTest(unittest.TestCase):
         self.powder_view = mock.create_autospec(PowderView)
         self.projection_calculator = mock.create_autospec(ProjectionCalculator)
         self.projection_calculator.configure_mock(**{'available_axes.return_value': ['|Q|', '2Theta', 'DeltaE']})
-        self.projection_calculator.configure_mock(**{'available_units.return_value': ['meV', 'cm-1']})
         self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.mainview = mock.create_autospec(MainView)
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -70,6 +70,7 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         cache_mock = mock.MagicMock()
         slice_presenter._slice_cache['workspace'] = cache_mock
         type(cache_mock).overplot_lines = mock.MagicMock()
+        cache_mock.energy_axis.e_unit = 'meV'
 
         slice_presenter.add_overplot_line('workspace', recoil_key, True)
         compute_recoil_mock.assert_called_once()

--- a/mslice/tests/slice_widget_presenter_test.py
+++ b/mslice/tests/slice_widget_presenter_test.py
@@ -165,11 +165,19 @@ class SliceWidgetPresenterTest(unittest.TestCase):
         dims = ['dim1', 'dim2']
         get_available_axes_mock.return_value = dims
         get_axis_range_mock.return_value = (0, 1, 0.1)
+        self.slice_view.get_units = mock.Mock(side_effect=['meV', 'cm-1', 'cm-1'])
         slice_widget_presenter.workspace_selection_changed()
+        assert (self.slice_view.get_slice_x_axis.call_count == 1)
         assert (self.slice_view.populate_slice_x_options.called)
         assert (self.slice_view.populate_slice_y_options.called)
         assert (get_available_axes_mock.called)
         assert (get_axis_range_mock.called)
+        # Test energy unit conversion is different for second call
+        slice_widget_presenter.workspace_selection_changed()
+        self.slice_view.get_slice_x_axis.assert_called()
+        self.slice_view.get_slice_x_axis.return_value = 'DeltaE'
+        slice_widget_presenter.workspace_selection_changed()
+        assert (self.slice_view.get_slice_x_axis.call_count == 5)
         # Test error handling
         get_axis_range_mock.side_effect = KeyError
         slice_widget_presenter.workspace_selection_changed()
@@ -188,3 +196,9 @@ class SliceWidgetPresenterTest(unittest.TestCase):
                 pass
             self.slice_view.clear_displayed_error.assert_called()
             self.slice_view.reset_mock()
+
+    def test_set_energy_default(self):
+        slice_presenter = SliceWidgetPresenter(self.slice_view)
+        slice_presenter.set_energy_default("meV")
+        self.slice_view.set_units.assert_called_once()
+        self.slice_view.set_energy_default.assert_called_once()

--- a/mslice/tests/workspace_test.py
+++ b/mslice/tests/workspace_test.py
@@ -52,7 +52,7 @@ class BaseWorkspaceTest(unittest.TestCase):
         self.assertTrue((result == expected_values).all())
 
     def set_attribute(self):
-        from mslice.workspace.base import attribute_to_comment
+        from mslice.workspace.helperfunctions import attribute_to_comment
         self.attr = {'axes':[1, object]}
         attribute_to_comment(self.attr, self.workspace.raw_ws)
 

--- a/mslice/tests/workspace_test.py
+++ b/mslice/tests/workspace_test.py
@@ -51,6 +51,14 @@ class BaseWorkspaceTest(unittest.TestCase):
         result.sort()
         self.assertTrue((result == expected_values).all())
 
+    def set_attribute(self):
+        from mslice.workspace.base import attribute_to_comment
+        self.attr = {'axes':[1, object]}
+        attribute_to_comment(self.attr, self.workspace.raw_ws)
+
+    def check_attribute_propagation(self, new_workspace):
+        assert (hasattr(new_workspace, 'axes'))
+        assert (new_workspace.axes == self.attr['axes'])
 
 class WorkspaceTest(BaseWorkspaceTest):
 
@@ -97,3 +105,8 @@ class WorkspaceTest(BaseWorkspaceTest):
         result = result.get_signal()
         expected_values = np.multiply(list_to_add, 2)
         self.assertTrue((result == expected_values).all())
+
+    def test_attribute_propagation(self):
+        self.set_attribute()
+        new_workspace = Workspace(self.workspace.raw_ws, 'new')
+        self.check_attribute_propagation(new_workspace)

--- a/mslice/views/cut_plotter.py
+++ b/mslice/views/cut_plotter.py
@@ -28,7 +28,7 @@ def draw_interactive_cut(workspace):
 
 
 @plt.set_category(plt.CATEGORY_CUT)
-def plot_cut_impl(workspace, x_units, intensity_range=None, plot_over=False, legend=None):
+def plot_cut_impl(workspace, intensity_range=None, plot_over=False, legend=None):
     if not plot_over:
         plt.cla()
 
@@ -36,7 +36,7 @@ def plot_cut_impl(workspace, x_units, intensity_range=None, plot_over=False, leg
     ax = cur_fig.add_subplot(111, projection='mslice')
     legend = workspace.name if legend is None else legend
     ax.errorbar(workspace, 'o-', label=legend, picker=PICKER_TOL_PTS, intensity_range=intensity_range,
-                plot_over=plot_over, x_units=x_units)
+                plot_over=plot_over)
 
     return ax.lines
 

--- a/mslice/views/interfaces/cut_view.py
+++ b/mslice/views/interfaces/cut_view.py
@@ -56,6 +56,15 @@ class CutView:
     def get_minimum_step(self):
         pass
 
+    def get_energy_units(self):
+        pass
+
+    def set_energy_units(self, unit):
+        pass
+
+    def set_energy_units_default(self, unit):
+        pass
+
     def display_error(self, string):
         pass
 

--- a/mslice/views/interfaces/powder_projection_view.py
+++ b/mslice/views/interfaces/powder_projection_view.py
@@ -29,9 +29,6 @@ class PowderView(object):
     def get_powder_u2(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
-    def get_powder_units(self):
-        raise NotImplementedError("This method must be implemented in a concrete view before being called")
-
     def set_powder_u1(self, name):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 

--- a/mslice/views/interfaces/slice_view.py
+++ b/mslice/views/interfaces/slice_view.py
@@ -53,6 +53,15 @@ class SliceView:
     def get_slice_colourmap(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 
+    def get_units(self):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def set_units(self, en_unit):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
+    def set_energy_default(self, en_default):
+        raise NotImplementedError("This method must be implemented in a concrete view before being called")
+
     def error_invalid_x_params(self):
         raise NotImplementedError("This method must be implemented in a concrete view before being called")
 

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -151,8 +151,8 @@ class CutWidget(CutView, QWidget):
     def set_energy_units(self, unit):
         self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(unit))
 
-    def set_energy_units_default(self, val):
-        self._en_default = val
+    def set_energy_units_default(self, unit):
+        self._en_default = unit
 
     def set_cut_axis(self, axis_name):
         index = [ind for ind in range(self.cmbCutAxis.count()) if str(self.cmbCutAxis.itemText(ind)) == axis_name]

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -13,6 +13,8 @@ from mslice.util.qt.QtWidgets import QWidget
 from mslice.presenters.cut_widget_presenter import CutWidgetPresenter
 
 from mslice.views.interfaces.cut_view import CutView
+
+from mslice.models.units import EnergyUnits
 from .command import Command
 
 
@@ -40,8 +42,9 @@ class CutWidget(CutView, QWidget):
         self.lneCutStep.editingFinished.connect(self._step_edited)
         self.enable_integration_axis(False)
         self.set_validators()
+        self._en = EnergyUnits('meV')
         self._en_default = 'meV'
-        self._en_unit_index = {'meV':0, 'cm-1':1}
+        self.cmbCutEUnits.currentIndexChanged.connect(self._changed_unit)
 
     def _btn_clicked(self):
         sender = self.sender()
@@ -51,19 +54,37 @@ class CutWidget(CutView, QWidget):
 
     def _step_edited(self):
         """Checks that user inputted step size is not too small."""
-        if self._minimumStep:
+        if self.get_minimum_step():
             try:
                 value = float(self.lneCutStep.text())
             except ValueError:
                 value = 0.0
                 self.display_error('Invalid cut step parameter. Using default.')
             if value == 0.0:
-                self.lneCutStep.setText('%.5f' % (self._minimumStep))
+                self.lneCutStep.setText('%.5f' % (self.get_minimum_step()))
                 self.display_error('Setting step size to default.')
-            elif value < (self._minimumStep / 100.):
+            elif value < (self.get_minimum_step() / 100.):
                 self.display_error('Step size too small!')
                 return False
         return True
+
+    def _changed_unit(self):
+        new_unit = self.get_energy_units()
+        if self._en.factor_to(new_unit) != 1.:
+            if 'DeltaE' in self.get_cut_axis():
+                cut_start, cut_end, cut_step = self._en.convert_to(new_unit,
+                                                                   self.get_cut_axis_start(),
+                                                                   self.get_cut_axis_end(),
+                                                                   self.get_cut_axis_step())
+                self.populate_cut_params(cut_start, cut_end, cut_step)
+            elif 'DeltaE' in self.get_integration_axis():
+                int_start, int_end, int_width = self._en.convert_to(new_unit,
+                                                                    self.get_integration_start(),
+                                                                    self.get_integration_end(),
+                                                                    self.get_integration_width())
+                self.populate_integration_params(int_start, int_end)
+                self.lneCutIntegrationWidth.setText(int_width)
+        self._en = EnergyUnits(new_unit)
 
     def display_error(self, error_string):
         self.error_occurred.emit(error_string)
@@ -127,6 +148,9 @@ class CutWidget(CutView, QWidget):
     def get_energy_units(self):
         return self.cmbCutEUnits.currentText()
 
+    def set_energy_units(self, unit):
+        self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(unit))
+
     def set_energy_units_default(self, val):
         self._en_default = val
 
@@ -138,10 +162,15 @@ class CutWidget(CutView, QWidget):
             self.cmbCutAxis.blockSignals(False)
 
     def set_minimum_step(self, value):
+        # Sets the minimum step size for this cut which if cut axis is DeltaE is always in meV
         self._minimumStep = value
 
     def get_minimum_step(self):
-        return self._minimumStep
+        # Returns the minimum step size in the current energy unit if cut axis is DeltaE
+        if 'DeltaE' in self.get_cut_axis():
+            return self._minimumStep * self._en.factor_from_meV()
+        else:
+            return self._minimumStep
 
     def populate_cut_axis_options(self, options):
         self.cmbCutAxis.blockSignals(True)
@@ -180,7 +209,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutIntegrationWidth.setText("")
         self.lneCutSmoothing.setText("")
         self.rdoCutNormToOne.setChecked(0)
-        self.cmbCutEUnits.setCurrentIndex(self._en_unit_index[self._en_default])
+        self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(self._en_default))
 
     def is_fields_cleared(self):
         current_fields = self.get_input_fields()
@@ -200,17 +229,20 @@ class CutWidget(CutView, QWidget):
         self.lneCutIntegrationWidth.setText(saved_input['integration_width'])
         self.lneCutSmoothing.setText(saved_input['smoothing'])
         self.rdoCutNormToOne.setChecked(saved_input['normtounity'])
-        self.cmbCutEUnits.setCurrentIndex(self._en_unit_index[saved_input['energy_unit']])
+        self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(saved_input['energy_unit']))
 
     def get_input_fields(self):
         saved_input = dict()
         saved_input['axes'] = [str(self.cmbCutAxis.itemText(ind)) for ind in range(self.cmbCutAxis.count())]
-        saved_input['cut_parameters'] = [self.get_cut_axis_start(),
-                                         self.get_cut_axis_end(),
-                                         self.get_cut_axis_step()]
-        saved_input['integration_range'] = [self.get_integration_start(),
-                                            self.get_integration_end()]
-        saved_input['integration_width'] = self.get_integration_width()
+        cut_params = (self.get_cut_axis_start(), self.get_cut_axis_end(), self.get_cut_axis_step())
+        int_params = (self.get_integration_start(), self.get_integration_end(), self.get_integration_width())
+        if 'DeltaE' in self.get_cut_axis():
+            cut_params = list(self._en.to_meV(*cut_params))
+        if 'DeltaE' in self.get_integration_axis():
+            int_params = list(self._en.to_meV(*int_params))
+        saved_input['cut_parameters'] = list(cut_params)
+        saved_input['integration_range'] = list(int_params)[:2]
+        saved_input['integration_width'] = list(int_params)[2]
         saved_input['smoothing'] = self.get_smoothing()
         saved_input['normtounity'] = self.get_intensity_is_norm_to_one()
         saved_input['energy_unit'] = self.get_energy_units()

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -40,6 +40,8 @@ class CutWidget(CutView, QWidget):
         self.lneCutStep.editingFinished.connect(self._step_edited)
         self.enable_integration_axis(False)
         self.set_validators()
+        self._en_default = 'meV'
+        self._en_unit_index = {'meV':0, 'cm-1':1}
 
     def _btn_clicked(self):
         sender = self.sender()
@@ -122,6 +124,12 @@ class CutWidget(CutView, QWidget):
     def get_smoothing(self):
         return str(self.lneCutSmoothing.text())
 
+    def get_energy_units(self):
+        return self.cmbCutEUnits.currentText()
+
+    def set_energy_units_default(self, val):
+        self._en_default = val
+
     def set_cut_axis(self, axis_name):
         index = [ind for ind in range(self.cmbCutAxis.count()) if str(self.cmbCutAxis.itemText(ind)) == axis_name]
         if index:
@@ -172,6 +180,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutIntegrationWidth.setText("")
         self.lneCutSmoothing.setText("")
         self.rdoCutNormToOne.setChecked(0)
+        self.cmbCutEUnits.setCurrentIndex(self._en_unit_index[self._en_default])
 
     def is_fields_cleared(self):
         current_fields = self.get_input_fields()
@@ -191,6 +200,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutIntegrationWidth.setText(saved_input['integration_width'])
         self.lneCutSmoothing.setText(saved_input['smoothing'])
         self.rdoCutNormToOne.setChecked(saved_input['normtounity'])
+        self.cmbCutEUnits.setCurrentIndex(self._en_unit_index[saved_input['energy_unit']])
 
     def get_input_fields(self):
         saved_input = dict()
@@ -203,6 +213,7 @@ class CutWidget(CutView, QWidget):
         saved_input['integration_width'] = self.get_integration_width()
         saved_input['smoothing'] = self.get_smoothing()
         saved_input['normtounity'] = self.get_intensity_is_norm_to_one()
+        saved_input['energy_unit'] = self.get_energy_units()
         return saved_input
 
     def enable(self):
@@ -210,6 +221,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutEnd.setEnabled(True)
         self.lneCutStep.setEnabled(True)
         self.cmbCutAxis.setEnabled(True)
+        self.cmbCutEUnits.setEnabled(True)
 
         self.lneCutIntegrationStart.setEnabled(True)
         self.lneCutIntegrationEnd.setEnabled(True)
@@ -232,6 +244,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutEnd.setEnabled(False)
         self.lneCutStep.setEnabled(False)
         self.cmbCutAxis.setEnabled(False)
+        self.cmbCutEUnits.setEnabled(False)
 
         self.lneCutIntegrationStart.setEnabled(False)
         self.lneCutIntegrationEnd.setEnabled(False)

--- a/mslice/widgets/cut/cut.ui
+++ b/mslice/widgets/cut/cut.ui
@@ -144,6 +144,27 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="4">
+      <widget class="QLabel" name="labCutEUnits">
+       <property name="text">
+        <string>en</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="5">
+      <widget class="QComboBox" name="cmbCutEUnits">
+       <item>
+        <property name="text">
+         <string>meV</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>cm-1</string>
+        </property>
+       </item>
+      </widget>
+     </item>
      <item row="3" column="6" colspan="2">
       <widget class="QPushButton" name="btnCutPlot">
        <property name="text">

--- a/mslice/widgets/projection/powder/powder.py
+++ b/mslice/widgets/projection/powder/powder.py
@@ -68,7 +68,6 @@ class PowderWidget(PowderView, QWidget):
         # Signals are blocked to prevent self._u1_changed being called here (it would be false alarm)
         self.cmbPowderU1.blockSignals(True)
         self.cmbPowderU1.clear()
-        # Assuming that u1 and u2 both have the same possible units.
         self._name_to_index = {}
         for idx, value in enumerate(u1_options):
             self.cmbPowderU1.addItem(value)
@@ -82,14 +81,6 @@ class PowderWidget(PowderView, QWidget):
         for value in u2_options:
             self.cmbPowderU2.addItem(value)
         self.cmbPowderU2.blockSignals(False)
-
-    def populate_powder_projection_units(self, powder_projection_units):
-        self.cmbPowderUnits.clear()
-        for unit in powder_projection_units:
-            self.cmbPowderUnits.addItem(unit)
-
-    def get_powder_units(self):
-        return str(self.cmbPowderUnits.currentText())
 
     def disable_calculate_projections(self, disable):
         self.groupBox.setDisabled(disable)

--- a/mslice/widgets/projection/powder/powder.ui
+++ b/mslice/widgets/projection/powder/powder.ui
@@ -45,16 +45,6 @@
         <item row="1" column="1">
          <widget class="QComboBox" name="cmbPowderU2"/>
         </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Units</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QComboBox" name="cmbPowderUnits"/>
-        </item>
         <item row="2" column="1">
          <widget class="QPushButton" name="btnPowderCalculateProjection">
           <property name="text">
@@ -71,13 +61,13 @@
     <widget class="QLabel" name="error_msg">
      <property name="minimumSize">
       <size>
-       <width>200</width>
+       <width>400</width>
        <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>200</width>
+       <width>400</width>
        <height>16777215</height>
       </size>
      </property>

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -36,10 +36,11 @@ class SliceWidget(SliceView, QWidget):
         self._minimumStep = {}
         self.lneSliceXStep.editingFinished.connect(lambda: self._step_edited('x', self.lneSliceXStep))
         self.lneSliceYStep.editingFinished.connect(lambda: self._step_edited('y', self.lneSliceYStep))
-        self.enable_units_choice(False)
         self.cmbSliceXAxis.currentIndexChanged.connect(lambda ind: self._change_axes(1, ind))
         self.cmbSliceYAxis.currentIndexChanged.connect(lambda ind: self._change_axes(2, ind))
         self.set_validators()
+        self._en_default = 'meV'
+        self._en_unit_index = {'meV':0, 'cm-1':1}
 
     def get_presenter(self):
         return self._presenter
@@ -82,16 +83,6 @@ class SliceWidget(SliceView, QWidget):
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
-
-    def enable_units_choice(self, enabled):
-        if enabled:
-            # TODO implement conversion from meV to cm-1
-            pass
-            #self.cmbSliceUnits.show()
-            #self.label_16.show()
-        else:
-            self.cmbSliceUnits.hide()
-            self.label_16.hide()
 
     def get_units(self):
         return self.cmbSliceUnits.currentText()
@@ -199,6 +190,7 @@ class SliceWidget(SliceView, QWidget):
         self.lneSliceIntensityStart.setText("")
         self.lneSliceIntensityEnd.setText("")
         self.rdoSliceNormToOne.setChecked(0)
+        self.cmbSliceUnits.setCurrentIndex(self._en_unit_index[self._en_default])
         self._minimumStep = {}
 
     def disable(self):
@@ -215,6 +207,7 @@ class SliceWidget(SliceView, QWidget):
         self.rdoSliceNormToOne.setEnabled(False)
         self.btnSliceDisplay.setEnabled(False)
         self.cmbSliceColormap.setEnabled(False)
+        self.cmbSliceUnits.setEnabled(False)
 
     def enable(self):
         self.cmbSliceXAxis.setEnabled(True)
@@ -230,12 +223,16 @@ class SliceWidget(SliceView, QWidget):
         self.rdoSliceNormToOne.setEnabled(True)
         self.btnSliceDisplay.setEnabled(True)
         self.cmbSliceColormap.setEnabled(True)
+        self.cmbSliceUnits.setEnabled(True)
 
     def set_validators(self):
         line_edits = [self.lneSliceXStart, self.lneSliceXEnd, self.lneSliceXStep, self.lneSliceYStart,
                       self.lneSliceYEnd, self.lneSliceYStep, self.lneSliceIntensityStart, self.lneSliceIntensityEnd]
         for line_edit in line_edits:
             line_edit.setValidator(QDoubleValidator())
+
+    def set_units_default(self, val):
+        self._en_default = val
 
     def clear_displayed_error(self):
         self._display_error("")

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -138,12 +138,14 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
             for item_index in range(current_list.count()):
                 current_list.item(item_index).setSelected(False)
             for this_index in (index if hasattr(index, "__iter__") else [index]):
-                current_list.item(this_index).setSelected(True)
+                if this_index >= 0:
+                    current_list.item(this_index).setSelected(True)
         else:
             for item_index in range(current_list.count()):
                 current_list.setItemSelected(current_list.item(item_index), False)
             for this_index in (index if hasattr(index, "__iter__") else [index]):
-                current_list.setItemSelected(current_list.item(this_index), True)
+                if this_index >= 0:
+                    current_list.setItemSelected(current_list.item(this_index), True)
 
     def get_workspace_index(self, ws_name):
         current_list = self.current_list()

--- a/mslice/workspace/base.py
+++ b/mslice/workspace/base.py
@@ -1,32 +1,5 @@
 import abc
-import pickle
-import codecs
 from six import add_metaclass
-
-def attribute_from_comment(ws, raw_ws):
-    try:
-        comstr = raw_ws.getComment()
-    except AttributeError:
-        comstr = ''
-    if comstr:
-        try:
-            attrdict = pickle.loads(codecs.decode(comstr.encode(), 'base64'))
-        except ValueError:
-            pass
-        else:
-            raw_ws.setComment(attrdict.pop('comment', ''))
-            for (k, v) in list(attrdict.items()):
-                if hasattr(ws, k):
-                    setattr(ws, k, v)
-
-def attribute_to_comment(attrdict, raw_ws):
-    try:
-        comstr = raw_ws.getComment()
-        if 'comment' not in attrdict.keys() and comstr:
-            attrdict['comment'] = comstr
-        raw_ws.setComment(str(codecs.encode(pickle.dumps(attrdict), 'base64').decode()))
-    except AttributeError:
-        pass
 
 
 @add_metaclass(abc.ABCMeta)
@@ -74,4 +47,12 @@ class WorkspaceBase(object):
 
     @abc.abstractmethod
     def __neg__(self):
+        return
+
+    @abc.abstractmethod
+    def save_attributes(self):
+        return
+
+    @abc.abstractmethod
+    def remove_comment_attributes(self):
         return

--- a/mslice/workspace/base.py
+++ b/mslice/workspace/base.py
@@ -1,5 +1,26 @@
 import abc
+import pickle
+import codecs
 from six import add_metaclass
+
+def attribute_from_comment(ws, raw_ws):
+    comstr = raw_ws.getComment()
+    if comstr:
+        try:
+            attrdict = pickle.loads(codecs.decode(comstr.encode(), 'base64'))
+        except ValueError:
+            pass
+        else:
+            raw_ws.setComment(attrdict.pop('comment', ''))
+            for (k, v) in list(attrdict.items()):
+                if hasattr(ws, k):
+                    setattr(ws, k, v)
+
+def attribute_to_comment(attrdict, raw_ws):
+    comstr = raw_ws.getComment()
+    if 'comment' not in attrdict.keys() and comstr:
+        attrdict['comment'] = comstr
+    raw_ws.setComment(str(codecs.encode(pickle.dumps(attrdict), 'base64').decode()))
 
 
 @add_metaclass(abc.ABCMeta)

--- a/mslice/workspace/base.py
+++ b/mslice/workspace/base.py
@@ -4,7 +4,10 @@ import codecs
 from six import add_metaclass
 
 def attribute_from_comment(ws, raw_ws):
-    comstr = raw_ws.getComment()
+    try:
+        comstr = raw_ws.getComment()
+    except AttributeError:
+        comstr = ''
     if comstr:
         try:
             attrdict = pickle.loads(codecs.decode(comstr.encode(), 'base64'))
@@ -17,10 +20,13 @@ def attribute_from_comment(ws, raw_ws):
                     setattr(ws, k, v)
 
 def attribute_to_comment(attrdict, raw_ws):
-    comstr = raw_ws.getComment()
-    if 'comment' not in attrdict.keys() and comstr:
-        attrdict['comment'] = comstr
-    raw_ws.setComment(str(codecs.encode(pickle.dumps(attrdict), 'base64').decode()))
+    try:
+        comstr = raw_ws.getComment()
+        if 'comment' not in attrdict.keys() and comstr:
+            attrdict['comment'] = comstr
+        raw_ws.setComment(str(codecs.encode(pickle.dumps(attrdict), 'base64').decode()))
+    except AttributeError:
+        pass
 
 
 @add_metaclass(abc.ABCMeta)

--- a/mslice/workspace/helperfunctions.py
+++ b/mslice/workspace/helperfunctions.py
@@ -1,0 +1,43 @@
+import pickle
+import codecs
+
+def attribute_from_comment(ws, raw_ws):
+    try:
+        comstr = raw_ws.getComment()
+    except AttributeError:
+        comstr = ''
+    if comstr:
+        try:
+            attrdict = pickle.loads(codecs.decode(comstr.encode(), 'base64'))
+        except ValueError:
+            pass
+        else:
+            raw_ws.setComment(attrdict.pop('comment', ''))
+            for (k, v) in list(attrdict.items()):
+                if hasattr(ws, k):
+                    setattr(ws, k, v)
+
+def attribute_to_comment(attrdict, raw_ws):
+    try:
+        comstr = raw_ws.getComment()
+        if 'comment' not in attrdict.keys() and comstr:
+            attrdict['comment'] = comstr
+        raw_ws.setComment(str(codecs.encode(pickle.dumps(attrdict), 'base64').decode()))
+    except AttributeError:
+        pass
+
+class WrapWorkspaceAttribute(object):
+
+    def __init__(self, workspace):
+        self.workspace = workspace if (hasattr(workspace, 'save_attributes')
+                                       and hasattr(workspace, 'remove_comment_attributes')) else None
+
+    def __enter__(self):
+        if self.workspace:
+            self.workspace.save_attributes()
+        return self.workspace
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.workspace:
+            self.workspace.remove_comment_attributes()
+        return True

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-from .base import WorkspaceBase
+from .base import WorkspaceBase, attribute_from_comment
 from .histo_mixin import HistoMixin
 from .workspace_mixin import WorkspaceMixin
 from .workspace import Workspace
@@ -19,10 +19,13 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         self.name = name
         self._cut_params = {}
         self.is_PSD = None
+        self.axes = []
+        attribute_from_comment(self, mantid_ws)
 
     def rewrap(self, ws):
         new_ws = HistogramWorkspace(ws, self.name)
         new_ws.is_PSD = self.is_PSD
+        new_ws.axes = self.axes
         return new_ws
 
     def convert_to_matrix(self):

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -1,8 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
-from .base import WorkspaceBase, attribute_from_comment
+from .base import WorkspaceBase
 from .histo_mixin import HistoMixin
 from .workspace_mixin import WorkspaceMixin
 from .workspace import Workspace
+from .helperfunctions import attribute_from_comment, attribute_to_comment
 
 from mantid.api import IMDHistoWorkspace
 from mantid.simpleapi import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
@@ -36,3 +37,14 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         ws_conv = Scale(ws_conv, bin_size, OutputWorkspace=self.name, StoreInADS=False)
         ConvertToDistribution(ws_conv, StoreInADS=False)
         return Workspace(ws_conv, self.name)
+
+    def save_attributes(self):
+        attrdict = {}
+        comstr = self.raw_ws.getComment()
+        for k, v in [['comment', comstr], ['axes', self.axes]]:
+            if k:
+                attrdict[k] = v
+        attribute_to_comment(attrdict, self.raw_ws)
+
+    def remove_comment_attributes(self):
+        attribute_from_comment(None, self.raw_ws)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -1,8 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
-from .base import WorkspaceBase, attribute_from_comment
+from .base import WorkspaceBase
 from .histogram_workspace import HistogramWorkspace
 from .pixel_mixin import PixelMixin
 from .workspace_mixin import WorkspaceMixin
+from .helperfunctions import attribute_from_comment, attribute_to_comment
 
 from mantid.api import IMDEventWorkspace
 
@@ -37,3 +38,14 @@ class PixelWorkspace(PixelMixin, WorkspaceMixin, WorkspaceBase):
         new_ws.e_fixed = self.e_fixed
         new_ws.axes = self.axes
         return new_ws
+
+    def save_attributes(self):
+        attrdict = {}
+        comstr = self.raw_ws.getComment()
+        for k, v in [['comment', comstr], ['axes', self.axes]]:
+            if k:
+                attrdict[k] = v
+        attribute_to_comment(attrdict, self.raw_ws)
+
+    def remove_comment_attributes(self):
+        attribute_from_comment(None, self.raw_ws)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-from .base import WorkspaceBase
+from .base import WorkspaceBase, attribute_from_comment
 from .histogram_workspace import HistogramWorkspace
 from .pixel_mixin import PixelMixin
 from .workspace_mixin import WorkspaceMixin
@@ -27,10 +27,13 @@ class PixelWorkspace(PixelMixin, WorkspaceMixin, WorkspaceBase):
         self.is_PSD = None
         self.e_mode = None
         self.e_fixed = None
+        self.axes = []
+        attribute_from_comment(self, mantid_ws)
 
     def rewrap(self, ws):
         new_ws = PixelWorkspace(ws, self.name)
         new_ws.is_PSD = self.is_PSD
         new_ws.e_mode = self.e_mode
         new_ws.e_fixed = self.e_fixed
+        new_ws.axes = self.axes
         return new_ws

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-from .base import WorkspaceBase
+from .base import WorkspaceBase, attribute_from_comment
 from .workspace_mixin import WorkspaceMixin
 
 from mantid.api import MatrixWorkspace
@@ -20,6 +20,8 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
         self.is_PSD = None
         self.e_mode = None
         self.e_fixed = None
+        self.axes = []
+        attribute_from_comment(self, mantid_ws)
 
     def rewrap(self, mantid_ws):
         new_ws = Workspace(mantid_ws, self.name)
@@ -28,4 +30,5 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
         new_ws.e_fixed = self.e_fixed
         new_ws.ef_defined = self.ef_defined
         new_ws.limits = self.limits
+        new_ws.axes = self.axes
         return new_ws

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
-from .base import WorkspaceBase, attribute_from_comment
+from .base import WorkspaceBase
 from .workspace_mixin import WorkspaceMixin
+from .helperfunctions import attribute_from_comment, attribute_to_comment
 
 from mantid.api import MatrixWorkspace
 
@@ -32,3 +33,14 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
         new_ws.limits = self.limits
         new_ws.axes = self.axes
         return new_ws
+
+    def save_attributes(self):
+        attrdict = {}
+        comstr = self.raw_ws.getComment()
+        for k, v in [['comment', comstr], ['axes', self.axes]]:
+            if k:
+                attrdict[k] = v
+        attribute_to_comment(attrdict, self.raw_ws)
+
+    def remove_comment_attributes(self):
+        attribute_from_comment(None, self.raw_ws)


### PR DESCRIPTION
This PR adds an energy units conversion framework to MSlice. Only two units are implemented: `meV` (`DeltaE` in Mantid notation, and the actual unit used in all calculations in MSlice) and `cm-1` (`DeltaE_inWavenumber` in Mantid notation).

A new class, `EnergyUnits` has been added to facilitate conversion to/from `meV` before each workspace operation that needs it. The `Axis` class has been modified to be aware of the different energy units and to call `EnergyUnits` for the necessary conversions.

New comboboxes on the `Slice` and `Cut` tabs have been added so users can specify the desired unit. If this is not `meV`, then the output workspaces generated by the `Slice` and `Cut` algorithms are changed (rescaled) to the new unit using either `ScaleX` (for `non-PSD` workspaces) or `TransformMD`. The Mantid `units` label is still left as `DeltaE` however, so to preserve knowledge of the actual energy units, the `Axis` objects used by `Slice` and `Cut` is included in the (MSlice) workspace objects as attributes. 

As the `algorithms` only work with pure Mantid workspaces these attributes would be lost on re-wrapping, so a mechanism to `pickle` these `Axis` attributes via the `comment` attribute of the Mantid workspace is used (TODO: change from using `comment` to using `log`).

The energy units combo box in the `Powder` tab has been removed - the conversion (using `MakeProjection`) to `PixelWorkspace` (`MDEventWorkspace` in Mantid terms) is now done only in `meV` - but `Slice` and `Cut` from the `PixelWorkspace` can convert the energy units to something else.

Finally a new menu option has been added which sets the default energy unit used by MSlice - this basically resets the energy units combo box to the default unit if it encounters a new workspace without saved cut parameters, so that users don't have to keep clicking on the combo box if they want to regularly use a unit that is not `meV`.

TODO: sort out file saving mechanisms for different energy units.

**To test:**

<!-- Instructions for testing. -->

Code review.

Run MSlice and load some workspaces. Plot slices and cuts with `cm-1` as the unit and check they look equivalent to the cuts with `meV` - not that changing from `meV` to `cm-1` in the combo box should trigger a callback that will rescale the parameters in the `DeltaE` cut or slice parameter fields.

Check that when `cm-1` is selected as the default unit in the `Options` menu that when clicking on a new workspace or new cut axis that the energy units is set to `cm-1`.

Check that the overplot information (recoil and powder lines) still look ok in `cm-1`. 

Check that interactive cuts work ok in `cm-1`.

Check that script generation with plots in `cm-1` works and the scripts reproduce the plots.

More detailed test instructions to follow.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #438
