### PR TITLE
Cut plotter bugsfixes

### DIFF
--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -40,7 +40,7 @@ _intensity_to_workspace = {
 
 def _update_cache(cut_presenter, ws_name, CutAxis, IntegrationAxis, NormToOne):
     """Creates a list of all cuts used to create a particular cut. This is required when plot over is used."""
-    cut_list = cut_presenter._cut_cache_list
+    cut_list = cut_presenter._cut_cache_dict
     cut_cache = cut_presenter._cut_cache
     int_axis = Axis(*IntegrationAxis.split(','))
     cut_axis = Axis(*CutAxis.split(','))

--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -40,29 +40,13 @@ _intensity_to_workspace = {
 
 def _update_cache(cut_presenter, ws_name, CutAxis, IntegrationAxis, NormToOne):
     """Creates a list of all cuts used to create a particular cut. This is required when plot over is used."""
-    cut_list = cut_presenter._cut_cache_dict
-    cut_cache = cut_presenter._cut_cache
+    import mslice.plotting.pyplot as plt
     int_axis = Axis(*IntegrationAxis.split(','))
     cut_axis = Axis(*CutAxis.split(','))
     width = None if int_axis.end - int_axis.start == 0 else str(int_axis.end - int_axis.start)
-    if len(cut_list) == 0:
-        cut = Cut(cut_axis, int_axis, None, None, NormToOne, width)
-        cut.workspace_name = ws_name
-        cut_list.append(cut)
-        cut_cache[ws_name] = cut
-    else:
-        for cut in cut_list:
-            if str(cut.cut_axis) == str(cut_axis) and cut.width == float(width) and cut.norm_to_one == NormToOne\
-                    and cut.workspace_name == ws_name:
-                if cut.integration_axis.start > int_axis.start:
-                    cut.integration_axis = int_axis.start
-                if cut.integration_axis.end < int_axis.end:
-                    cut.integration_axis.end = int_axis.end
-                return
     cut = Cut(cut_axis, int_axis, None, None, NormToOne, width)
-    cut.workspace_name = ws_name
-    cut_list.append(cut)
-    cut_cache[ws_name] = cut
+    cut_presenter.save_cache(plt.gca(), cut, True)
+    cut_presenter._cut_cache[ws_name] = cut
 
 def _update_legend():
     plot_handler = GlobalFigureManager.get_active_figure().plot_handler

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -75,7 +75,7 @@ class CutPlot(IPlot):
         self._canvas.figure.gca().remove_callack(self.mpl_axes_changed)
 
     def window_closing(self):
-        icut = self._cut_plotter_presenter.get_icut(self.ws_name)
+        icut = self._cut_plotter_presenter.get_icut()
         if icut is not None:
             icut.window_closing()
             self.manager.button_pressed_connected(False)
@@ -243,11 +243,11 @@ class CutPlot(IPlot):
         self.plot_window.show()
 
     def save_icut(self):
-        icut = self._cut_plotter_presenter.get_icut(self.ws_name)
+        icut = self._cut_plotter_presenter.get_icut()
         return icut.save_cut()
 
     def flip_icut(self):
-        icut = self._cut_plotter_presenter.get_icut(self.ws_name)
+        icut = self._cut_plotter_presenter.get_icut()
         icut.flip_axis()
 
     def _get_line_index(self, line):

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -1,6 +1,7 @@
 from matplotlib.widgets import RectangleSelector
 
 from mslice.models.axis import Axis
+from mslice.models.cut.cut import Cut
 from mslice.models.cut.cut_functions import output_workspace_name
 from mslice.models.workspacemanager.workspace_algorithms import (get_limits)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
@@ -16,7 +17,12 @@ class InteractiveCut(object):
 
         self.horizontal = None
         self.connect_event = [None, None, None, None]
+        # We need to access the CutPlotterPresenter instance of the particular CutPlot (window) we are using
+        # But there is no way to get without changing the active category then calling the GlobalFigureManager.
+        # So we create a new temporary here. After the first time we plot a 1D plot, the correct category is set
+        # and we can get the correct CutPlot instance and its CutPlotterPresenter
         self._cut_plotter_presenter = CutPlotterPresenter()
+        self._is_initial_cut_plotter_presenter = True
         self._rect_pos_cache = [0, 0, 0, 0, 0, 0]
         self.rect = RectangleSelector(self._canvas.figure.gca(), self.plot_from_mouse_event,
                                       drawtype='box', useblit=True,
@@ -42,8 +48,15 @@ class InteractiveCut(object):
             units = self._canvas.figure.gca().get_yaxis().units if self.horizontal else \
                 self._canvas.figure.gca().get_xaxis().units
             integration_axis = Axis(units, integration_start, integration_end, 0)
-            self._cut_plotter_presenter.plot_interactive_cut(str(self._ws_title), ax, integration_axis, store)
-            self._cut_plotter_presenter.store_icut(self._ws_title, self)
+            cut = Cut(ax, integration_axis, None, None)
+            self._cut_plotter_presenter.plot_interactive_cut(str(self._ws_title), cut, store)
+            self._cut_plotter_presenter.set_is_icut(True)
+            if self._is_initial_cut_plotter_presenter:
+                # First time we've plotted a 1D cut - get the true CutPlotterPresenter
+                from mslice.plotting.pyplot import GlobalFigureManager
+                self._cut_plotter_presenter = GlobalFigureManager.get_active_figure().plot_handler._cut_plotter_presenter
+                self._is_initial_cut_plotter_presenter = False
+            self._cut_plotter_presenter.store_icut(self)
 
     def get_cut_parameters(self, pos1, pos2):
         start = pos1[not self.horizontal]
@@ -80,7 +93,7 @@ class InteractiveCut(object):
         self.slice_plot.update_workspaces()
 
     def clear(self):
-        self._cut_plotter_presenter.set_is_icut(self._ws_title, False)
+        self._cut_plotter_presenter.set_is_icut(False)
         self.rect.set_active(False)
         for event in self.connect_event:
             self._canvas.mpl_disconnect(event)

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -1,6 +1,5 @@
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists
 from mslice.models.cut.cut_functions import compute_cut
-from mslice.models.cut.cut import Cut
 from mslice.models.labels import generate_legend
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 import mslice.plotting.pyplot as plt
@@ -11,6 +10,7 @@ class CutPlotterPresenter(PresenterUtility):
 
     def __init__(self):
         self._main_presenter = None
+        self._interactive_cut_cache = None
         self._cut_cache = {}
         self._cut_cache_list = []  # List of all currently displayed cuts created with plot_over set to True
 
@@ -19,12 +19,7 @@ class CutPlotterPresenter(PresenterUtility):
         cut.workspace_name = workspace.name
         self._cut_cache[workspace.name] = cut
 
-        # If plot over is True you want to save all plotted cuts for use by the cli
-        if len(self._cut_cache_list) == 0 or plot_over:
-            self._cut_cache_list.append(cut)
-        if not plot_over:
-            self._cut_cache_list[:] = []
-            self._cut_cache_list.append(cut)
+        self.save_cache(cut, plot_over)
 
         if cut.width is not None:
             self._plot_with_width(workspace, cut, plot_over)
@@ -41,7 +36,7 @@ class CutPlotterPresenter(PresenterUtility):
                                  integration_axis.end)
         plot_cut_impl(cut_ws, cut_axis.units, (cut.intensity_start, cut.intensity_end), plot_over, legend)
         if update_main:
-            self.set_is_icut(workspace.name, False)
+            self.set_is_icut(False)
             self.update_main_window()
 
     def _plot_with_width(self, workspace, cut, plot_over):
@@ -58,6 +53,14 @@ class CutPlotterPresenter(PresenterUtility):
             plot_over = True
         cut.reset_integration_axis(cut.start, cut.end)
 
+    def save_cache(self, cut, plot_over=False):
+        # If plot over is True you want to save all plotted cuts for use by the cli
+        if len(self._cut_cache_list) == 0 or plot_over:
+            self._cut_cache_list.append(cut)
+        if not plot_over:
+            self._cut_cache_list[:] = []
+            self._cut_cache_list.append(cut)
+
     def save_cut_to_workspace(self, workspace, cut):
         compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one)
         self._main_presenter.update_displayed_workspaces()
@@ -73,31 +76,23 @@ class CutPlotterPresenter(PresenterUtility):
         workspace = get_workspace_handle(workspace)
         lines = plot_cut_impl(workspace, workspace.raw_ws.getDimension(0).getUnits(),
                               intensity_range=intensity_range, plot_over=plot_over)
-        self.set_is_icut(workspace.name, False)
+        self.set_is_icut(False)
         return lines
 
-    def plot_interactive_cut(self, workspace, cut_axis, integration_axis, store):
+    def plot_interactive_cut(self, workspace, cut, store):
         workspace = get_workspace_handle(workspace)
-        cut = Cut(cut_axis, integration_axis, None, None)
-        self._cut_cache[workspace.name] = cut
         self._plot_cut(workspace, cut, False, store, update_main=False)
         draw_interactive_cut(workspace)
 
-    def store_icut(self, workspace_name, icut):
-        self.set_is_icut(workspace_name, True)
-        self._cut_cache[workspace_name].icut = icut
+    def store_icut(self, icut):
+        self._interactive_cut_cache = icut
 
-    def set_is_icut(self, workspace_name, is_icut):
-        if not is_icut and workspace_name in self._cut_cache:
-            self._cut_cache[workspace_name].icut = None
+    def set_is_icut(self, is_icut):
         if cut_figure_exists():
             plt.gcf().canvas.manager.is_icut(is_icut)
 
-    def get_icut(self, workspace_name):
-        try:
-            return self._cut_cache[workspace_name].icut
-        except KeyError:
-            return None
+    def get_icut(self):
+        return self._interactive_cut_cache
 
     def update_main_window(self):
         if self._main_presenter is not None:

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -30,7 +30,7 @@ def add_header(script_lines, plot_handler):
     script_lines.append("\n")
 
 
-def add_plot_statements(script_lines, plot_handler):
+def add_plot_statements(script_lines, plot_handler, ax):
     """Adds plot statements to the script lines used to generate the python script"""
     from mslice.plotting.plot_window.slice_plot import SlicePlot
     from mslice.plotting.plot_window.cut_plot import CutPlot
@@ -45,7 +45,7 @@ def add_plot_statements(script_lines, plot_handler):
             add_slice_plot_statements(script_lines, plot_handler)
             add_overplot_statements(script_lines, plot_handler)
         elif isinstance(plot_handler, CutPlot):
-            add_cut_plot_statements(script_lines, plot_handler)
+            add_cut_plot_statements(script_lines, plot_handler, ax)
 
         script_lines.append("mc.Show()\n")
 
@@ -125,11 +125,11 @@ def add_overplot_statements(script_lines, plot_handler):
                         plot_handler.ws_name, cif))
 
 
