### PR TITLE
Fix cut saving bugs

### DIFF
--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -38,7 +38,8 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
             file_dialog.selectNameFilter(ext_to_qtfilter[default_ext])
         if (file_dialog.exec_()):
             path = str(file_dialog.selectedFiles()[0])
-            if '.' not in path: # add extension unless there's one in the name
+            filename = os.path.basename(path)
+            if '.' not in filename: # add extension unless there's one in the name
                 try:
                     sel = file_dialog.selectedFilter()
                 except AttributeError:   # Qt5 only has selectedNameFilter

--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -39,7 +39,11 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
         if (file_dialog.exec_()):
             path = str(file_dialog.selectedFiles()[0])
             if '.' not in path: # add extension unless there's one in the name
-                path += file_dialog.selectedFilter()[-5:-1]
+                try:
+                    sel = file_dialog.selectedFilter()
+                except AttributeError:   # Qt5 only has selectedNameFilter
+                    sel = str(file_dialog.selectedNameFilter())
+                path += sel[-5:-1]
             ext = path[path.rfind('.'):]
             return os.path.dirname(path), os.path.basename(path), ext
 

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -10,6 +10,7 @@ import os.path
 
 import numpy as np
 from scipy import constants
+from six import string_types
 
 from mantid.api import WorkspaceUnitValidator
 from mantid.api import MatrixWorkspace
@@ -244,8 +245,19 @@ def save_workspaces(workspaces, path, save_name, extension, slice_nonpsd=False):
         save_method = save_matlab
     else:
         raise RuntimeError("unrecognised file extension")
-    for workspace in workspaces:
-        _save_single_ws(workspace, save_name, save_method, path, extension, slice_nonpsd)
+    if isinstance(save_name, string_types):
+        if len(workspaces) == 1:
+            save_names = [save_name]
+        else:
+            from os.path import splitext
+            name, _ = splitext(save_name)
+            save_names = ['{}_{:03d}{}'.format(name, idx+1, extension) for idx in range(len(workspaces))]
+    else:
+        save_names = [save_name] if not hasattr(save_name, '__iter__') else save_name
+        if len(save_names) != len(workspaces):
+            save_names = [None] * len(workspaces)
+    for workspace, save_name_single in zip(workspaces, save_names):
+        _save_single_ws(workspace, save_name_single, save_method, path, extension, slice_nonpsd)
 
 
 def export_workspace_to_ads(workspace):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -32,6 +32,7 @@ class CutPlot(IPlot):
         self._legends_visible = []
         self._legend_dict = {}
         self.ws_name = workspace_name
+        self.ws_list = [workspace_name]
         self._lines = self.line_containers()
         self.setup_connections(self.plot_window)
         self.default_options = None

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -165,7 +165,10 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def save_plot(self):
         file_path, save_name, ext = get_save_directory(save_as_image=True)
-        workspaces = self.plot_handler.ws_list
+        if hasattr(self.plot_handler, 'ws_list'):
+            workspaces = self.plot_handler.ws_list
+        else:
+            workspaces = [self.plot_handler.ws_name]
         try:
             save_workspaces(workspaces, file_path, save_name, ext, slice_nonpsd=True)
         except RuntimeError as e:

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -165,9 +165,9 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def save_plot(self):
         file_path, save_name, ext = get_save_directory(save_as_image=True)
-        workspace = self.plot_handler.ws_name
+        workspaces = self.plot_handler.ws_list
         try:
-            save_workspaces([workspace], file_path, save_name, ext, slice_nonpsd=True)
+            save_workspaces(workspaces, file_path, save_name, ext, slice_nonpsd=True)
         except RuntimeError as e:
             if str(e) == "unrecognised file extension":
                 if not save_name.endswith(".pdf"):

--- a/mslice/views/cut_plotter.py
+++ b/mslice/views/cut_plotter.py
@@ -37,6 +37,11 @@ def plot_cut_impl(workspace, intensity_range=None, plot_over=False, legend=None,
     legend = workspace.name if legend is None else legend
     ax.errorbar(workspace, 'o-', label=legend, picker=PICKER_TOL_PTS, intensity_range=intensity_range,
                 plot_over=plot_over, en_conversion=en_conversion)
+    if plot_over:
+        cur_fig.canvas.manager.plot_handler.ws_list.append(workspace.name)
+    else:
+        cur_fig.canvas.manager.plot_handler.ws_list = [workspace.name]
+
 
     return ax.lines
 


### PR DESCRIPTION
Fixes a but where only the first cut plotted on a window is saved.

**To test:**

<!-- Instructions for testing. -->

Load data and make a cut. Click on the save icon in the cut window and save to a file. Make another cut, plot it (not plot over) and save that to a file also. Before this fix the two files are the same - and show the data from the first cut made. Now they should be different.

Make multiple (plot over) cuts on a single plot window. Click save. If you select a data file format (e.g. `ascii`) it will save multiple files for each cut, appending a serial number to the files to distinguish them.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #472
