### PR TITLE
Added override to avoid load overwrite dialog

### DIFF
--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -82,7 +82,7 @@ def Load(Filename, OutputWorkspace=None):
         else:
             raise RuntimeError('could not find the path %s' % Filename)
 
-    get_dataloader_presenter().load_workspace([Filename], merge)
+    get_dataloader_presenter().load_workspace([Filename], merge, force_overwrite=-1)
     name = ospath.splitext(ospath.basename(Filename))[0]
     if OutputWorkspace is not None:
         old_name = ospath.splitext(ospath.basename(Filename))[0]

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -17,11 +17,12 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
         self._main_presenter = None
         self._EfCache = None
 
-    def load_workspace(self, file_paths, merge=False):
+    def load_workspace(self, file_paths, merge=False, force_overwrite=False):
         """
         Loads one or more workspaces.
         :param file_paths: list of paths to files to load
         :param merge: boolean - whether to combine files into a single workspace
+        :param force_overwrite: int - 0: asks for overwrite, 1 always overwrite, -1 never overwrite
         """
         with show_busy(self._view):
             ws_names = [os.path.splitext(os.path.basename(base))[0] for base in file_paths]
@@ -31,15 +32,15 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     return
                 ws_names = [ws_names[0] + '_merged']
                 file_paths = ['+'.join(file_paths)]
-            self._load_ws(file_paths, ws_names)
+            self._load_ws(file_paths, ws_names, force_overwrite)
 
-    def _load_ws(self, file_paths, ws_names):
+    def _load_ws(self, file_paths, ws_names, force_overwrite):
         not_loaded = []
         not_opened = []
         multi = len(ws_names) > 1
         allChecked = False
         for i, ws_name in enumerate(ws_names):
-            if not self._confirm_workspace_overwrite(ws_name):
+            if not self._confirm_workspace_overwrite(ws_name, force_overwrite):
                 not_loaded.append(ws_name)
             else:
                 try:
@@ -78,9 +79,12 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
             get_limits(ws_name, 'DeltaE')  # This is call needed to process the limits.
             return allChecked
 
-    def _confirm_workspace_overwrite(self, ws_name):
+    def _confirm_workspace_overwrite(self, ws_name, force_overwrite):
         if ws_name in get_visible_workspace_names():
-            return self._view.confirm_overwrite_workspace()
+            if force_overwrite == 0:
+                return self._view.confirm_overwrite_workspace()
+            else:
+                return force_overwrite == 1
         else:
             return True
 

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -73,7 +73,7 @@ class CommandLineTest(unittest.TestCase):
         path = 'made_up_path'
         Load(path)
 
-        get_dlp().load_workspace.assert_called_once_with([path], False)
+        get_dlp().load_workspace.assert_called_once_with([path], False, force_overwrite=-1)
         get_workspace_mock.assert_called_with(path)
 
     @mock.patch('mslice.cli._mslice_commands.get_workspace_handle')
@@ -85,7 +85,7 @@ class CommandLineTest(unittest.TestCase):
         ospath_mock.splitext.return_value = [path]
         Load(path)
 
-        get_dlp().load_workspace.assert_called_once_with([path], True)
+        get_dlp().load_workspace.assert_called_once_with([path], True, force_overwrite=-1)
         get_workspace_mock.assert_called_with(path)
 
     @mock.patch('mslice.app.presenters.get_powder_presenter')


### PR DESCRIPTION
When running a script in MantidPlot or the workbench it crashes either program on reloading data because of the popup dialog which asks if the user would like to overwrite a workspace. This PR changes the CLI code to avoid asking for the overwrite by explicitly _not_ overwriting the loaded workspace.

Whilst investigating this issue another issue ( #497 ) related to running a script was found.

**To test:**

<!-- Instructions for testing. -->
Run MSlice through MantidPlot/Workbench, load a workspace and make a plot. Generate a script file and open it in the Python window. Run it (Ctrl+Enter) in that window and check that the plot is accurately created and MantidPlot/Workbench does not crash.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #464