-def add_cut_plot_statements(script_lines, plot_handler):
+def add_cut_plot_statements(script_lines, plot_handler, ax):
     """Adds cut specific statements to the script"""
     default_opts = plot_handler.default_options
 
-    add_cut_lines(script_lines, plot_handler)
+    add_cut_lines(script_lines, plot_handler, ax)
     add_plot_options(script_lines, plot_handler)
 
     script_lines.append("ax.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10({}))))\n".format(
@@ -139,8 +139,8 @@ def add_cut_plot_statements(script_lines, plot_handler):
         default_opts["ymin"]) if plot_handler.is_changed("x_log") else "")
 
 
-def add_cut_lines(script_lines, plot_handler):
-    cuts = plot_handler._cut_plotter_presenter._cut_cache_list
+def add_cut_lines(script_lines, plot_handler, ax):
+    cuts = plot_handler._cut_plotter_presenter._cut_cache_dict[ax]
     errorbars = plot_handler._canvas.figure.gca().containers
     add_cut_lines_with_width(errorbars, script_lines, cuts)
 

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -96,9 +96,9 @@ class CommandLineTest(unittest.TestCase):
         result = MakeProjection(workspace, '|Q|', 'DeltaE')
         signal = result.get_signal()
         self.assertEqual(type(result), PixelWorkspace)
