### PR TITLE
Pop up error dialog on invalid LaTeX string

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from mslice.models.colors import to_hex
 from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter
-from mslice.presenters.quick_options_presenter import quick_options
+from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.plotting.plot_window.plot_options import CutPlotOptions
 from mslice.plotting.plot_window.iplot import IPlot
 
@@ -389,7 +389,10 @@ class CutPlot(IPlot):
 
     @title.setter
     def title(self, value):
-        self.manager.title = value
+        if check_latex(value):
+            self.manager.title = value
+        else:
+            self.plot_window.display_error("invalid latex string")
 
     @property
     def x_label(self):
@@ -397,7 +400,10 @@ class CutPlot(IPlot):
 
     @x_label.setter
     def x_label(self, value):
-        self.manager.x_label = value
+        if check_latex(value):
+            self.manager.x_label = value
+        else:
+            self.plot_window.display_error("invalid latex string")
 
     @property
     def y_label(self):
@@ -405,7 +411,10 @@ class CutPlot(IPlot):
 
     @y_label.setter
     def y_label(self, value):
-        self.manager.y_label = value
+        if check_latex(value):
+            self.manager.y_label = value
+        else:
+            self.plot_window.display_error("invalid latex string")
 
     @property
     def x_range(self):

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -198,7 +198,7 @@ class PlotFigureManagerQT(QtCore.QObject):
         error_box.setWindowTitle("Error")
         error_box.setIcon(QtWidgets.QMessageBox.Warning)
         error_box.setText(message)
-        error_box.show()
+        error_box.exec_()
 
     def update_grid(self):
         if self._xgrid:

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -130,3 +130,11 @@ class QuickLineOptions(QuickOptions):
     @property
     def legend(self):
         return self.line_widget.legend
+
+
+def QuickError(message):
+    error_box = QtWidgets.QMessageBox()
+    error_box.setWindowTitle("Error")
+    error_box.setIcon(QtWidgets.QMessageBox.Warning)
+    error_box.setText(message)
+    error_box.exec_()

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -8,7 +8,7 @@ import matplotlib.colors as colors
 
 from mslice.models.colors import to_hex
 from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
-from mslice.presenters.quick_options_presenter import quick_options
+from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.plotting.plot_window.iplot import IPlot
 from mslice.plotting.plot_window.interactive_cut import InteractiveCut
@@ -469,7 +469,10 @@ class SlicePlot(IPlot):
 
     @title.setter
     def title(self, value):
-        self.manager.title = value
+        if check_latex(value):
+            self.manager.title = value
+        else:
+            self.plot_window.display_error("invalid latex string")
 
     @property
     def x_label(self):
@@ -477,7 +480,10 @@ class SlicePlot(IPlot):
 
     @x_label.setter
     def x_label(self, value):
-        self.manager.x_label = value
+        if check_latex(value):
+            self.manager.x_label = value
+        else:
+            self.plot_window.display_error("invalid latex string")
 
     @property
     def y_label(self):
@@ -485,7 +491,10 @@ class SlicePlot(IPlot):
 
     @y_label.setter
     def y_label(self, value):
-        self.manager.y_label = value
+        if check_latex(value):
+            self.manager.y_label = value
+        else:
+            self.plot_window.display_error("invalid latex string")
 
     @property
     def x_range(self):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -162,7 +162,9 @@ class SlicePlot(IPlot):
 
     def update_legend(self):
         axes = self._canvas.figure.gca()
-        axes.legend().draggable()
+        lgn = axes.legend()
+        if lgn:
+            lgn.draggable()
 
         if self._canvas.manager.plot_handler.icut is not None:
             self._canvas.manager.plot_handler.icut.rect.ax = axes

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -47,19 +47,23 @@ def _set_axis_options(view, target, model, has_logarithmic, grid):
         setattr(model, target[:-5] + 'grid', view.grid_state)
 
 
-def _set_label(view, target):
-    label = view.label
-    if '$' in label:
+def check_latex(value):
+    if '$' in value:
         from matplotlib.mathtext import MathTextParser
         parser = MathTextParser('ps')
         try:
-            parser.parse(label)
+            parser.parse(value)
         except ValueError:
-            QuickError('Invalid LaTeX in label string')
-        else:
-            target.set_text(label)
-    else:
+            return False
+    return True
+
+
+def _set_label(view, target):
+    label = view.label
+    if check_latex(label):
         target.set_text(label)
+    else:
+        QuickError('Invalid LaTeX in label string')
 
 
 def _set_line_options(view, model, line):

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -1,6 +1,6 @@
 from six import string_types
 from matplotlib import text
-from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLabelOptions, QuickLineOptions
+from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLabelOptions, QuickLineOptions, QuickError
 
 
 def quick_options(target, model, has_logarithmic=None):
@@ -48,7 +48,18 @@ def _set_axis_options(view, target, model, has_logarithmic, grid):
 
 
 def _set_label(view, target):
-    target.set_text(view.label)
+    label = view.label
+    if '$' in label:
+        from matplotlib.mathtext import MathTextParser
+        parser = MathTextParser('ps')
+        try:
+            parser.parse(label)
+        except ValueError:
+            QuickError('Invalid LaTeX in label string')
+        else:
+            target.set_text(label)
+    else:
+        target.set_text(label)
 
 
 def _set_line_options(view, model, line):

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -178,6 +178,14 @@ class QuickLabelTest(unittest.TestCase):
         quick_options(self.target, self.model)
         self.target.set_text.assert_not_called()
 
+    @patch('mslice.presenters.quick_options_presenter.QuickError')
+    def test_latex(self, quickerror, quick_label_options_view):
+        type(self.view).label = PropertyMock(return_value="$\a$")
+        quick_label_options_view.return_value = self.view
+        self.view.exec_ = MagicMock(return_value=True)
+        quick_options(self.target, self.model)
+        quickerror.assert_called()
+        self.target.set_text.assert_not_called()
 
 @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
 class QuickLineTest(unittest.TestCase):


### PR DESCRIPTION
Checks user input strings in the quick options label axes for invalid strings, and pop ups an error dialog if so. Previously MSlice would crash if the LaTeX string is invalid.

**To test:**

<!-- Instructions for testing. -->
Plot a cut or slice. Click on one of the axes and input an invalid LaTeX string, e.g. `$\a$`. An error dialog should pop up and the label remains unchanged. Previously MSlice would crash.
Click on the settings (cogwheel) icon and change one of the axes to an invalid string. Check that an error dialog again pops up instead of MSlice crashing.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #483
