### PR TITLE
Minor bugs fixes

### DIFF
--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -17,8 +17,6 @@ from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.util.qt.qapp import QAppThreadCall, mainloop
 from six import string_types
 from mslice.workspace.histogram_workspace import HistogramWorkspace
-from mslice.app.presenters import cli_slice_plotter_presenter
-from mslice.app.presenters import cli_cut_plotter_presenter
 
 from mslice.util.mantid import in_mantidplot
 
@@ -196,6 +194,7 @@ def PlotSlice(InputWorkspace, IntensityStart="", IntensityEnd="", Colormap=DEFAU
     _check_workspace_type(workspace, HistogramWorkspace)
 
     # slice cache needed from main slice plotter presenter
+    from mslice.app.presenters import cli_slice_plotter_presenter
     if is_gui():
         cli_slice_plotter_presenter._slice_cache = app.MAIN_WINDOW.slice_plotter_presenter._slice_cache
     cli_slice_plotter_presenter.change_intensity(workspace.name, IntensityStart, IntensityEnd)
@@ -225,6 +224,7 @@ def PlotCut(InputWorkspace, IntensityStart=0, IntensityEnd=0, PlotOver=False):
         intensity_range = None
     else:
         intensity_range = (IntensityStart, IntensityEnd)
+    from mslice.app.presenters import cli_cut_plotter_presenter
     cli_cut_plotter_presenter.plot_cut_from_workspace(workspace, intensity_range=intensity_range,
                                                       plot_over=PlotOver)
 

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -42,8 +42,6 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
                 path += file_dialog.selectedFilter()[-5:-1]
             ext = path[path.rfind('.'):]
             return os.path.dirname(path), os.path.basename(path), ext
-        else:
-            raise RuntimeError("dialog cancelled")
 
 
 def save_nexus(workspace, path, is_slice):

--- a/mslice/plotting/globalfiguremanager.py
+++ b/mslice/plotting/globalfiguremanager.py
@@ -55,6 +55,9 @@ class GlobalFigureManager(object):
     _active_figure = None
     _last_active_figure = None
     _figures = {}
+    # If the following attribute is True, "Make Current" will be disabled for all open figures. This will be used for
+    # the interactive cut window to stop other windows being made current whilst the interactive cut is active.
+    _disable_make_current = False
 
     @classmethod
     def destroy(cls, num):
@@ -271,6 +274,10 @@ class GlobalFigureManager(object):
 
     @classmethod
     def set_figure_as_current(cls, num=None):
+        if cls._disable_make_current:
+            cls.broadcast(None)
+            return
+
         if num is None:
             if cls._last_active_figure is None:
                 num = cls.get_active_figure().number
@@ -310,6 +317,14 @@ class GlobalFigureManager(object):
                 cls._figures[figure].flag_as_current()
             else:
                 cls._figures[figure].flag_as_kept()
+
+    @classmethod
+    def disable_make_current(cls, category=None):
+        cls._disable_make_current = True
+
+    @classmethod
+    def enable_make_current(cls, category=None):
+        cls._disable_make_current = False
 
     @classmethod
     def all_figure_numbers(cls):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -36,6 +36,7 @@ class CutPlot(IPlot):
         self.setup_connections(self.plot_window)
         self.default_options = None
         self._waterfall_cache = {}
+        self._is_icut = False
 
     def save_default_options(self):
         self.default_options = {
@@ -74,7 +75,7 @@ class CutPlot(IPlot):
 
     def window_closing(self):
         icut = self._cut_plotter_presenter.get_icut()
-        if icut is not None:
+        if icut is not None and self._is_icut:
             icut.window_closing()
             self.manager.button_pressed_connected(False)
             self.manager.picking_connected(False)
@@ -225,7 +226,7 @@ class CutPlot(IPlot):
             for element in error_bar_elements:
                 element.set_alpha(1)
 
-    def is_icut(self, is_icut):
+    def set_is_icut(self, is_icut):
         self.manager.button_pressed_connected(not is_icut)
         self.manager.picking_connected(not is_icut)
 
@@ -239,6 +240,7 @@ class CutPlot(IPlot):
         self.plot_window.action_waterfall.setVisible(not is_icut)
 
         self.plot_window.show()
+        self._is_icut = is_icut
 
     def save_icut(self):
         icut = self._cut_plotter_presenter.get_icut()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -59,6 +59,7 @@ class InteractiveCut(object):
                 from mslice.plotting.pyplot import GlobalFigureManager
                 self._cut_plotter_presenter = GlobalFigureManager.get_active_figure().plot_handler._cut_plotter_presenter
                 self._is_initial_cut_plotter_presenter = False
+                GlobalFigureManager.disable_make_current()
             self._cut_plotter_presenter.store_icut(self)
 
     def get_cut_parameters(self, pos1, pos2):

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -114,9 +114,9 @@ class PlotFigureManagerQT(QtCore.QObject):
     def get_cut_background(self):
         return self.plot_handler.background
 
-    def is_icut(self, is_icut):
+    def set_is_icut(self, is_icut):
         if self.plot_handler is not None:
-            self.plot_handler.is_icut(is_icut)
+            self.plot_handler.set_is_icut(is_icut)
 
     def picking_connected(self, connect):
         if connect:

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -432,6 +432,8 @@ class SlicePlot(IPlot):
         if self.icut is not None:
             self.icut.clear()
             self.icut = None
+            from mslice.plotting.pyplot import GlobalFigureManager
+            GlobalFigureManager.enable_make_current()
         else:
             self.icut = InteractiveCut(self, self._canvas, self.ws_name)
 

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -88,7 +88,7 @@ class CutPlotterPresenter(PresenterUtility):
 
     def set_is_icut(self, is_icut):
         if cut_figure_exists():
-            plt.gcf().canvas.manager.is_icut(is_icut)
+            plt.gcf().canvas.manager.set_is_icut(is_icut)
 
     def get_icut(self):
         return self._interactive_cut_cache

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -77,6 +77,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             elif not psd and self._psd:
                 self._workspace_manager_view.tab_changed.emit(TAB_NONPSD)
                 self._psd = False
+        else:
+            # Default is PSD mode, if changed to a non-2D-workspace the GUI resets to the PSD ("Powder") tab
+            self._psd = True
 
     def _confirm_workspace_overwrite(self, ws_name):
         if ws_name in get_visible_workspace_names():

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -189,20 +189,20 @@ class CommandLineTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             Cut(workspace)
 
-    @mock.patch('mslice.cli._mslice_commands.cli_slice_plotter_presenter')
-    def test_plot_slice(self, spp):
+    def test_plot_slice(self):
         slice_ws = Slice(self.create_pixel_workspace('test_plot_slice_cli'))
-        PlotSlice(slice_ws)
-        spp.plot_from_cache(slice_ws)
+        with mock.patch('mslice.app.presenters.cli_slice_plotter_presenter') as spp:
+            PlotSlice(slice_ws)
+        spp.plot_from_cache.assert_called_once_with(slice_ws)
 
-    @mock.patch('mslice.cli._mslice_commands.cli_slice_plotter_presenter')
-    def test_plot_slice_non_psd(self, spp):
+    def test_plot_slice_non_psd(self):
         slice_ws = Slice(self.create_workspace('test_plot_slice_non_psd_cli'))
-        PlotSlice(slice_ws)
-        spp.plot_from_cache(slice_ws)
+        with mock.patch('mslice.app.presenters.cli_slice_plotter_presenter') as spp:
+            PlotSlice(slice_ws)
+        spp.plot_from_cache.assert_called_once_with(slice_ws)
 
     @mock.patch('mslice.cli._mslice_commands.is_gui')
-    @mock.patch('mslice.cli._mslice_commands.cli_cut_plotter_presenter')
+    @mock.patch('mslice.app.presenters.cli_cut_plotter_presenter')
     def test_plot_cut(self, cpp, is_gui):
         is_gui.return_value = True
         workspace = self.create_pixel_workspace('test_plot_cut_cli')
@@ -211,7 +211,7 @@ class CommandLineTest(unittest.TestCase):
         cpp.plot_cut_from_workspace.assert_called_once_with(cut, intensity_range=None, plot_over=False)
 
     @mock.patch('mslice.cli._mslice_commands.is_gui')
-    @mock.patch('mslice.cli._mslice_commands.cli_cut_plotter_presenter')
+    @mock.patch('mslice.app.presenters.cli_cut_plotter_presenter')
     def test_plot_cut_non_psd(self, cpp, is_gui):
         is_gui.return_value = True
         workspace = self.create_workspace('test_plot_cut_non_psd_cli')
@@ -221,8 +221,7 @@ class CommandLineTest(unittest.TestCase):
 
     @mock.patch('mantid.plots.plotfunctions.errorbar')
     @mock.patch('mslice.cli._mslice_commands.is_gui')
-    @mock.patch('mslice.cli._mslice_commands.cli_cut_plotter_presenter')
-    def test_errorbar_command(self, cpp, is_gui, mantid_errorbar):
+    def test_errorbar_command(self, is_gui, mantid_errorbar):
         is_gui.return_value = True
         workspace = self.create_workspace('test_plot_cut_non_psd_cli')
         cut = Cut(workspace)
@@ -260,7 +259,7 @@ class CommandLineTest(unittest.TestCase):
 
     @mock.patch('mslice.cli._mslice_commands.is_gui')
     @mock.patch('mslice.cli._mslice_commands.GlobalFigureManager')
-    @mock.patch('mslice.cli._mslice_commands.cli_cut_plotter_presenter')
+    @mock.patch('mslice.app.presenters.cli_cut_plotter_presenter')
     def test_that_make_current_works_on_figure_number(self, cpp, gfm, is_gui):
         is_gui.return_value = True
         gfm.set_figure_as_current = mock.Mock()

--- a/mslice/tests/file_io_test.py
+++ b/mslice/tests/file_io_test.py
@@ -73,8 +73,6 @@ class FileIOTest(unittest.TestCase):
     def test_save_directory_cancelled(self, file_dialog_mock):
         file_dialog_mock.return_value = self.mock_dialog
         self.mock_dialog.exec_.return_value = False
-        with self.assertRaises(RuntimeError):
-            get_save_directory()
         self.mock_dialog.selectedFiles.assert_not_called()
         self.mock_dialog.selectedFilter.assert_not_called()
 

--- a/mslice/tests/slice_functions_test.py
+++ b/mslice/tests/slice_functions_test.py
@@ -50,7 +50,7 @@ class SliceFunctionsTest(unittest.TestCase):
     def test_boltzmann_dist(self):
         e_axis = np.arange(self.e_axis.start, self.e_axis.end, self.e_axis.step)
         boltz = compute_boltzmann_dist(10, e_axis)
-        self.assertAlmostEqual(boltz[0], 109592.269, 3)
+        self.assertAlmostEqual(boltz[0], 109592.269, 0)
         self.assertAlmostEqual(boltz[10], 1.0, 3)
         self.assertAlmostEqual(boltz[20], 0.000009125, 9)
 


### PR DESCRIPTION
This PR fixes several bugs identified in the unscripted testing for Mantid 4.0

It also fixes some issues with the unit testing on PyCharm in Windows (using Mantid 3.13) which seems to be sensitive to recursive import

**To test:**

<!-- Instructions for testing. -->

1. Load a non-PSD workspace (e.g. `MAR21335_Ei60.00meV.nxspe`). Then change tab to `MDEvent` or `MDHisto`. Then change back to `2D` and click on the workspace name again. Check that it correctly disables the `Powder` tab and enables the `Slice` and `Cut` tabs.

2. Plot a slice from the loaded workspace. Got to `File`->`Generate Script`. In the file dialog, click `Cancel`. Check that no exception is raised.

3. In the slice window, click `Interactive Cut`. Draw a rectangular region in the slice and see that a cut window pops up. Click on `Interactive Cut` again to disable interactive cut mode. Then in the cut window click on `Keep`. Back in the slice window, click `Interactive Cut` again and draw another rectangle, and see that a new cut window is created. Now go back to the first cut window (which has `Keep` checked) and click `Make Current` - check that this is not allowed (the GUI will force `Keep` to again be checked). Now close the first cut window (the one with `Keep` checked). Verify that the slice is still in interactive mode. Now close the second cut window (the interactive cut window). Check that interactive mode is disabled in the slice.

Check unit tests for windows under PyCharm works...

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #445 #447 #403