-        self.assertAlmostEqual(signal[0][0], 0, 4)
-        self.assertAlmostEqual(signal[0][11], 0.1753, 4)
-        self.assertAlmostEqual(signal[0][28], 0.4248, 4)
+        self.assertAlmostEqual(signal[0][0], 0, 2)
+        self.assertAlmostEqual(signal[0][11], 0.175, 2)
+        self.assertAlmostEqual(signal[0][28], 0.4248, 2)
 
     @mock.patch('mslice.app.presenters.get_powder_presenter')
     def test_projection_fail_non_PSD(self, get_pp):
@@ -114,8 +114,8 @@ class CommandLineTest(unittest.TestCase):
         result = Slice(workspace)
         signal = result.get_signal()
         self.assertEqual(type(result), Workspace)
-        self.assertAlmostEqual(0.4250, signal[1][10], 4)
-        self.assertAlmostEqual(0.9250, signal[4][11], 4)
+        self.assertAlmostEqual(0.425, signal[1][10], 2)
+        self.assertAlmostEqual(0.925, signal[4][11], 2)
 
     @mock.patch('mslice.app.presenters.get_slice_plotter_presenter')
     def test_slice_non_psd_axes_specified(self, get_spp):
@@ -124,8 +124,8 @@ class CommandLineTest(unittest.TestCase):
         result = Slice(workspace, 'DeltaE,0,15,1', '|Q|,0,3,0.1')
         signal = result.get_signal()
         self.assertEqual(type(result), Workspace)
-        self.assertAlmostEqual(0.4250, signal[2][0], 4)
-        self.assertAlmostEqual(0.9250, signal[5][1], 4)
+        self.assertAlmostEqual(0.425, signal[2][0], 2)
+        self.assertAlmostEqual(0.925, signal[5][1], 2)
 
     @mock.patch('mslice.cli._mslice_commands.is_gui')
     @mock.patch('mslice.app.presenters.get_cut_plotter_presenter')
