### PR TITLE
Fix 2theta units naming bug

### DIFF
--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -77,7 +77,7 @@ def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode):
         idx = 1
         unit = 'MomentumTransfer'
         name = '|Q|'
-    elif cut_axis.units == 'Degrees':
+    elif cut_axis.units == 'Degrees' or cut_axis.units == '2Theta':
         ws_out = _cut_nonPSD_theta(cut_binning, int_binning, selected_workspace)
         idx = 1
         unit = 'Degrees'

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -6,6 +6,7 @@ from mantid.simpleapi import BinMD, ConvertSpectrumAxis, CreateMDHistoWorkspace,
 
 from mslice.models.alg_workspace_ops import fill_in_missing_input, get_number_of_steps
 from mslice.models.axis import Axis
+from mslice.models.labels import is_momentum, is_twotheta
 from mslice.models.units import EnergyUnits
 from mslice.workspace.helperfunctions import attribute_to_log
 from .cut_normalisation import normalize_workspace
@@ -72,12 +73,12 @@ def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode):
     idx = 0
     unit = 'DeltaE'
     name = 'EnergyTransfer'
-    if cut_axis.units == '|Q|':
+    if is_momentum(cut_axis.units):
         ws_out = _cut_nonPSD_momentum(cut_binning, int_binning, emode, selected_workspace)
         idx = 1
         unit = 'MomentumTransfer'
         name = '|Q|'
-    elif cut_axis.units == 'Degrees' or cut_axis.units == '2Theta':
+    elif is_twotheta(cut_axis.units):
         ws_out = _cut_nonPSD_theta(cut_binning, int_binning, selected_workspace)
         idx = 1
         unit = 'Degrees'

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -11,7 +11,14 @@ recoil_labels = {1: 'Hydrogen', 2: 'Deuterium', 4: 'Helium'}
 MOD_Q_LABEL = '|Q|'
 THETA_LABEL = '2Theta'
 DELTA_E_LABEL = 'DeltaE'
+TWOTHETA_UNITS = ('Degrees', '2Theta')
+MOMENTUM_UNITS = ('MomentumTransfer', '|Q|')
 
+def is_twotheta(unit):
+    return any([unit in val for val in TWOTHETA_UNITS])
+
+def is_momentum(unit):
+    return any([unit in val for val in MOMENTUM_UNITS])
 
 def get_recoil_key(label):
     for key, value in recoil_labels.items():
@@ -23,10 +30,10 @@ def get_recoil_key(label):
 def get_display_name(axis):
     if 'DeltaE' in axis.units:
         return EnergyUnits(axis.e_unit).label()
-    elif 'MomentumTransfer' in axis.units or '|Q|' in axis.units:
+    elif is_momentum(axis.units):
         # Matplotlib 1.3 doesn't handle LaTeX very well. Sometimes no legend appears if we use LaTeX
         return '|Q| (recip. Ang.)' if MPL_COMPAT else r'$|Q|$ ($\mathrm{\AA}^{-1}$)'
-    elif 'Degrees' in axis.units or '2Theta' in axis.units:
+    elif is_twotheta(axis.units):
         return 'Scattering Angle (degrees)' if MPL_COMPAT else r'Scattering Angle 2$\theta$ ($^{\circ}$)'
     else:
         return axis.units

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -26,7 +26,7 @@ def get_display_name(axis):
     elif 'MomentumTransfer' in axis.units or '|Q|' in axis.units:
         # Matplotlib 1.3 doesn't handle LaTeX very well. Sometimes no legend appears if we use LaTeX
         return '|Q| (recip. Ang.)' if MPL_COMPAT else r'$|Q|$ ($\mathrm{\AA}^{-1}$)'
-    elif '2Theta' in axis.units:
+    elif 'Degrees' in axis.units or '2Theta' in axis.units:
         return 'Scattering Angle (degrees)' if MPL_COMPAT else r'Scattering Angle 2$\theta$ ($^{\circ}$)'
     else:
         return axis.units

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -8,6 +8,7 @@ from mantid.geometry import CrystalStructure, ReflectionGenerator, ReflectionCon
 from scipy import constants
 
 from mslice.models.alg_workspace_ops import get_number_of_steps
+from mslice.models.labels import is_momentum, is_twotheta
 from mslice.models.workspacemanager.workspace_algorithms import propagate_properties
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.util.mantid.mantid_algorithms import LoadCIF, CloneWorkspace
@@ -153,11 +154,11 @@ def get_sample_temperature_from_string(string):
 def compute_recoil_line(ws_name, axis, relative_mass=1):
     efixed = get_workspace_handle(ws_name).e_fixed
     x_axis = np.arange(axis.start, axis.end, axis.step)
-    if axis.units == 'MomentumTransfer' or axis.units == '|Q|':
+    if is_momentum(axis.units):
         momentum_transfer = x_axis
         line = np.square(momentum_transfer * 1.e10 * constants.hbar) / (2 * relative_mass * constants.neutron_mass) /\
             (constants.elementary_charge / 1000)
