### PR TITLE
Subtract script generation bugfix

### DIFF
--- a/buildscripts/buildscript.sh
+++ b/buildscripts/buildscript.sh
@@ -65,7 +65,7 @@ echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 ${script_dir}/create_virtualenv.sh ${py_exe} ${venv_dir}
 source ${venv_dir}/bin/activate
 # ensure mantid is on the python path
-export PYTHONPATH=/opt/${pkg_name}/bin
+export PYTHONPATH=/opt/${pkg_name}/bin:/opt/${pkg_name}/lib
 
 # ------------------------------------------------------------------------------
 # installation

--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -18,10 +18,7 @@ from mslice.util.qt.qapp import QAppThreadCall, mainloop
 from six import string_types
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 
-from mslice.util.mantid import in_mantidplot
-
-if in_mantidplot():
-    from mslice.util.mantid.mantid_algorithms import *  # noqa: F401
+from mslice.util.mantid.mantid_algorithms import *  # noqa: F401
 
 # -----------------------------------------------------------------------------
 # Command functions

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -56,6 +56,8 @@ def compute_cut(selected_workspace, cut_axis, integration_axis, e_mode, PSD, is_
 
 
 def _compute_cut_PSD(selected_workspace, cut_axis, integration_axis):
+    cut_axis.units = cut_axis.units.replace('2Theta', 'Degrees')
+    integration_axis.units = integration_axis.units.replace('2Theta', 'Degrees')
     fill_in_missing_input(cut_axis, selected_workspace)
     n_steps = get_number_of_steps(cut_axis)
     cut_binning = " ,".join(map(str, (cut_axis.units, cut_axis.start_meV, cut_axis.end_meV, n_steps)))

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -10,7 +10,6 @@ import os.path
 
 import numpy as np
 from scipy import constants
-from uuid import uuid4
 
 from mantid.api import WorkspaceUnitValidator
 from mantid.api import MatrixWorkspace
@@ -190,7 +189,6 @@ def combine_workspace(selected_workspaces, new_name):
 
 def add_workspace_runs(selected_ws):
     out_ws_name = selected_ws[0] + '_sum'
-    workspaces = [get_workspace_handle(ws) for ws in selected_ws]
     sum_ws = MergeRuns(OutputWorkspace=out_ws_name, InputWorkspaces=selected_ws)
     propagate_properties(get_workspace_handle(selected_ws[0]), sum_ws)
 

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -197,14 +197,14 @@ def add_workspace_runs(selected_ws):
 
 
 def subtract(workspaces, background_ws, ssf):
-    bg_ws = get_workspace_handle(str(background_ws)).raw_ws
-    scaled_bg_ws = Scale(OutputWorkspace='scaled_bg_ws', store=False, InputWorkspace=bg_ws, Factor=ssf)
+    with wrap_in_ads([get_workspace_handle(str(background_ws))]):
+        scaled_bg_ws = Scale(OutputWorkspace='scaled_bg_ws', store=False, InputWorkspace=str(background_ws), Factor=ssf)
     try:
         for ws_name in workspaces:
-            ws = get_workspace_handle(ws_name)
-            result = Minus(OutputWorkspace=ws_name + '_subtracted', LHSWorkspace=ws.raw_ws,
-                           RHSWorkspace=scaled_bg_ws.raw_ws)
-            propagate_properties(ws, result)
+            with wrap_in_ads([get_workspace_handle(ws_name), scaled_bg_ws]):
+                result = Minus(OutputWorkspace=ws_name + '_subtracted', LHSWorkspace=ws_name,
+                               RHSWorkspace=scaled_bg_ws.name)
+            propagate_properties(get_workspace_handle(ws_name), result)
     except ValueError as e:
         raise ValueError(e)
 

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -10,6 +10,7 @@ import os.path
 
 import numpy as np
 from scipy import constants
+from uuid import uuid4
 
 from mantid.api import WorkspaceUnitValidator
 from mantid.api import MatrixWorkspace
@@ -198,7 +199,8 @@ def add_workspace_runs(selected_ws):
 
 def subtract(workspaces, background_ws, ssf):
     with wrap_in_ads([get_workspace_handle(str(background_ws))]):
-        scaled_bg_ws = Scale(OutputWorkspace='scaled_bg_ws', store=False, InputWorkspace=str(background_ws), Factor=ssf)
+        scaled_bg_ws = Scale(OutputWorkspace='__MSL'+ str(background_ws) + '_scaled', 
+                             InputWorkspace=str(background_ws), Factor=ssf)
     try:
         for ws_name in workspaces:
             with wrap_in_ads([get_workspace_handle(ws_name), scaled_bg_ws]):

--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -1,9 +1,8 @@
-import ctypes
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_visible_workspace_names
 from mslice.util.qt import QtWidgets
 from mslice.scripting.helperfunctions import add_plot_statements
 from mslice.app.presenters import get_cut_plotter_presenter
-from mslice.workspace.base import WorkspaceBase
+from six import string_types
 
 
 def generate_script(ws_name, filename=None, plot_handler=None, window=None):
@@ -40,38 +39,15 @@ def preprocess_lines(ws_name, plot_handler, ax):
 
     return script_lines
 
-def _get_c_address(mslice_workspace):
-    # Hack to get the c-address of the shared pointer to the workspace object (assumes a boost.python.class and CPython)
-    mslice_workspace = get_workspace_handle(mslice_workspace)
-    if isinstance(mslice_workspace, WorkspaceBase):
-        return ctypes.cast(id(mslice_workspace.raw_ws), ctypes.POINTER(ctypes.c_void_p))[8]
-    return None
-
-def _parse_temp_ws_names(kwargs, current_ws_refs):
-    idx = kwargs.find('__TMP') + 5
-    ws_map = {}
-    while idx > 0:
-        addr_str = kwargs[idx:kwargs.find("'", idx)]
-        ws_map[int(addr_str, 16)] = addr_str
-        idx_tmp = kwargs.find('__TMP', idx)
-        idx =  idx + idx_tmp + 5 if idx_tmp > 0 else idx_tmp
-    for addr, addr_str in list(ws_map.items()):
-        if addr in current_ws_refs.keys():
-            kwargs = kwargs.replace("'__TMP{}'".format(addr_str), current_ws_refs[addr])
-    return kwargs
-
 def generate_script_lines(raw_ws, workspace_name):
     lines = []
     ws_name = workspace_name.replace(".", "_")
     alg_history = raw_ws.getHistory().getAlgorithmHistories()
     existing_ws_refs = []
-    current_ws_refs = {_get_c_address(ws): ws.replace(".", "_") for ws in get_visible_workspace_names()}
     for algorithm in alg_history:
         alg_name = algorithm.name()
         kwargs, output_ws = get_algorithm_kwargs(algorithm, existing_ws_refs)
-        if '__TMP' in kwargs:
-            kwargs = _parse_temp_ws_names(kwargs, current_ws_refs)
-        if output_ws is not None and output_ws != ws_name:
+        if (output_ws is not None and output_ws != ws_name):
             lines += ["{} = mc.{}({})\n".format(output_ws, alg_name, kwargs)]
             existing_ws_refs.append(output_ws)
         else:
@@ -84,21 +60,25 @@ def get_algorithm_kwargs(algorithm, existing_ws_refs):
     output_ws = None
     for prop in algorithm.getProperties():
         if not prop.isDefault():
+            pval = prop.value().replace("__MSL", "") if isinstance(prop.value(), string_types) else prop.value()
             if prop.name() == "OutputWorkspace":
-                output_ws = prop.value().replace(".", "_")
+                output_ws = pval.replace(".", "_")
+                if "__MSL" in prop.value():
+                    arguments += ["store=False"]
+                    continue
             if algorithm.name() == "Load":
                 if prop.name() == "Filename":
-                    arguments += ["{}='{}'".format(prop.name(), prop.value())]
+                    arguments += ["{}='{}'".format(prop.name(), pval)]
                     continue
                 elif prop.name() == "LoaderName" or prop.name() == "LoaderVersion":
                     continue
             elif algorithm.name() == "MakeProjection":
                 if prop.name() == "Limits" or prop.name() == "OutputWorkspace" or prop.name() == "ProjectionType":
                     continue
-            if isinstance(prop.value(), str) and prop.value().replace(".", "_") in existing_ws_refs:
-                arguments += ["{}={}".format(prop.name(), prop.value().replace(".", "_"))]
+            if isinstance(pval, str) and pval.replace(".", "_") in existing_ws_refs:
+                arguments += ["{}={}".format(prop.name(), pval.replace(".", "_"))]
             elif isinstance(prop.value(), str):
-                arguments += ["{}='{}'".format(prop.name(), prop.value())]
+                arguments += ["{}='{}'".format(prop.name(), pval)]
             else:
-                arguments += ["{}={}".format(prop.name(), prop.value())]
+                arguments += ["{}={}".format(prop.name(), pval)]
     return ", ".join(arguments), output_ws

--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -1,4 +1,4 @@
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_visible_workspace_names
+from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.util.qt import QtWidgets
 from mslice.scripting.helperfunctions import add_plot_statements
 from mslice.app.presenters import get_cut_plotter_presenter
@@ -38,6 +38,7 @@ def preprocess_lines(ws_name, plot_handler, ax):
         script_lines += generate_script_lines(ws, ws_name)
 
     return script_lines
+
 
 def generate_script_lines(raw_ws, workspace_name):
     lines = []

--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -60,10 +60,12 @@ def get_algorithm_kwargs(algorithm, existing_ws_refs):
     output_ws = None
     for prop in algorithm.getProperties():
         if not prop.isDefault():
-            pval = prop.value().replace("__MSL", "") if isinstance(prop.value(), string_types) else prop.value()
+            pval = prop.value()
+            if isinstance(pval, string_types):
+                pval = pval.replace("__MSL", "").replace("_HIDDEN", "")
             if prop.name() == "OutputWorkspace":
                 output_ws = pval.replace(".", "_")
-                if "__MSL" in prop.value():
+                if "_HIDDEN" in prop.value():
                     arguments += ["store=False"]
                     continue
             if algorithm.name() == "Load":

--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -42,22 +42,35 @@ def preprocess_lines(ws_name, plot_handler, ax):
 
 def _get_c_address(mslice_workspace):
     # Hack to get the c-address of the shared pointer to the workspace object (assumes a boost.python.class and CPython)
+    mslice_workspace = get_workspace_handle(mslice_workspace)
     if isinstance(mslice_workspace, WorkspaceBase):
         return ctypes.cast(id(mslice_workspace.raw_ws), ctypes.POINTER(ctypes.c_void_p))[8]
+    return None
+
+def _parse_temp_ws_names(kwargs, current_ws_refs):
+    idx = kwargs.find('__TMP') + 5
+    ws_map = {}
+    while idx > 0:
+        addr_str = kwargs[idx:kwargs.find("'", idx)]
+        ws_map[int(addr_str, 16)] = addr_str
+        idx_tmp = kwargs.find('__TMP', idx)
+        idx =  idx + idx_tmp + 5 if idx_tmp > 0 else idx_tmp
+    for addr, addr_str in list(ws_map.items()):
+        if addr in current_ws_refs.keys():
+            kwargs = kwargs.replace("'__TMP{}'".format(addr_str), current_ws_refs[addr])
+    return kwargs
 
 def generate_script_lines(raw_ws, workspace_name):
     lines = []
     ws_name = workspace_name.replace(".", "_")
     alg_history = raw_ws.getHistory().getAlgorithmHistories()
     existing_ws_refs = []
-    current_ws_refs = {'__TMP{:016x}'.format(_get_c_address(get_workspace_handle(ws))).upper(): ws.replace(".", "_")
-                       for ws in get_visible_workspace_names()}
+    current_ws_refs = {_get_c_address(ws): ws.replace(".", "_") for ws in get_visible_workspace_names()}
     for algorithm in alg_history:
         alg_name = algorithm.name()
-        kwargs, output_ws = get_algorithm_kwargs(algorithm, ws_name, existing_ws_refs)
-        ws_ref = [ws_ref for ws_ref in current_ws_refs.keys() if ws_ref in kwargs]
-        for ref in ws_ref:
-            kwargs = kwargs.replace("'{}'".format(ref), current_ws_refs[ref])
+        kwargs, output_ws = get_algorithm_kwargs(algorithm, existing_ws_refs)
+        if '__TMP' in kwargs:
+            kwargs = _parse_temp_ws_names(kwargs, current_ws_refs)
         if output_ws is not None and output_ws != ws_name:
             lines += ["{} = mc.{}({})\n".format(output_ws, alg_name, kwargs)]
             existing_ws_refs.append(output_ws)
@@ -66,7 +79,7 @@ def generate_script_lines(raw_ws, workspace_name):
     return lines
 
 
-def get_algorithm_kwargs(algorithm, workspace_name, existing_ws_refs):
+def get_algorithm_kwargs(algorithm, existing_ws_refs):
     arguments = []
     output_ws = None
     for prop in algorithm.getProperties():
@@ -82,7 +95,7 @@ def get_algorithm_kwargs(algorithm, workspace_name, existing_ws_refs):
             elif algorithm.name() == "MakeProjection":
                 if prop.name() == "Limits" or prop.name() == "OutputWorkspace" or prop.name() == "ProjectionType":
                     continue
-            if prop.value().replace(".", "_") in existing_ws_refs:
+            if isinstance(prop.value(), str) and prop.value().replace(".", "_") in existing_ws_refs:
                 arguments += ["{}={}".format(prop.name(), prop.value().replace(".", "_"))]
             elif isinstance(prop.value(), str):
                 arguments += ["{}='{}'".format(prop.name(), prop.value())]

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -181,10 +181,10 @@ def add_plot_options(script_lines, plot_handler):
     script_lines.append("ax.set_title('{}')\n".format(plot_handler.title))
 
     if plot_handler.is_changed("y_label"):
-        script_lines.append("ax.set_ylabel('{}')\n".format(plot_handler.y_label))
+        script_lines.append("ax.set_ylabel(r'{}')\n".format(plot_handler.y_label))
 
     if plot_handler.is_changed("x_label"):
-        script_lines.append("ax.set_xlabel('{}')\n".format(plot_handler.x_label))
+        script_lines.append("ax.set_xlabel(r'{}')\n".format(plot_handler.x_label))
 
     if plot_handler.is_changed("y_grid"):
         script_lines.append("ax.grid({}, axis='y')\n".format(plot_handler.y_grid))

--- a/mslice/tests/scripting_helperfunctions_test.py
+++ b/mslice/tests/scripting_helperfunctions_test.py
@@ -241,8 +241,8 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
         add_plot_options(script_lines, plot_handler)
 
         self.assertIn("ax.set_title('{}')\n".format(plot_handler.title), script_lines)
-        self.assertIn("ax.set_ylabel('{}')\n".format(plot_handler.y_label), script_lines)
-        self.assertIn("ax.set_xlabel('{}')\n".format(plot_handler.x_label), script_lines)
+        self.assertIn("ax.set_ylabel(r'{}')\n".format(plot_handler.y_label), script_lines)
+        self.assertIn("ax.set_xlabel(r'{}')\n".format(plot_handler.x_label), script_lines)
         self.assertIn("ax.grid({}, axis='y')\n".format(plot_handler.y_grid), script_lines)
         self.assertIn("ax.grid({}, axis='x')\n".format(plot_handler.x_grid), script_lines)
         self.assertIn("ax.set_ylim(bottom={}, top={})\n".format(*plot_handler.y_range), script_lines)

--- a/mslice/tests/scripting_tests.py
+++ b/mslice/tests/scripting_tests.py
@@ -89,20 +89,25 @@ class ScriptingTest(unittest.TestCase):
 
         load_alg = mock.MagicMock()
         load_alg.name.return_value = 'Load'
+        load_alg_prop_filename = mock.MagicMock()
+        load_alg_prop_filename.name.return_value = "Filename"
 
         make_projection_alg = mock.MagicMock()
         make_projection_alg.name.return_value = 'MakeProjection'
 
         raw_ws.getHistory().getAlgorithmHistories.return_value = [load_alg, make_projection_alg]
+        get_alg_kwargs.return_value = ('some args', 'workspace')
 
-        script_lines = generate_script_lines(raw_ws, ws_name)
+        with mock.patch('mslice.scripting._get_c_address') as get_addr:
+            get_addr.return_value = ''
+            script_lines = generate_script_lines(raw_ws, ws_name)
         self.assertEquals(get_alg_kwargs.call_count, 2)
 
-        self.assertIn(mock.call(load_alg, ws_name), get_alg_kwargs.call_args_list)
-        self.assertIn(mock.call(make_projection_alg, ws_name), get_alg_kwargs.call_args_list)
+        self.assertIn(mock.call(load_alg, []), get_alg_kwargs.call_args_list)
+        self.assertIn(mock.call(make_projection_alg, []), get_alg_kwargs.call_args_list)
 
-        make_projection_kwargs = get_alg_kwargs(make_projection_alg, ws_name)
-        load_kwargs = get_alg_kwargs(load_alg, ws_name)
+        make_projection_kwargs, output_ws = get_alg_kwargs(make_projection_alg, ws_name)
+        load_kwargs, output_ws = get_alg_kwargs(load_alg, ws_name)
 
         self.assertIn("ws_{} = mc.{}({})\n".format(ws_name, load_alg.name(), load_kwargs), script_lines)
         self.assertIn("ws_{} = mc.{}({})\n".format(ws_name, make_projection_alg.name(),
@@ -118,15 +123,18 @@ class ScriptingTest(unittest.TestCase):
         load_alg.name.return_value = 'Load'
         some_other_alg = mock.MagicMock()
         some_other_alg.name.return_value = 'SomeOtherAlgorithm'
+        get_alg_kwargs.return_value = ('some args', 'workspace')
 
         raw_ws.getHistory().getAlgorithmHistories.return_value = [some_other_alg, load_alg]
 
-        script_lines = generate_script_lines(raw_ws, ws_name)
+        with mock.patch('mslice.scripting._get_c_address') as get_addr:
+            get_addr.return_value = ''
+            script_lines = generate_script_lines(raw_ws, ws_name)
 
-        self.assertIn(mock.call(load_alg, ws_name), get_alg_kwargs.call_args_list)
-        self.assertEquals(get_alg_kwargs.call_count, 1)
+        self.assertIn(mock.call(load_alg, []), get_alg_kwargs.call_args_list)
+        self.assertEquals(get_alg_kwargs.call_count, 2)
 
-        load_kwargs = get_alg_kwargs(load_alg, ws_name)
+        load_kwargs, output_ws = get_alg_kwargs(load_alg, ws_name)
         self.assertIn("ws_{} = mc.{}({})\n".format(ws_name, load_alg.name(), load_kwargs), script_lines)
 
     def test_that_get_algorithm_kwargs_works_as_expected_with_load(self):
@@ -137,16 +145,11 @@ class ScriptingTest(unittest.TestCase):
         load_alg_prop_filename.name.return_value = "Filename"
         load_alg_prop_filename.isDefault.return_value = False
 
-        load_alg_prop_workspace = mock.MagicMock()
-        load_alg_prop_workspace.name.return_value = "OutputWorkspace"
-        load_alg_prop_workspace.isDefault.return_value = False
+        load_alg.getProperties.return_value = [load_alg_prop_filename]
 
-        load_alg.getProperties.return_value = [load_alg_prop_workspace, load_alg_prop_filename]
-
-        arguments = get_algorithm_kwargs(load_alg, 'workspace_name')
+        arguments, output_ws = get_algorithm_kwargs(load_alg, [])
 
         self.assertIn("{}='{}'".format("Filename", load_alg_prop_filename.value()), arguments)
-        self.assertNotIn("{}='{}'".format("OutputWorkspace", load_alg_prop_workspace.value()), arguments)
 
     def test_that_get_algorithm_kwargs_works_as_expected_with_make_projection(self):
         make_proj_alg = mock.MagicMock()
@@ -154,6 +157,7 @@ class ScriptingTest(unittest.TestCase):
 
         make_proj_alg_prop_input_ws = mock.MagicMock()
         make_proj_alg_prop_input_ws.name.return_value = "InputWorkspace"
+        make_proj_alg_prop_input_ws.value.return_value = "workspace_name"
         make_proj_alg_prop_input_ws.isDefault.return_value = False
 
         make_proj_alg_prop_output_ws = mock.MagicMock()
@@ -162,10 +166,10 @@ class ScriptingTest(unittest.TestCase):
 
         make_proj_alg.getProperties.return_value = [make_proj_alg_prop_output_ws, make_proj_alg_prop_input_ws]
 
-        args = get_algorithm_kwargs(make_proj_alg, 'workspace_name')
+        args, output_ws = get_algorithm_kwargs(make_proj_alg, ['workspace_name'])
 
         self.assertNotIn("{}='{}'".format("OutputWorkspace", make_proj_alg_prop_output_ws.value()), args)
-        self.assertIn("{}=ws_{}".format("InputWorkspace", 'workspace_name'), args)
+        self.assertIn("{}={}".format("InputWorkspace", 'workspace_name'), args)
 
     def test_that_get_algorithm_kwargs_works_as_expected_with_make_projection_using_string_property_value(self):
         make_proj_alg = mock.MagicMock()
@@ -178,7 +182,7 @@ class ScriptingTest(unittest.TestCase):
 
         make_proj_alg.getProperties.return_value = [make_proj_alg_prop]
 
-        args = get_algorithm_kwargs(make_proj_alg, 'workspace_name')
+        args, output_ws = get_algorithm_kwargs(make_proj_alg, 'workspace_name')
 
         self.assertIn("{}='{}'".format("SomeProp", "string"), args)
 
@@ -193,7 +197,7 @@ class ScriptingTest(unittest.TestCase):
 
         make_proj_alg.getProperties.return_value = [make_proj_alg_prop]
 
-        args = get_algorithm_kwargs(make_proj_alg, 'workspace_name')
+        args, output_ws = get_algorithm_kwargs(make_proj_alg, 'workspace_name')
 
         self.assertIn("{}={}".format("SomeProp", 12), args)
 
@@ -208,7 +212,7 @@ class ScriptingTest(unittest.TestCase):
 
         some_alg.getProperties.return_value = [some_alg_prop]
 
-        args = get_algorithm_kwargs(some_alg, 'workspace_name')
+        args, output_ws = get_algorithm_kwargs(some_alg, 'workspace_name')
 
         self.assertIn("{}={}".format("SomeProp", 12), args)
 
@@ -223,6 +227,19 @@ class ScriptingTest(unittest.TestCase):
 
         some_alg.getProperties.return_value = [some_alg_prop]
 
-        args = get_algorithm_kwargs(some_alg, 'workspace_name')
+        args, output_ws = get_algorithm_kwargs(some_alg, 'workspace_name')
 
         self.assertIn("{}='{}'".format("SomeProp", "string"), args)
+
+    def test_get_c_address(self):
+        ws_lhs = self.create_workspace('lhs_ws')
+        ws_rhs = self.create_workspace('rhs_ws')
+
+        from mslice.cli import Scale, Minus
+        ws_rhs_scaled = Scale(ws_rhs, 0.5)
+        ws_subtracted = Minus(ws_lhs, ws_rhs_scaled)
+        from mslice.models.workspacemanager.workspace_provider import add_workspace
+        add_workspace(ws_rhs_scaled, 'ws_rhs_scaled')
+
+        lines = generate_script_lines(ws_subtracted.raw_ws, 'lhs_ws_subtracted')
+        self.assertTrue(all(['__TMP' not in line for line in lines]))

--- a/mslice/tests/scripting_tests.py
+++ b/mslice/tests/scripting_tests.py
@@ -98,9 +98,7 @@ class ScriptingTest(unittest.TestCase):
         raw_ws.getHistory().getAlgorithmHistories.return_value = [load_alg, make_projection_alg]
         get_alg_kwargs.return_value = ('some args', 'workspace')
 
-        with mock.patch('mslice.scripting._get_c_address') as get_addr:
-            get_addr.return_value = ''
-            script_lines = generate_script_lines(raw_ws, ws_name)
+        script_lines = generate_script_lines(raw_ws, ws_name)
         self.assertEquals(get_alg_kwargs.call_count, 2)
 
         self.assertIn(mock.call(load_alg, []), get_alg_kwargs.call_args_list)
@@ -127,9 +125,7 @@ class ScriptingTest(unittest.TestCase):
 
         raw_ws.getHistory().getAlgorithmHistories.return_value = [some_other_alg, load_alg]
 
-        with mock.patch('mslice.scripting._get_c_address') as get_addr:
-            get_addr.return_value = ''
-            script_lines = generate_script_lines(raw_ws, ws_name)
+        script_lines = generate_script_lines(raw_ws, ws_name)
 
         self.assertIn(mock.call(load_alg, []), get_alg_kwargs.call_args_list)
         self.assertEquals(get_alg_kwargs.call_count, 2)
@@ -230,16 +226,3 @@ class ScriptingTest(unittest.TestCase):
         args, output_ws = get_algorithm_kwargs(some_alg, 'workspace_name')
 
         self.assertIn("{}='{}'".format("SomeProp", "string"), args)
-
-    def test_get_c_address(self):
-        ws_lhs = self.create_workspace('lhs_ws')
-        ws_rhs = self.create_workspace('rhs_ws')
-
-        from mslice.cli import Scale, Minus
-        ws_rhs_scaled = Scale(ws_rhs, 0.5)
-        ws_subtracted = Minus(ws_lhs, ws_rhs_scaled)
-        from mslice.models.workspacemanager.workspace_provider import add_workspace
-        add_workspace(ws_rhs_scaled, 'ws_rhs_scaled')
-
-        lines = generate_script_lines(ws_subtracted.raw_ws, 'lhs_ws_subtracted')
-        self.assertTrue(all(['__TMP' not in line for line in lines]))

--- a/mslice/tests/workspace_provider_test.py
+++ b/mslice/tests/workspace_provider_test.py
@@ -41,7 +41,7 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
         result = get_workspace_handle('test_ws_2d_subtracted')
         np.testing.assert_array_almost_equal(result.raw_ws.dataY(0), [0.05] * 20)
         np.testing.assert_array_almost_equal(self.test_ws_2d.raw_ws.dataY(0), [1] * 20)
-        self.assertFalse('scaled_bg_ws' in get_visible_workspace_names())
+        self.assertFalse('test_ws_2d_scaled' in get_visible_workspace_names())
 
     def test_add_workspace(self):
         original_data = self.test_ws_2d.raw_ws.dataY(0)

--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-from contextlib import contextmanager
 from uuid import uuid4
 from six import string_types
 
@@ -11,33 +10,43 @@ from mslice.workspace import wrap_workspace
 from mslice.workspace.base import WorkspaceBase as MsliceWorkspace
 from mslice.workspace.workspace import Workspace as MsliceWorkspace2D
 
+def _parse_ws_names(args, kwargs):
+    input_workspace = None
+    if 'InputWorkspace' in kwargs:
+        input_workspace = kwargs['InputWorkspace']
+        kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(kwargs['InputWorkspace'])
+    elif len(args) > 0:
+        input_workspace = args[0]
+        args = (_name_or_wrapper_to_workspace(args[0]),) + args[1:]
+
+    output_name = ''
+    if 'OutputWorkspace' in kwargs:
+        output_name = kwargs.pop('OutputWorkspace')
+
+    for ws in [k for k in kwargs.keys() if isinstance(kwargs[k], MsliceWorkspace)]:
+        if input_workspace is None and 'LHS' in ws:
+            input_workspace = kwargs[ws]
+        if 'Input' not in ws and 'Output' not in ws:
+            kwargs[ws] = _name_or_wrapper_to_workspace(kwargs[ws])
+
+    return (input_workspace, output_name, args, kwargs)
 
 def wrap_algorithm(algorithm):
     def alg_wrapper(*args, **kwargs):
-        output_name = ''
-        input_workspace = None
-        if 'InputWorkspace' in kwargs:
-            input_workspace = kwargs['InputWorkspace']
-            kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(kwargs['InputWorkspace'])
-        elif len(args) > 0:
-            input_workspace = args[0]
-            args = (_name_or_wrapper_to_workspace(args[0]),) + args[1:]
-        if 'OutputWorkspace' in kwargs:
-            output_name = kwargs.pop('OutputWorkspace')
-        store = kwargs.pop('store', True)
-        for ws in [k for k in kwargs.keys() if isinstance(kwargs[k], MsliceWorkspace)]:
-            if input_workspace is None and 'LHS' in ws:
-                input_workspace = kwargs[ws]
-            if 'Input' not in ws and 'Output' not in ws:
-                kwargs[ws] = _name_or_wrapper_to_workspace(kwargs[ws])
+
+        input_workspace, output_name, args, kwargs = _parse_ws_names(args, kwargs)
+
         args = tuple([_name_or_wrapper_to_workspace(arg) if isinstance(arg, MsliceWorkspace) else arg for arg in args])
+
         if 'InputWorkspaces' in kwargs:
             kwargs['InputWorkspaces'] = [_name_or_wrapper_to_workspace(arg) for arg in kwargs['InputWorkspaces']]
+
         for ky in [k for k in kwargs.keys() if 'Workspace' in k]:
             if isinstance(kwargs[ky], string_types) and '__MSL' not in kwargs[ky]:
                 kwargs[ky] = _name_or_wrapper_to_workspace(kwargs[ky])
 
         ads_name = '__MSL' + output_name if output_name else '__MSLTMP' + str(uuid4())[:8]
+        store = kwargs.pop('store', True)
         if not store:
             ads_name += '_HIDDEN'
 


### PR DESCRIPTION
Fixes a bug in the generation of a script from a workspace created by subtracting two other workspaces.

**To test:**

Download the datafiles here:  [subtract_bug.zip](https://github.com/mantidproject/mslice/files/2989165/subtract_bug.zip)). Load both datafiles, and subtract one from the other using the `Subtract` button. Plot a slice or cut of the subtracted workspace, and then save a script file from the plot (`File`->`Generate Script`). Run the generated file (`import <file>`) and check that it recreates the plot you generated from. 

In previous versions the subtracted file is not reference properly and running the generated script will give an error.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #458 
