### PR TITLE
Disabled Save Cut to Workspace until area selected

### DIFF
--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -60,6 +60,7 @@ class InteractiveCut(object):
                 self._cut_plotter_presenter = GlobalFigureManager.get_active_figure().plot_handler._cut_plotter_presenter
                 self._is_initial_cut_plotter_presenter = False
                 GlobalFigureManager.disable_make_current()
+                self.slice_plot.plot_window.action_save_cut.setVisible(True)
             self._cut_plotter_presenter.store_icut(self)
 
     def get_cut_parameters(self, pos1, pos2):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -399,7 +399,6 @@ class SlicePlot(IPlot):
             self.plot_window.action_keep.trigger()
             self.plot_window.action_keep.setEnabled(False)
             self.plot_window.action_make_current.setEnabled(False)
-            self.plot_window.action_save_cut.setVisible(True)
             self.plot_window.action_flip_axis.setVisible(True)
             self._canvas.setCursor(Qt.CrossCursor)
         else:


### PR DESCRIPTION
Disabled the `Save Cut to Workspace` button in the slice until an area has been selected by the rectangular select tool and a cut has been created.

**To test:**

<!-- Instructions for testing. -->
Load a data file and `Display` a slice. Click on the `Interactive Cut` button on the plot window toolbar. Check that the `Save Cut to Workspace` button is not visible. Select an area with the rectangular select tool. Check that a separate cut plot window appears and that the `Save Cut to Workspace` button is now enabled.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #480