-    elif axis.units == 'Degrees' or axis.units == '2Theta':
+    elif is_twotheta(axis.units):
         tth = x_axis * np.pi / 180.
         if 'Direct' in get_workspace_handle(ws_name).e_mode:
             line = efixed * (2 - 2 * np.cos(tth)) / (relative_mass + 1 - np.cos(tth))
@@ -170,9 +171,9 @@ def compute_recoil_line(ws_name, axis, relative_mass=1):
 
 def compute_powder_line(ws_name, axis, element, cif_file=False):
     efixed = get_workspace_handle(ws_name).e_fixed
-    if axis.units == 'MomentumTransfer' or axis.units == '|Q|':
+    if is_momentum(axis.units):
         x0 = _compute_powder_line_momentum(ws_name, axis, element, cif_file)
-    elif axis.units == 'Degrees' or axis.units == '2Theta':
+    elif is_twotheta(axis.units):
         x0 = _compute_powder_line_degrees(ws_name, axis, element, efixed, cif_file)
     else:
         raise RuntimeError("units of axis not recognised")

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -157,7 +157,7 @@ def compute_recoil_line(ws_name, axis, relative_mass=1):
         momentum_transfer = x_axis
         line = np.square(momentum_transfer * 1.e10 * constants.hbar) / (2 * relative_mass * constants.neutron_mass) /\
             (constants.elementary_charge / 1000)
-    elif axis.units == 'Degrees':
+    elif axis.units == 'Degrees' or axis.units == '2Theta':
         tth = x_axis * np.pi / 180.
         if 'Direct' in get_workspace_handle(ws_name).e_mode:
             line = efixed * (2 - 2 * np.cos(tth)) / (relative_mass + 1 - np.cos(tth))
@@ -172,7 +172,7 @@ def compute_powder_line(ws_name, axis, element, cif_file=False):
     efixed = get_workspace_handle(ws_name).e_fixed
     if axis.units == 'MomentumTransfer' or axis.units == '|Q|':
         x0 = _compute_powder_line_momentum(ws_name, axis, element, cif_file)
-    elif axis.units == 'Degrees':
+    elif axis.units == 'Degrees' or axis.units == '2Theta':
         x0 = _compute_powder_line_degrees(ws_name, axis, element, efixed, cif_file)
     else:
         raise RuntimeError("units of axis not recognised")

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -4,6 +4,7 @@ from mslice.models.slice.slice_functions import (compute_slice, sample_temperatu
                                                  compute_powder_line)
 from mslice.models.cmap import ALLOWED_CMAPS
 from mslice.models.slice.slice import Slice
+from mslice.models.labels import is_momentum, is_twotheta
 from mslice.views.slice_plotter import (set_colorbar_label, plot_cached_slice, remove_line,
                                         plot_overplot_line, create_slice_figure)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
@@ -52,7 +53,7 @@ class SlicePlotterPresenter(PresenterUtility):
         self._main_presenter.update_displayed_workspaces()
 
     def _cache_slice(self, slice, colourmap, norm, sample_temp, x_axis, y_axis):
-        rotated = x_axis.units not in ['MomentumTransfer', 'Degrees', '2Theta', '|Q|']
+        rotated = not is_twotheta(x_axis.units) and not is_momentum(x_axis.units)
         (q_axis, e_axis) = (x_axis, y_axis) if not rotated else (y_axis, x_axis)
         self._slice_cache[slice.name[2:]] = Slice(slice, colourmap, norm, sample_temp, q_axis, e_axis, rotated)
 

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -52,7 +52,7 @@ class SlicePlotterPresenter(PresenterUtility):
         self._main_presenter.update_displayed_workspaces()
 
     def _cache_slice(self, slice, colourmap, norm, sample_temp, x_axis, y_axis):
-        rotated = x_axis.units not in ['MomentumTransfer', 'Degrees', '|Q|']
+        rotated = x_axis.units not in ['MomentumTransfer', 'Degrees', '2Theta', '|Q|']
         (q_axis, e_axis) = (x_axis, y_axis) if not rotated else (y_axis, x_axis)
         self._slice_cache[slice.name[2:]] = Slice(slice, colourmap, norm, sample_temp, q_axis, e_axis, rotated)
 


### PR DESCRIPTION
This fixes a bug where the label for a 2-theta cut is `2Theta` rather than the expected `Degrees`. It seems that `MDWorkspaces` and `MatrixWorkspace` have different conventions: `MatrixWorkspace` expects `Degrees` which was what MSlice had but `MDWorkspace`s are more flexible and in the GUI in MSlice we call that axis `2Theta` which is then passed to the different algorithms which do not recognise this (they expect `Degrees`). 

This PR updates the relevant checks in the `Cut` and `Slice` algorithms so that they will now accept both `Degrees` and `2Theta`.

**To test:**

<!-- Instructions for testing. -->

Repeat the cuts / slices detailed in issue #454 and check that they are correctly plotted now (e.g. `DeltaE` vs `2Theta` and `2Theta` vs `DeltaE` slices are consistent and cuts along `2Theta` work as described. Also check that overplotting lines work on the slices.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #454 .
