### PR TITLE
Fixed ads export bug

### DIFF
--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -82,12 +82,12 @@ def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode, a
         ws_out = _cut_nonPSD_momentum(cut_binning, int_binning, emode, selected_workspace, algo)
         idx = 1
         unit = 'MomentumTransfer'
-        name = '|Q|'
+        name = '__MSL_|Q|'
     elif is_twotheta(cut_axis.units):
         ws_out = _cut_nonPSD_theta(int_binning, cut_binning, selected_workspace, algo)
         idx = 1 if 'Rebin' in algo else 0
         unit = 'Degrees'
-        name = 'Theta'
+        name = '__MSL_Theta'
     elif integration_axis.units == '|Q|':
         ws_out = _cut_nonPSD_momentum(int_binning, cut_binning, emode, selected_workspace, algo)
     else:

--- a/mslice/models/cut/cut_algorithm.py
+++ b/mslice/models/cut/cut_algorithm.py
@@ -77,7 +77,7 @@ def _compute_cut_nonPSD(selected_workspace, cut_axis, integration_axis, emode, a
                                       integration_axis.end_meV)))
     idx = 0 if 'Rebin' in algo else 1
     unit = 'DeltaE'
-    name = 'EnergyTransfer'
+    name = '__MSL_EnergyTransfer'
     if is_momentum(cut_axis.units):
         ws_out = _cut_nonPSD_momentum(cut_binning, int_binning, emode, selected_workspace, algo)
         idx = 1

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .histo_mixin import HistoMixin
 from .workspace_mixin import WorkspaceMixin
-from .workspace import Workspace
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import IMDHistoWorkspace

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -6,7 +6,6 @@ from .workspace import Workspace
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import IMDHistoWorkspace
-from mantid.simpleapi import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
 
 
 class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
@@ -33,13 +32,14 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         return new_ws
 
     def convert_to_matrix(self):
+        from mslice.util.mantid.mantid_algorithms import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
         ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization',
                                                   FindXAxis=False, StoreInADS=False, OutputWorkspace=self.name)
         coord = self.get_coordinates()
         bin_size = coord[coord.keys()[0]][1] - coord[coord.keys()[0]][0]
         ws_conv = Scale(ws_conv, bin_size, OutputWorkspace=self.name, StoreInADS=False)
         ConvertToDistribution(ws_conv, StoreInADS=False)
-        return Workspace(ws_conv, self.name)
+        return ws_conv
 
     def save_attributes(self):
         attrdict = {}


### PR DESCRIPTION
Changed code in `convert_to_matrix` to use wrapped MSlice versions of Mantid algorithms which does the workspace name conversions rather than using the Mantid `simpleapi` algorithms directly.

**To test:**

<!-- Instructions for testing. -->
Run MSlice in MantidPlot or Workbench. Load data and make a cut. In the `MD Histo` tab click on `Save to MantidPlot` / `Save to Workbench`. The workspace should appear in the ADS.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #492
