### PR TITLE
Keep dialog open

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -92,9 +92,9 @@ class CutPlot(IPlot):
         if bounds['x_label'] < y < bounds['title']:
             if bounds['y_label'] < x:
                 if y < bounds['x_range']:
-                    quick_options('x_range', self, self.x_log)
+                    quick_options('x_range', self, self.x_log, redraw_signal=self.plot_window.redraw)
                 elif x < bounds['y_range']:
-                    quick_options('y_range', self, self.y_log)
+                    quick_options('y_range', self, self.y_log, redraw_signal=self.plot_window.redraw)
             self._canvas.draw()
 
     def object_clicked(self, target):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -55,6 +55,7 @@ class CutPlot(IPlot):
         }
 
     def setup_connections(self, plot_window):
+        plot_window.redraw.connect(self._canvas.draw)
         plot_window.menu_intensity.setDisabled(True)
         plot_window.menu_information.setDisabled(True)
         plot_window.action_interactive_cuts.setVisible(False)
@@ -83,9 +84,7 @@ class CutPlot(IPlot):
         self._canvas.figure.clf()
 
     def plot_options(self):
-        new_config = CutPlotOptionsPresenter(CutPlotOptions(), self).get_new_config()
-        if new_config:
-            self._canvas.draw()
+        CutPlotOptionsPresenter(CutPlotOptions(redraw_signal=self.plot_window.redraw), self)
 
     def plot_clicked(self, x, y):
         bounds = self.calc_figure_boundaries()

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -17,8 +17,9 @@ class PlotOptionsDialog(QtWidgets.QDialog):
     yRangeEdited = Signal()
     xGridEdited = Signal()
     yGridEdited = Signal()
+    ok_clicked = Signal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, redraw_signal=None):
         QtWidgets.QDialog.__init__(self, parent)
         load_ui(__file__, 'plot_options.ui', self)
 
@@ -29,10 +30,17 @@ class PlotOptionsDialog(QtWidgets.QDialog):
         self.lneXMax.editingFinished.connect(self.xRangeEdited)
         self.lneYMin.editingFinished.connect(self.yRangeEdited)
         self.lneYMax.editingFinished.connect(self.yRangeEdited)
-        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.accepted.connect(self._ok_clicked)
         self.buttonBox.rejected.connect(self.reject)
         self.chkXGrid.stateChanged.connect(self.xGridEdited)
         self.chkYGrid.stateChanged.connect(self.yGridEdited)
+        self.redraw_signal = redraw_signal
+
+    def _ok_clicked(self):
+        self.ok_clicked.emit()
+        self.redraw_signal.emit()
+        if not self.is_kept_open:
+            self.accept()
 
     @property
     def x_range(self):
@@ -110,14 +118,18 @@ class PlotOptionsDialog(QtWidgets.QDialog):
     def y_grid(self, value):
         self.chkYGrid.setChecked(value)
 
+    @property
+    def is_kept_open(self):
+        return self.keep_open.isChecked()
+
 
 class SlicePlotOptions(PlotOptionsDialog):
 
     cRangeEdited = Signal()
     cLogEdited = Signal()
 
-    def __init__(self):
-        super(SlicePlotOptions, self).__init__()
+    def __init__(self, redraw_signal=None):
+        super(SlicePlotOptions, self).__init__(redraw_signal=redraw_signal)
         self.chkXLog.hide()
         self.chkYLog.hide()
         self.cut_options.hide()
@@ -160,8 +172,8 @@ class CutPlotOptions(PlotOptionsDialog):
     yLogEdited = Signal()
     showLegendsEdited = Signal()
 
-    def __init__(self):
-        super(CutPlotOptions, self).__init__()
+    def __init__(self, redraw_signal=None):
+        super(CutPlotOptions, self).__init__(redraw_signal=redraw_signal)
         self._line_widgets = []
         self.groupBox_4.hide()
 

