### PR TITLE
Restrict slices to always have DeltaE as an axis

### DIFF
--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -81,6 +81,11 @@ class SliceWidget(SliceView, QWidget):
         if axes[curr_axis] == axes[other_axis]:
             new_index = (index[other_axis] + 1) % num_items
             axes_set[other_axis](new_index)
+        if 'DeltaE' not in axes:
+            iDeltaE = [[id for id in range(cmb.count()) if 'DeltaE' in str(cmb.itemText(id))]
+                       for cmb in [self.cmbSliceXAxis, self.cmbSliceYAxis]]
+            if len(iDeltaE[other_axis]) > 0:
+                axes_set[other_axis](iDeltaE[other_axis][0])
         self._presenter.populate_slice_params()
 
     def _change_unit(self):


### PR DESCRIPTION
Adds checks in the slice widget which forces one of the axes to be energy (`DeltaE`). Thus if the user tries to select two non-energy axes, the one which they did not just select will be switched to energy.

**To test:**

<!-- Instructions for testing. -->
Load a workspace. In the slice tab, check that if you try to select both `2Theta` and `|Q|` as axes - it should switch which ever axis you did not select back to `DeltaE`.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #482
