### PR TITLE
Fixed bug to allow plotting indirect nxspe files

### DIFF
--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -96,6 +96,11 @@ def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode):
     AddSampleLog(_tmpws, LogName='Ei', LogText='3.', LogType='Number', EnableLogging=False)
     _tmpws = ConvertToMD(_tmpws, EnableLogging=False, StoreInADS=False, PreprocDetectorsWS='-',
                          QDimensions='|Q|', dEAnalysisMode='Direct')
+    # TODO: Refactor the above code after Mantid framework has been changed to avoid the hack.
+    # The above lines create an empty MD workspace with the same logs as the calculated Workspace2D output of the
+    # cut algorithms. These logs are then copied (using copyExperimentInfos below) to the generated MDHistoWorkspace
+    # Ideally we should be able to use the CopyLogs algorithm between a Workspace2D and MD workspace or
+    # copyExperimentInfos should understand a Workspace2D input, either of which will need changes to Mantid.
     ws_out = CreateMDHistoWorkspace(SignalInput=ws_out.extractY(), ErrorInput=ws_out.extractE(), Dimensionality=1,
                                     Extents=extents, NumberOfBins=xdim.getNBins(), Names=name, Units=unit,
                                     StoreInADS=False, EnableLogging=False)

--- a/mslice/models/slice/slice_algorithm.py
+++ b/mslice/models/slice/slice_algorithm.py
@@ -81,8 +81,12 @@ class Slice(PythonAlgorithm):
         ebin = '%f, %f, %f' % (axes[e_axis].start_meV, axes[e_axis].step_meV, axes[e_axis].end_meV)
         qbin = '%f, %f, %f' % (axes[q_axis].start_meV, axes[q_axis].step_meV, axes[q_axis].end_meV)
         if axes[q_axis].units == '|Q|':
-            thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin, EMode=e_mode,
-                               StoreInADS=False)
+            if 'Indirect' in e_mode and workspace.run().hasProperty('Efix'):
+                thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin, EMode=e_mode,
+                                   StoreInADS=False, EFixed=workspace.run().getProperty('Efix').value)
+            else:
+                thisslice = SofQW3(InputWorkspace=workspace, QAxisBinning=qbin, EAxisBinning=ebin, EMode=e_mode,
+                                   StoreInADS=False)
         elif axes[q_axis].units == '2Theta':
             thisslice = ConvertSpectrumAxis(InputWorkspace=workspace, Target='Theta', StoreInADS=False)
             thisslice = Rebin2D(InputWorkspace=thisslice, Axis1Binning=ebin, Axis2Binning=qbin, StoreInADS=False)

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -193,7 +193,7 @@ def _compute_powder_line_momentum(ws_name, q_axis, element, cif_file):
 def _crystal_structure(ws_name, element, cif_file):
     if cif_file:
         ws = get_workspace_handle(ws_name).raw_ws
-        LoadCIF(InputWorkspace=ws, InputFile=cif_file)
+        LoadCIF(Workspace=ws, InputFile=cif_file)
         return ws.sample().getCrystalStructure()
     else:
         return CrystalStructure(crystal_structure[element][0], crystal_structure[element][1],

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -61,9 +61,10 @@ def processEfixed(workspace):
 def _processLoadedWSLimits(workspace):
     """ Processes an (angle-deltaE) workspace to get the limits and step size in angle, energy and |Q| """
     # For cases, e.g. indirect, where EFixed has not been set yet, return calculate later.
-    workspace.e_fixed = get_EFixed(workspace.raw_ws)
     if workspace.e_fixed is None:
-        return
+        workspace.e_fixed = get_EFixed(workspace.raw_ws)
+        if workspace.e_fixed is None:
+            return
     if isinstance(workspace, PixelWorkspace):
         process_limits_event(workspace)
     elif isinstance(workspace, Workspace):

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 
 from .busy import show_busy
-from mslice.models.workspacemanager.workspace_algorithms import load
+from mslice.models.workspacemanager.workspace_algorithms import load, get_limits
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_visible_workspace_names
 from mslice.presenters.interfaces.data_loader_presenter import DataLoaderPresenterInterface
 from mslice.presenters.presenter_utility import PresenterUtility
@@ -74,6 +74,8 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
             Ef, allChecked = self._view.get_workspace_efixed(ws_name, multi, self._EfCache)
             self._EfCache = Ef
             ws.e_fixed = Ef
+            ws.raw_ws.run().addProperty('Efix', Ef, True)
+            get_limits(ws_name, 'DeltaE')  # This is call needed to process the limits.
             return allChecked
 
     def _confirm_workspace_overwrite(self, ws_name):


### PR DESCRIPTION
Fixes bug in loading an indirect instrument `nxspe` file which prevented it from plotting

**To test:**

<!-- Instructions for testing. -->

Load the nxspe file in [iris_reduced_data.zip](https://github.com/mantidproject/mslice/files/2945457/iris_reduced_data.zip) and check that you can plot slices and cuts from it.  

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #451