@@ -136,8 +136,8 @@ class CommandLineTest(unittest.TestCase):
         result = Cut(workspace)
         signal = result.get_signal()
         self.assertEqual(type(result), HistogramWorkspace)
-        self.assertAlmostEqual(1.1299, signal[5], 4)
-        self.assertAlmostEqual(1.375, signal[8], 4)
+        self.assertAlmostEqual(1.129, signal[5], 2)
+        self.assertAlmostEqual(1.375, signal[8], 2)
 
     @mock.patch('mslice.app.presenters.get_slice_plotter_presenter')
     def test_slice_psd(self, get_spp):

--- a/mslice/tests/cut_plotter_presenter_test.py
+++ b/mslice/tests/cut_plotter_presenter_test.py
@@ -85,21 +85,12 @@ class CutPlotterPresenterTest(unittest.TestCase):
         get_ws_handle_mock.return_value = mock_ws
         cut_axis = Axis("units", "0", "100", "1")
         integration_axis = Axis("units", 0.0, 100.0, 0)
-        self.cut_plotter_presenter.plot_interactive_cut('workspace', cut_axis, integration_axis, False)
+        cut = Cut(cut_axis, integration_axis, None, None)
+        self.cut_plotter_presenter.plot_interactive_cut('workspace', cut, False)
 
         self.assertEqual(1, compute_cut_mock.call_count)
         self.assertEqual(1, plot_cut_impl_mock.call_count)
         self.assertEqual(1, draw_interact_mock.call_count)
-
-    def test_store_icut(self):
-        self.cut_plotter_presenter.set_is_icut = mock.MagicMock()
-        mock_ws = mock.MagicMock()
-        mock_ws.icut = 'icut'
-        mock_ws.name = 'workspace'
-        mock_icut = mock.MagicMock()
-        self.cut_plotter_presenter._cut_cache = {'workspace': mock_ws}
-        self.cut_plotter_presenter.store_icut(mock_ws.name, mock_icut)
-        self.cut_plotter_presenter.set_is_icut.assert_called_once_with(mock_ws.name, True)
 
     @mock.patch('mslice.presenters.cut_plotter_presenter.cut_figure_exists')
     def test_set_is_icut(self, cut_figure_exists):
@@ -111,17 +102,12 @@ class CutPlotterPresenterTest(unittest.TestCase):
 
         self.cut_plotter_presenter.set_is_icut(mock_ws.name, False)
 
-    def test_get_icut(self):
-        mock_ws = mock.MagicMock()
-        mock_ws.name = 'workspace'
-        mock_ws.icut = 'icut'
-
-        self.cut_plotter_presenter._cut_cache = {}
-        return_value = self.cut_plotter_presenter.get_icut('workspace')
+    def test_store_and_get_icut(self):
+        return_value = self.cut_plotter_presenter.get_icut()
         self.assertEquals(return_value, None)
 
-        self.cut_plotter_presenter._cut_cache = {mock_ws.name: mock_ws}
-        return_value = self.cut_plotter_presenter.get_icut('workspace')
+        self.cut_plotter_presenter.store_icut('icut')
+        return_value = self.cut_plotter_presenter.get_icut()
         self.assertEquals(return_value, 'icut')
 
     def test_workspace_selection_changed(self):


### PR DESCRIPTION
This is a small PR to fix some bugs identified during implementation of the energy units conversion framework - because the fixes here don't really fit into that work.

This PR fixes the first two issues mentioned in #443 (buttons doing nothing in the interactive cut window, and script generation getting things wrong if there are multiple cut windows and the user switches back and forth between them). The third issue cannot be addressed easily but the machinery for it is included in PR #442 (inclusion of MSlice `Axis` instances within `Workspaces` and using workspace comments to propagate them through Mantid algorithms). This is because the CLI does not really use the `CutPlotterPresenter` which is used by the GUI to cache cut information. So calls to cache cut information from the CLI must be in the `errorbar` function itself.

**To test:**

<!-- Instructions for testing. -->

1. Load a workspace, make a slice from it and select `Interactive Cut`. In the interactive cut window (with the 1D line plot) click on either of the `Save workspace` or `Flip axis` buttons and check that they work as advertise (e.g. a workspace is created in the `MDHisto` tab and the integration axis is changed).

2. Make a series of cuts using `Plot Over` then `Keep` that figure. Make another series of cuts and go back to the kept (first) figure. Click on its `File` menu and select `Generate Script`. Check that the generated script is correct for this figure window. Go the the second window (the `Current` one) and generate a script for that one and also check that it's ok.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #443 .
