### PR TITLE
Add image copy button to plots

### DIFF
--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -42,6 +42,7 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.window.action_keep.triggered.connect(self.report_as_kept)
         self.window.action_make_current.triggered.connect(self.report_as_current)
         self.window.action_save_image.triggered.connect(self.save_plot)
+        self.window.action_copy_image.triggered.connect(self.copy_plot)
         self.window.action_print_plot.triggered.connect(self.print_plot)
         self.window.action_plot_options.triggered.connect(self._plot_options)
         self.window.action_toggle_legends.triggered.connect(self._toggle_legend)
@@ -185,6 +186,12 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def save_image(self, path, resolution=300):
         self.canvas.figure.savefig(path, dpi=resolution)
+
+    def copy_plot(self):
+        import io
+        buf = io.BytesIO()
+        self.canvas.figure.savefig(buf, dpi=300)
+        QtWidgets.QApplication.clipboard().setImage(QtGui.QImage.fromData(buf.getvalue()))
 
     def error_box(self, message):
         error_box = QtWidgets.QMessageBox(self)

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -130,6 +130,7 @@ class PlotWindow(QtWidgets.QMainWindow):
         self.keep_make_current_seperator = toolbar.addSeparator()
 
         self.action_save_image = add_action(toolbar, self, "Save Image", icon_name='fa.save')
+        self.action_copy_image = add_action(toolbar, self, "Copy Image", icon_name='fa.copy')
         self.action_print_plot = add_action(toolbar, self,  "Print", icon_name='fa.print')
         self.action_plot_options = add_action(toolbar, self, "Plot Options", icon_name='fa.cog')
 


### PR DESCRIPTION
Adds a `Copy` button to plot windows which copies the plot image (bitmap only) to the system clipboard.

**To test:**

Make a slice and/or cut and then click on the `Copy` button on the toolbar (next to the `Save` button). Then go into another program which can handle images (e.g. GIMP, Paint, Word, LibreOffice) and paste the image - check that it's the correct image of the plot.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #452
