### PR TITLE
Integration option for cuts

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -108,6 +108,9 @@ class MainWindow(MainView, QMainWindow):
 
         self.actionEUnitConvEnabled.triggered.connect(partial(self.set_energy_conversion, True))
         self.actionEUnitConvDisabled.triggered.connect(partial(self.set_energy_conversion, False))
+        self._cut_algo_map = {'Rebin': self.actionCutAlgoRebin, 'Integration': self.actionCutAlgoIntegration}
+        self.actionCutAlgoRebin.triggered.connect(partial(self.set_cut_algorithm, 'Rebin'))
+        self.actionCutAlgoIntegration.triggered.connect(partial(self.set_cut_algorithm, 'Integration'))
 
     def setup_save(self):
         menu = QMenu()
@@ -249,3 +252,13 @@ class MainWindow(MainView, QMainWindow):
 
     def is_energy_conversion_allowed(self):
         return self.actionEUnitConvEnabled.isChecked()
+
+    def set_cut_algorithm(self, algo):
+        for action in self._cut_algo_map.keys():
+            if algo not in action:
+                self._cut_algo_map[action].setChecked(False)
+
+    def get_cut_algorithm(self):
+        for action in self._cut_algo_map.keys():
+            if self._cut_algo_map[action].isChecked():
+                return action

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -424,8 +424,16 @@
      <addaction name="actionEUnitConvEnabled"/>
      <addaction name="actionEUnitConvDisabled"/>
     </widget>
+    <widget class="QMenu" name="menuCutAlgo">
+     <property name="title">
+      <string>Cut algorithm</string>
+     </property>
+     <addaction name="actionCutAlgoRebin"/>
+     <addaction name="actionCutAlgoIntegration"/>
+    </widget>
     <addaction name="menuDefault_Energy_Units"/>
     <addaction name="menuEUnitConv"/>
+    <addaction name="menuCutAlgo"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuOptions"/>
@@ -452,6 +460,25 @@
    </property>
    <property name="text">
     <string>Disabled</string>
+   </property>
+  </action>
+  <action name="actionCutAlgoRebin">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Rebin</string>
+   </property>
+  </action>
+  <action name="actionCutAlgoIntegration">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Integration</string>
    </property>
   </action>
  </widget>

--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -167,7 +167,7 @@ def Slice(InputWorkspace, Axis1=None, Axis2=None, NormToOne=False):
     return get_slice_plotter_presenter().create_slice(workspace, x_axis, y_axis, None, None, NormToOne, DEFAULT_CMAP)
 
 
