### PR TITLE
Left and Right multiplication of workspaces now work as expected

### DIFF
--- a/mslice/workspace/workspace_mixin.py
+++ b/mslice/workspace/workspace_mixin.py
@@ -112,6 +112,9 @@ class WorkspaceMixin(object):
     def __mul__(self, other):
         return self._binary_op(operator.mul, other)
 
+    def __rmul__(self, other):
+        return self._binary_op(operator.mul, other)
+
     def __div__(self, other):
         return self._binary_op(operator.div, other)
 


### PR DESCRIPTION
Description of work.
Multiplication of workspaces and real numbers can now be done on a commutatively.
This was done by overloading the `__rmul__` operator.
**To test:**
Open Mslice
Load a workspace
Try to perform a workspace multiplication both ways (ws * 2 and 2 * ws)
<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #462 .
