### PR TITLE
Add horizontal header to dataloader to allow sorting

### DIFF
--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -76,9 +76,12 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self.table_view.setModel(self.file_system)
         self.table_view.setRootIndex(self.file_system.index(self.root_path))
         self.table_view.setColumnWidth(0, 320)    # Make name wide
+        self.table_view.setColumnWidth(1, 123)
+        self.table_view.setColumnWidth(2, 123)
         self.table_view.setColumnWidth(3, 140)    # Show date modified
         self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.sort_files(self._sort_column)
+        self.table_view.horizontalHeader().swapSections(1, 3)  # Swap the type and date modified columns
 
     def _update_from_path(self):
         new_path = self.directory.absolutePath()

--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -76,8 +76,6 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self.table_view.setModel(self.file_system)
         self.table_view.setRootIndex(self.file_system.index(self.root_path))
         self.table_view.setColumnWidth(0, 320)    # Make name wide
-        self.table_view.setColumnHidden(1, True)  # Hide size column
-        self.table_view.setColumnHidden(2, True)  # Hide type column
         self.table_view.setColumnWidth(3, 140)    # Show date modified
         self.table_view.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.sort_files(self._sort_column)

--- a/mslice/widgets/dataloader/dataloader.ui
+++ b/mslice/widgets/dataloader/dataloader.ui
@@ -48,15 +48,18 @@
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
        <widget class="QTableView" name="table_view">
+        <property name="alternatingRowColors">
+         <bool>false</bool>
+        </property>
         <property name="showGrid">
          <bool>false</bool>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
         </property>
         <property name="cornerButtonEnabled">
          <bool>false</bool>
         </property>
-        <attribute name="horizontalHeaderVisible">
-         <bool>false</bool>
-        </attribute>
         <attribute name="verticalHeaderVisible">
          <bool>false</bool>
         </attribute>
@@ -93,7 +96,7 @@
               <property name="editable">
                <bool>false</bool>
               </property>
-              <property name="currentText">
+              <property name="currentText" stdset="0">
                <string>Name</string>
               </property>
               <item>


### PR DESCRIPTION
Description of work.
I added a horizontal header to QTableView in the dataloader with the ability to sort items
**To test:**

<!-- Instructions for testing. -->
Open MSlice
Observe that the horizontal header in not hidden
Click the arrow next to the column title to sort according to the title name
Click the arrow again for the reversed sorting order

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #459 .