--- a/mslice/plotting/plot_window/plot_options.ui
+++ b/mslice/plotting/plot_window/plot_options.ui
@@ -342,19 +342,32 @@
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="layoutDirection">
-      <enum>Qt::LeftToRight</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
+    <widget class="QWidget" name="cut_options" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_1">
+      <item>
+       <widget class="QCheckBox" name="keep_open">
+        <property name="text">
+         <string>Keep open</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDialogButtonBox" name="buttonBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -27,7 +27,7 @@ class MatplotlibQTCanvas(FigureCanvas):
 class PlotWindow(QtWidgets.QMainWindow):
     """The plot window that holds a matplotlib figure"""
 
-    redraw = QtCore.Signal(bool)
+    redraw = QtCore.Signal()
 
     def __init__(self, manager, parent=None):
         super(PlotWindow, self).__init__(parent)

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -27,6 +27,8 @@ class MatplotlibQTCanvas(FigureCanvas):
 class PlotWindow(QtWidgets.QMainWindow):
     """The plot window that holds a matplotlib figure"""
 
+    redraw = QtCore.Signal(bool)
+
     def __init__(self, manager, parent=None):
         super(PlotWindow, self).__init__(parent)
         self.setup_ui(manager)
@@ -240,7 +242,7 @@ def add_action(holder, parent, text, on_triggered=None, icon_name=None,
     holder"""
     action = QtWidgets.QAction(text, parent)
     if icon_name is not None:
-        action.setIcon(get_icon(icon_name, "black", 1.3))
+        action.setIcon(get_icon(icon_name))
     action.setCheckable(checkable)
     action.setChecked(checked)
     action.setVisible(visible)

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -6,6 +6,8 @@ from mslice.util.qt.QtCore import Signal
 
 class QuickOptions(QtWidgets.QDialog):
 
+    ok_clicked = Signal(bool)
+
     def __init__(self):
         super(QuickOptions, self).__init__()
         self.layout = QtWidgets.QVBoxLayout()
@@ -17,11 +19,12 @@ class QuickOptions(QtWidgets.QDialog):
         self.button_row.addWidget(self.cancel_button)
         self.ok_button.clicked.connect(self.accept)
         self.cancel_button.clicked.connect(self.reject)
+        self.keep_open = QtWidgets.QCheckBox('Keep open')
 
 
 class QuickAxisOptions(QuickOptions):
 
-    def __init__(self, target, existing_values, grid, log):
+    def __init__(self, target, existing_values, grid, log, redraw_signal):
         super(QuickAxisOptions, self).__init__()
         self.setWindowTitle("Edit " + target)
         self.log = log
@@ -52,6 +55,16 @@ class QuickAxisOptions(QuickOptions):
             row4.addWidget(self.log_scale)
             self.layout.addLayout(row4)
         self.layout.addLayout(self.button_row)
+        self.layout.addWidget(self.keep_open)
+        self.ok_button.clicked.disconnect()
+        self.ok_button.clicked.connect(self._ok_clicked)
+        self.redraw_signal = redraw_signal
+
+    def _ok_clicked(self):
+        self.ok_clicked.emit(True)
+        self.redraw_signal.emit(True)
+        if not self.is_kept_open:
+            self.accept()
 
     @property
     def range_min(self):
@@ -65,6 +78,9 @@ class QuickAxisOptions(QuickOptions):
     def grid_state(self):
         return self.grid.checkState()
 
+    @property
+    def is_kept_open(self):
+        return self.keep_open.isChecked()
 
 class QuickLabelOptions(QuickOptions):
 

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -6,7 +6,7 @@ from mslice.util.qt.QtCore import Signal
 
 class QuickOptions(QtWidgets.QDialog):
 
-    ok_clicked = Signal(bool)
+    ok_clicked = Signal()
 
     def __init__(self):
         super(QuickOptions, self).__init__()
@@ -61,8 +61,8 @@ class QuickAxisOptions(QuickOptions):
         self.redraw_signal = redraw_signal
 
     def _ok_clicked(self):
-        self.ok_clicked.emit(True)
-        self.redraw_signal.emit(True)
+        self.ok_clicked.emit()
+        self.redraw_signal.emit()
         if not self.is_kept_open:
             self.accept()
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -61,6 +61,7 @@ class SlicePlot(IPlot):
         }
 
     def setup_connections(self, plot_window):
+        plot_window.redraw.connect(self._canvas.draw)
         plot_window.action_interactive_cuts.setVisible(True)
         plot_window.action_interactive_cuts.triggered.connect(self.toggle_interactive_cuts)
         plot_window.action_save_cut.setVisible(False)
@@ -145,11 +146,11 @@ class SlicePlot(IPlot):
         if bounds['x_label'] < y < bounds['title']:
             if bounds['y_label'] < x < bounds['colorbar_label']:
                 if y < bounds['x_range']:
-                    quick_options('x_range', self)
+                    quick_options('x_range', self, redraw_signal=self.plot_window.redraw)
                 elif x < bounds['y_range']:
-                    quick_options('y_range', self)
+                    quick_options('y_range', self, redraw_signal=self.plot_window.redraw)
                 elif x > bounds['colorbar_range']:
-                    quick_options('colorbar_range', self, self.colorbar_log)
+                    quick_options('colorbar_range', self, self.colorbar_log, redraw_signal=self.plot_window.redraw)
             self._canvas.draw()
 
     def object_clicked(self, target):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -137,9 +137,7 @@ class SlicePlot(IPlot):
         pass
 
     def plot_options(self):
-        new_config = SlicePlotOptionsPresenter(SlicePlotOptions(), self).get_new_config()
-        if new_config:
-            self._canvas.draw()
+        SlicePlotOptionsPresenter(SlicePlotOptions(redraw_signal=self.plot_window.redraw), self)
 
     def plot_clicked(self, x, y):
         bounds = self.calc_figure_boundaries()

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -37,6 +37,8 @@ class SlicePlotOptionsPresenter(PlotOptionsPresenter):
 
         self._view.cLogEdited.connect(self._set_colorbar_log)
         self._view.cRangeEdited.connect(self._set_c_range)
+        self._view.ok_clicked.connect(self.get_new_config)
+        self._view.show()
 
     def set_properties(self):
         properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'x_grid', 'y_grid',
@@ -45,16 +47,12 @@ class SlicePlotOptionsPresenter(PlotOptionsPresenter):
             setattr(self._view, p, getattr(self._model, p))
 
     def get_new_config(self):
-        dialog_accepted = self._view.exec_()
-        if not dialog_accepted:
-            return None
         if self._color_config['modified']:
             self._model.change_axis_scale(self._color_config['c_range'], self._color_config['log'])
         for key, value in list(self._modified_values.items()):
             setattr(self._model, key, value)
         self._model.x_range = self._xy_config['x_range']
         self._model.y_range = self._xy_config['y_range']
-        return True
 
     def _set_c_range(self):
         self._color_config['c_range'] = self._view.colorbar_range
@@ -78,6 +76,9 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         line_options = self._model.get_all_line_options()
         self._view.set_line_options(line_options)
 
+        self._view.ok_clicked.connect(self.get_new_config)
+        self._view.show()
+
     def set_properties(self):
         properties = ['title', 'x_label', 'y_label', 'x_range', 'y_range', 'x_log', 'y_log',
                       'x_grid', 'y_grid', 'show_legends']
@@ -85,13 +86,9 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
             setattr(self._view, p, getattr(self._model, p))
 
     def get_new_config(self):
-        dialog_accepted = self._view.exec_()
-        if not dialog_accepted:
-            return None
         if self._xy_config['modified']:
             self._model.change_axis_scale(self._xy_config)
         for key, value in list(self._modified_values.items()):
             setattr(self._model, key, value)
         line_options = self._view.get_line_options()
         self._model.set_all_line_options(line_options)
-        return True

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -8,7 +8,7 @@ def quick_options(target, model, has_logarithmic=None, redraw_signal=None):
     if isinstance(target, text.Text):
         quick_label_options(target)
     elif isinstance(target, string_types):
-        quick_axis_options(target, model, has_logarithmic, redraw_signal)
+        return quick_axis_options(target, model, has_logarithmic, redraw_signal)
     else:
         quick_line_options(target, model)
 
@@ -26,6 +26,7 @@ def quick_axis_options(target, model, has_logarithmic=None, redraw_signal=None):
     view = QuickAxisOptions(target, getattr(model, target), grid, has_logarithmic, redraw_signal)
     view.ok_clicked.connect(lambda: _set_axis_options(view, target, model, has_logarithmic, grid))
     view.show()
+    return view
 
 
 def quick_line_options(target, model):
@@ -40,6 +41,7 @@ def _run_quick_options(view, update_model_function, *args):
 
 
 def _set_axis_options(view, target, model, has_logarithmic, grid):
+    print('setting axis options')
     range = (float(view.range_min), float(view.range_max))
     setattr(model, target, range)
     if has_logarithmic is not None:

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -41,7 +41,6 @@ def _run_quick_options(view, update_model_function, *args):
 
 
 def _set_axis_options(view, target, model, has_logarithmic, grid):
-    print('setting axis options')
     range = (float(view.range_min), float(view.range_max))
     setattr(model, target, range)
     if has_logarithmic is not None:

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -3,12 +3,12 @@ from matplotlib import text
 from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLabelOptions, QuickLineOptions, QuickError
 
 
-def quick_options(target, model, has_logarithmic=None):
+def quick_options(target, model, has_logarithmic=None, redraw_signal=None):
     """Find which quick_options to use based on type of target"""
     if isinstance(target, text.Text):
         quick_label_options(target)
     elif isinstance(target, string_types):
-        quick_axis_options(target, model, has_logarithmic)
+        quick_axis_options(target, model, has_logarithmic, redraw_signal)
     else:
         quick_line_options(target, model)
 
@@ -18,13 +18,14 @@ def quick_label_options(target):
     _run_quick_options(view, _set_label, target)
 
 
-def quick_axis_options(target, model, has_logarithmic=None):
+def quick_axis_options(target, model, has_logarithmic=None, redraw_signal=None):
     if target[:1] == 'x' or target[:1] == 'y':
         grid = getattr(model, target[:-5] + 'grid')
     else:
         grid = None
-    view = QuickAxisOptions(target, getattr(model, target), grid, has_logarithmic)
-    _run_quick_options(view, _set_axis_options, target, model, has_logarithmic, grid)
+    view = QuickAxisOptions(target, getattr(model, target), grid, has_logarithmic, redraw_signal)
+    view.ok_clicked.connect(lambda: _set_axis_options(view, target, model, has_logarithmic, grid))
+    view.show()
 
 
 def quick_line_options(target, model):


### PR DESCRIPTION
Changes the `QuickAxisOptions` and `PlotOptions` classes to be non-modal and to have a `Keep open` check box. If this is not checked the `Ok` button will close the dialog. If it is checked then `Ok` will submit the new values entered to the plot but the dialog will stay open. This is done by connecting the options dialog to both the update function in the presenter and the `_canvas.draw()` function of the plot window. When the `Ok` button is clicked, a Qt `Signal` is emitted to the presenter to update the model, and then another signal is emitted to the canvas to redraw the graph. (I think there is no guarantee that these signals will be processed one after the other so there may be a race condition but in testing this didn't not seem to be a problem and I did not want to add a time delay between them).

**To test:**

<!-- Instructions for testing. -->
Make a plot (slice or cut). Double click on one of the axes - the quick options dialog will pop up. Check the `Keep open` box and type a new value for the limits. Hit `enter` or click `Ok` and check that the plot updates but the dialog stays open. Uncheck the `Keep open` box, and change the value again, and hit `enter` / click `Ok`. Check that the plot updates correctly and the dialog is closed. Do the same for the main plot options (click on the cogwheel icon).

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #460