-def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False):
+def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False, Algorithm='Rebin'):
     """
     Cuts workspace.
     :param InputWorkspace: Workspace to cut. The parameter can be either a python
@@ -193,7 +193,7 @@ def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False):
     cut_axis = _process_axis(CutAxis, 0, workspace)
     integration_axis = _process_axis(IntegrationAxis, 1 if workspace.is_PSD else 2,
                                      workspace, string_function=_string_to_integration_axis)
-    cut = compute_cut(workspace, cut_axis, integration_axis, NormToOne, store=True)
+    cut = compute_cut(workspace, cut_axis, integration_axis, NormToOne, Algorithm, store=True)
     get_cut_plotter_presenter().update_main_window()
 
     return cut

--- a/mslice/cli/plotfunctions.py
+++ b/mslice/cli/plotfunctions.py
@@ -72,7 +72,8 @@ def errorbar(axes, workspace, *args, **kwargs):
     cur_fig.canvas.draw()
     axes.pchanged()  # This call is to let the waterfall callback know to update
 
-    cut = Cut(cut_axis, int_axis, intensity_min, intensity_max, workspace.norm_to_one, width='')
+    cut = Cut(cut_axis, int_axis, intensity_min, intensity_max, workspace.norm_to_one, width='',
+              algorithm=workspace.algorithm)
     cut.workspace_name = workspace.parent
     presenter.save_cache(axes, cut, plot_over)
 

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -1,7 +1,8 @@
 class Cut(object):
     """Groups parameters needed to cut and validates them"""
 
-    def __init__(self, cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one=False, width=None):
+    def __init__(self, cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one=False, width=None,
+                 algorithm='Rebin'):
         self.cut_axis = cut_axis
         self.integration_axis = integration_axis
         self.intensity_start = intensity_start
@@ -13,6 +14,7 @@ class Cut(object):
         self.start = integration_axis.start
         self.end = integration_axis.end
         self.width = width
+        self.algorithm = algorithm
         self.workspace_name = 'None'
 
     def reset_integration_axis(self, start, end):
@@ -98,3 +100,11 @@ class Cut(object):
             self._width = self.end - self.start
         else:
             self._width = None
+
+    @property
+    def algorithm(self):
+        return self._algorithm
+
+    @algorithm.setter
+    def algorithm(self, algo):
+        self._algorithm = algo

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -1,8 +1,9 @@
+import numpy as np
 
 from mantid.api import PythonAlgorithm, WorkspaceProperty
-from mantid.kernel import Direction, PropertyManagerProperty, StringMandatoryValidator
+from mantid.kernel import Direction, PropertyManagerProperty, StringMandatoryValidator, StringListValidator
 from mantid.simpleapi import BinMD, ConvertSpectrumAxis, CreateMDHistoWorkspace, Rebin2D, SofQW3, TransformMD, \
-    ConvertToMD, DeleteWorkspace, CreateSimulationWorkspace, AddSampleLog, CopyLogs
+    ConvertToMD, DeleteWorkspace, CreateSimulationWorkspace, AddSampleLog, CopyLogs, Integration, Rebin, Transpose
 
 from mslice.models.alg_workspace_ops import fill_in_missing_input, get_number_of_steps
 from mslice.models.axis import Axis
@@ -23,6 +24,7 @@ class Cut(PythonAlgorithm):
         self.declareProperty('EMode', 'Direct', StringMandatoryValidator())
         self.declareProperty('PSD', False)
         self.declareProperty('NormToOne', False)
+        self.declareProperty('Algorithm', 'Rebin', StringListValidator(['Rebin', 'Integration']))
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '', direction=Direction.Output))
 
     def PyExec(self):
@@ -36,7 +38,8 @@ class Cut(PythonAlgorithm):
         e_mode = self.getProperty('EMode').value
         PSD = self.getProperty('PSD').value
         norm_to_one = self.getProperty('NormToOne').value
-        cut = compute_cut(workspace, cut_axis, int_axis, e_mode, PSD, norm_to_one)
+        algo = self.getProperty('Algorithm').value
+        cut = compute_cut(workspace, cut_axis, int_axis, e_mode, PSD, norm_to_one, algo)
         if 'DeltaE' in cut_axis.units and cut_axis.scale != 1.:
             cut = TransformMD(InputWorkspace=cut, Scaling=[EnergyUnits(cut_axis.e_unit).factor_from_meV()])
         attribute_to_log({'axes':[cut_axis, int_axis], 'norm_to_one':norm_to_one}, cut)
@@ -45,11 +48,11 @@ class Cut(PythonAlgorithm):
     def category(self):
         return 'MSlice'
 
-def compute_cut(selected_workspace, cut_axis, integration_axis, e_mode, PSD, is_norm):
+def compute_cut(selected_workspace, cut_axis, integration_axis, e_mode, PSD, is_norm, algo):
     if PSD:
         cut = _compute_cut_PSD(selected_workspace, cut_axis, integration_axis)
     else:
-        cut = _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, e_mode)
+        cut = _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, e_mode, algo)
     if is_norm:
         normalize_workspace(cut)
     return cut
@@ -68,27 +71,27 @@ def _compute_cut_PSD(selected_workspace, cut_axis, integration_axis):
                  AlignedDim0=cut_binning, StoreInADS=False)
 
 
-def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode):
+def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode, algo):
     cut_binning = " ,".join(map(str, (cut_axis.start_meV, cut_axis.step_meV, cut_axis.end_meV)))
     int_binning = " ,".join(map(str, (integration_axis.start_meV, integration_axis.end_meV - integration_axis.start_meV,
                                       integration_axis.end_meV)))
-    idx = 0
+    idx = 0 if 'Rebin' in algo else 1
     unit = 'DeltaE'
     name = 'EnergyTransfer'
     if is_momentum(cut_axis.units):
-        ws_out = _cut_nonPSD_momentum(cut_binning, int_binning, emode, selected_workspace)
+        ws_out = _cut_nonPSD_momentum(cut_binning, int_binning, emode, selected_workspace, algo)
         idx = 1
         unit = 'MomentumTransfer'
         name = '|Q|'
     elif is_twotheta(cut_axis.units):
-        ws_out = _cut_nonPSD_theta(cut_binning, int_binning, selected_workspace)
-        idx = 1
+        ws_out = _cut_nonPSD_theta(int_binning, cut_binning, selected_workspace, algo)
+        idx = 1 if 'Rebin' in algo else 0
         unit = 'Degrees'
         name = 'Theta'
     elif integration_axis.units == '|Q|':
-        ws_out = _cut_nonPSD_momentum(int_binning, cut_binning, emode, selected_workspace)
+        ws_out = _cut_nonPSD_momentum(int_binning, cut_binning, emode, selected_workspace, algo)
     else:
-        ws_out = _cut_nonPSD_theta(int_binning, cut_binning, selected_workspace)
+        ws_out = _cut_nonPSD_theta(cut_binning, int_binning, selected_workspace, algo)
     xdim = ws_out.getDimension(idx)
     extents = " ,".join(map(str, (xdim.getMinimum(), xdim.getMaximum())))
 
@@ -113,21 +116,48 @@ def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode):
     return ws_out
 
 
-def _cut_nonPSD_theta(cut_binning, int_binning, selected_workspace):
+def _cut_nonPSD_theta(ax1_binning, ax2_binning, selected_workspace, algo):
 
-    converted_nonpsd = ConvertSpectrumAxis( OutputWorkspace='__convToTheta', InputWorkspace=selected_workspace,
-                                            Target='theta', StoreInADS=False)
+    converted_nonpsd = ConvertSpectrumAxis(InputWorkspace=selected_workspace, Target='theta', StoreInADS=False)
 
-    ws_out = Rebin2D(InputWorkspace=converted_nonpsd, Axis1Binning=int_binning, Axis2Binning=cut_binning,
-                     StoreInADS=False)
+    if 'Integration' in algo:
+        ax1 = [float(x1) for x1 in ax1_binning.split(',')]
+        ax2 = [float(x2) for x2 in ax2_binning.split(',')]
+        if np.abs((ax1[2]-ax1[0]) - ax1[1]) < 0.0001:
+            ws_out = Integration(InputWorkspace=converted_nonpsd, RangeLower=ax1[0], RangeUpper=ax1[2], EnableLogging=False)
+            ws_out = Transpose(InputWorkspace=ws_out, EnableLogging=False)
+            ws_out = Rebin(InputWorkspace=ws_out, Params=ax2_binning, EnableLogging=False)
+        else:
+            ws_out = Rebin(InputWorkspace=converted_nonpsd, Params=ax1_binning, EnableLogging=False)
+            ws_out = Transpose(InputWorkspace=ws_out, EnableLogging=False)
+            ws_out = Integration(InputWorkspace=ws_out, RangeLower=ax2[0], RangeUpper=ax2[2], EnableLogging=False)
+    else:
+        ws_out = Rebin2D(InputWorkspace=converted_nonpsd, Axis1Binning=ax1_binning, Axis2Binning=ax2_binning,
+                         StoreInADS=False, UseFractionalArea=True, EnableLogging=False)
     return ws_out
 
-
-def _cut_nonPSD_momentum(q_binning, e_binning, emode, selected_workspace):
+def _cut_indirect_or_direct(q_binning, e_binning, emode, selected_workspace):
     if 'Indirect' in emode and selected_workspace.run().hasProperty('Efix'):
         ws_out = SofQW3(InputWorkspace=selected_workspace, QAxisBinning=q_binning, EAxisBinning=e_binning, EMode=emode,
-                        StoreInADS=False, EFixed=selected_workspace.run().getProperty('Efix').value)
+                        StoreInADS=False, EFixed=selected_workspace.run().getProperty('Efix').value, EnableLogging=False)
     else:
         ws_out = SofQW3(InputWorkspace=selected_workspace, OutputWorkspace='out', EMode=emode, QAxisBinning=q_binning,
-                        EAxisBinning=e_binning, StoreInADS=False)
+                        EAxisBinning=e_binning, StoreInADS=False, EnableLogging=False)
+    return ws_out
+
+def _cut_nonPSD_momentum(q_binning, e_binning, emode, selected_workspace, algo):
+    if 'Integration' in algo:
+        qbins = [float(q) for q in q_binning.split(',')]
+        ebins = [float(e) for e in e_binning.split(',')]
+        if np.abs((qbins[2]-qbins[0]) - qbins[1]) < 0.0001:
+            qbinstr = ','.join(map(str, [qbins[0], (qbins[2]-qbins[0])/100., qbins[2]]))
+            ws_out = _cut_indirect_or_direct(qbinstr, e_binning, emode, selected_workspace)
+            ws_out = Transpose(InputWorkspace=ws_out, EnableLogging=False)
+            ws_out = Integration(InputWorkspace=ws_out, RangeLower=qbins[0], RangeUpper=qbins[2], EnableLogging=False)
+        else:
+            ebinstr = ','.join(map(str, [ebins[0], (ebins[2]-ebins[0])/100., ebins[2]]))
+            ws_out = _cut_indirect_or_direct(q_binning, ebinstr, emode, selected_workspace)
+            ws_out = Integration(InputWorkspace=ws_out, RangeLower=ebins[0], RangeUpper=ebins[2], EnableLogging=False)
+    else:
+        ws_out = _cut_indirect_or_direct(q_binning, e_binning, emode, selected_workspace)
     return ws_out

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -42,7 +42,7 @@ class Cut(PythonAlgorithm):
         cut = compute_cut(workspace, cut_axis, int_axis, e_mode, PSD, norm_to_one, algo)
         if 'DeltaE' in cut_axis.units and cut_axis.scale != 1.:
             cut = TransformMD(InputWorkspace=cut, Scaling=[EnergyUnits(cut_axis.e_unit).factor_from_meV()])
-        attribute_to_log({'axes':[cut_axis, int_axis], 'norm_to_one':norm_to_one}, cut)
+        attribute_to_log({'axes':[cut_axis, int_axis], 'norm_to_one':norm_to_one, 'algorithm': algo}, cut)
         self.setProperty('OutputWorkspace', cut)
 
     def category(self):

--- a/mslice/models/cut/cut_functions.py
+++ b/mslice/models/cut/cut_functions.py
@@ -13,11 +13,12 @@ def output_workspace_name(selected_workspace, integration_start, integration_end
         integration_end) + ")"
 
 
-def compute_cut(workspace, cut_axis, integration_axis, is_norm, store=True):
+def compute_cut(workspace, cut_axis, integration_axis, is_norm, algo='Rebin', store=True):
     out_ws_name = output_workspace_name(workspace.name, integration_axis.start, integration_axis.end)
     cut = mantid_algorithms.Cut(OutputWorkspace=out_ws_name, store=store, InputWorkspace=workspace,
                                 CutAxis=cut_axis.to_dict(), IntegrationAxis=integration_axis.to_dict(),
-                                EMode=workspace.e_mode, PSD=workspace.is_PSD, NormToOne=is_norm)
+                                EMode=workspace.e_mode, PSD=workspace.is_PSD, NormToOne=is_norm,
+                                Algorithm=algo)
     cut.parent = workspace.name
     return cut
 

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -27,7 +27,8 @@ class CutPlotterPresenter(PresenterUtility):
     def _plot_cut(self, workspace, cut, plot_over, store=True, update_main=True):
         cut_axis = cut.cut_axis
         integration_axis = cut.integration_axis
-        cut_ws = compute_cut(workspace, cut_axis, integration_axis, cut.norm_to_one, store)
+        algo = self._main_presenter.get_cut_algorithm() if self._main_presenter is not None else 'Rebin'
+        cut_ws = compute_cut(workspace, cut_axis, integration_axis, cut.norm_to_one, algo, store)
         legend = generate_legend(workspace.name, integration_axis.units, integration_axis.start, integration_axis.end)
         en_conversion = self._main_presenter.is_energy_conversion_allowed() if self._main_presenter else True
         plot_cut_impl(cut_ws, (cut.intensity_start, cut.intensity_end), plot_over, legend, en_conversion)
@@ -63,7 +64,8 @@ class CutPlotterPresenter(PresenterUtility):
         return self._cut_cache_dict[ax] if ax in self._cut_cache_dict.keys() else None
 
     def save_cut_to_workspace(self, workspace, cut):
-        compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one)
+        algo = self._main_presenter.get_cut_algorithm() if self._main_presenter is not None else 'Rebin'
+        compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one, algo)
         self._main_presenter.update_displayed_workspaces()
 
     def plot_cut_from_selected_workspace(self, plot_over=False):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -27,8 +27,7 @@ class CutPlotterPresenter(PresenterUtility):
     def _plot_cut(self, workspace, cut, plot_over, store=True, update_main=True):
         cut_axis = cut.cut_axis
         integration_axis = cut.integration_axis
-        algo = self._main_presenter.get_cut_algorithm() if self._main_presenter is not None else 'Rebin'
-        cut_ws = compute_cut(workspace, cut_axis, integration_axis, cut.norm_to_one, algo, store)
+        cut_ws = compute_cut(workspace, cut_axis, integration_axis, cut.norm_to_one, cut.algorithm, store)
         legend = generate_legend(workspace.name, integration_axis.units, integration_axis.start, integration_axis.end)
         en_conversion = self._main_presenter.is_energy_conversion_allowed() if self._main_presenter else True
         plot_cut_impl(cut_ws, (cut.intensity_start, cut.intensity_end), plot_over, legend, en_conversion)
@@ -64,8 +63,7 @@ class CutPlotterPresenter(PresenterUtility):
         return self._cut_cache_dict[ax] if ax in self._cut_cache_dict.keys() else None
 
     def save_cut_to_workspace(self, workspace, cut):
-        algo = self._main_presenter.get_cut_algorithm() if self._main_presenter is not None else 'Rebin'
-        compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one, algo)
+        compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one, cut.algorithm)
         self._main_presenter.update_displayed_workspaces()
 
     def plot_cut_from_selected_workspace(self, plot_over=False):

--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -95,7 +95,8 @@ class CutWidgetPresenter(PresenterUtility):
 
         norm_to_one = bool(self._cut_view.get_intensity_is_norm_to_one())
         width = self._cut_view.get_integration_width()
-        return cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width
+        algo = self._main_presenter.get_cut_algorithm() if self._main_presenter is not None else 'Rebin'
+        return cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width, algo
 
     def _set_minimum_step(self, workspace, axis):
         """Gets axes limits and then sets the minimumStep dictionary with those values"""

--- a/mslice/presenters/interfaces/main_presenter.py
+++ b/mslice/presenters/interfaces/main_presenter.py
@@ -52,3 +52,7 @@ class MainPresenterInterface(object):
     @abc.abstractmethod
     def is_energy_conversion_allowed(self):
         pass
+
+    @abc.abstractmethod
+    def get_cut_algorithm(self):
+        pass

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -72,3 +72,6 @@ class MainPresenter(MainPresenterInterface):
 
     def is_energy_conversion_allowed(self):
         return self._mainView.is_energy_conversion_allowed()
+
+    def get_cut_algorithm(self):
+        return self._mainView.get_cut_algorithm()

--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -45,6 +45,17 @@ def generate_script_lines(raw_ws, workspace_name):
     ws_name = workspace_name.replace(".", "_")
     alg_history = raw_ws.getHistory().getAlgorithmHistories()
     existing_ws_refs = []
+
+    # Loop back from end to see if we have a Save / Load pair and truncate at the load if so
+    prev_algo = alg_history[-1]
+    for idx, algorithm in reversed(list(enumerate(alg_history[:-1]))):
+        new_algo = algorithm
+        if 'Save' in new_algo.name() and 'Load' in prev_algo.name():
+            alg_history = alg_history[idx+1:]
+            break
+        else:
+            prev_algo = new_algo
+
     for algorithm in alg_history:
         alg_name = algorithm.name()
         kwargs, output_ws = get_algorithm_kwargs(algorithm, existing_ws_refs)

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -143,6 +143,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts):
         cut_start, cut_end = integration_start, min(integration_start + cut.width, integration_end)
         intensity_range = (cut.intensity_start, cut.intensity_end)
         norm_to_one = cut.norm_to_one
+        algo_str = '' if 'Rebin' in cut.algorithm else ', Algorithm="{}"'.format(cut.algorithm)
 
         while cut_start != cut_end and index < len(errorbars):
             cut.integration_axis.start = cut_start
@@ -158,8 +159,8 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts):
             label = errorbar._label
 
             script_lines.append('cut_ws_{} = mc.Cut(ws_{}, CutAxis="{}", IntegrationAxis="{}", '
-                                'NormToOne={})\n'.format(index, cut.workspace_name, cut_axis, integration_axis,
-                                                         norm_to_one))
+                                'NormToOne={}{})\n'.format(index, cut.workspace_name, cut_axis, integration_axis,
+                                                           norm_to_one, algo_str))
 
             if intensity_range != (None, None):
                 script_lines.append(

--- a/mslice/tests/cut_widget_presenter_test.py
+++ b/mslice/tests/cut_widget_presenter_test.py
@@ -267,3 +267,22 @@ class CutWidgetPresenterTest(unittest.TestCase):
         cut_widget_presenter.set_energy_default("meV")
         self.view.set_energy_units.assert_called_once()
         self.view.set_energy_units_default.assert_called_once()
+
+    @patch('mslice.presenters.cut_widget_presenter.Cut')
+    def test_cut_integration_algorithm(self, mock_cut_obj):
+        cut_widget_presenter = CutWidgetPresenter(self.view)
+        cut_widget_presenter.register_master(self.main_presenter)
+        cut_plotter_presenter = mock.MagicMock()
+        cut_plotter_presenter.run_cut = mock.Mock()
+        cut_widget_presenter.set_cut_plotter_presenter(cut_plotter_presenter)
+        integrated_axis, integration_start, integration_end, width = ('integrated axis', 3, 8, "")
+        intensity_start, intensity_end, is_norm, workspace = (11, 30, True, 'ws1')
+        axis = Axis("units", "0", "100", "1")
+        integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
+        self._create_cut(axis, integration_axis, integration_start, integration_end, width,
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+        self.main_presenter.get_cut_algorithm = mock.Mock(return_value='Integration')
+        cut_widget_presenter.notify(Command.Plot)
+        self.view.display_error.assert_not_called()
+        mock_cut_obj.assert_called_once_with(axis, integration_axis, intensity_start, intensity_end,
+                                             is_norm, width, 'Integration')

--- a/mslice/views/interfaces/mainview.py
+++ b/mslice/views/interfaces/mainview.py
@@ -7,3 +7,6 @@ class MainView(object):
 
     def is_energy_conversion_allowed(self):
         pass
+
+    def get_cut_algorithm(self):
+        pass

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -23,6 +23,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         self.axes = []
         self.norm_to_one = False
         self.parent = None
+        self.algorithm = []
         attribute_from_log(self, mantid_ws)
 
     def rewrap(self, ws):


### PR DESCRIPTION
Adds the option to make cut using the `Integration` algorithm in Mantid rather than the `Rebin2D` or `SofQW3` algorithms. The resulting cuts should be almost exactly the same as with the rebin algorithms for the same cut integration limits, differing only by an overall scale factor. However, cuts with larger integration limits should give larger signal with the `Integration` algorithm compared with the rebin algorithms because the rebin algorithms renormalise the data to account for the larger (integration) bin size.

There is now a new menu option in the main window - under `Options` -> `Cut algorithm`. The default is the original `Rebin` algorithm, but there is now an option to use the `Integration` algorithm. 

**To test:**

<!-- Instructions for testing. -->
Load a workspace and make a cut using the original `Rebin` algorithm. Then change the algorithm in the options menu and repeat the cut - they should look the same except with a different overall scaling factor. Make a similar cut with a larger integration range and check that this signal is larger with the integration algorithm whilst it maybe the same or smaller with the Rebin algorithm.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #490

Notify MJCliffe on the Forum: https://forum.mantidproject.org/t/saving-data-from-mslice/541/3 when this is merged.
