### PR TITLE
Fix is_cut check

### DIFF
--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -152,7 +152,8 @@ def is_cut(*args):
     """
     Checks if args[0] is a HistogramWorkspace
     """
-    if isinstance(args[0], HistogramWorkspace) and args[0]._raw_ws.getNumDims() == 1:
+    if isinstance(args[0], HistogramWorkspace) and \
+            sum([args[0].raw_ws.getDimension(i).getNBins() != 1 for i in range(args[0]._raw_ws.getNumDims())]) == 1:
         return True
     else:
         return False


### PR DESCRIPTION
The check for `is_cut` introduced in PR 470 was incorrect and resulted in the base Matplotlib `errorbar` function being called on an MSlice cut object rather than the correct overloaded MSlice `errorbar` function, giving an error when trying to plot a cut from a PSD type data file (because the underlying workspace actually has two dimensions even though one has only one bin).

**To test:**

<!-- Instructions for testing. -->
Load a PSD data set, make projection and then try to make a cut (either from the widget or an interactive cut). It should now work.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #493
