### PR TITLE
Added menu option to save script to clipboard

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -63,6 +63,7 @@ class CutPlot(IPlot):
         plot_window.action_flip_axis.setVisible(False)
         plot_window.action_flip_axis.triggered.connect(self.flip_icut)
         plot_window.action_gen_script.triggered.connect(self.generate_script)
+        plot_window.action_gen_script_clipboard.triggered.connect(lambda: self.generate_script(clipboard=True))
         plot_window.action_waterfall.triggered.connect(self.toggle_waterfall)
         plot_window.waterfall_x_edt.editingFinished.connect(self.toggle_waterfall)
         plot_window.waterfall_y_edt.editingFinished.connect(self.toggle_waterfall)
@@ -347,9 +348,9 @@ class CutPlot(IPlot):
         if new_line and num_lines > 1:
             self.toggle_waterfall()
 
-    def generate_script(self):
+    def generate_script(self, clipboard=False):
         try:
-            generate_script(self.ws_name, None, self, self.plot_window)
+            generate_script(self.ws_name, None, self, self.plot_window, clipboard)
         except Exception as e:
             # We don't want any exceptions raised in the GUI as could crash the GUI
             self.plot_window.display_error(e.message)

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -81,8 +81,10 @@ class PlotWindow(QtWidgets.QMainWindow):
         self.setMenuBar(self.menubar)
 
     def add_file_actions(self, menu):
-        self.action_gen_script = add_action(menu, self, "Generate Script")
+        self.action_gen_script = add_action(menu, self, "Generate Script File")
         menu.addAction(self.action_gen_script)
+        self.action_gen_script_clipboard = add_action(menu, self, "Generate Script to Clipboard")
+        menu.addAction(self.action_gen_script_clipboard)
 
         self.action_quit = add_action(menu, self, "Close")
         menu.addAction(self.action_quit)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -109,6 +109,7 @@ class SlicePlot(IPlot):
             partial(self.toggle_overplot_line, 'Tantalum', False))
         plot_window.action_cif_file.triggered.connect(partial(self.cif_file_powder_line))
         plot_window.action_gen_script.triggered.connect(self.generate_script)
+        plot_window.action_gen_script_clipboard.triggered.connect(lambda: self.generate_script(clipboard=True))
 
     def disconnect(self, plot_window):
         plot_window.action_interactive_cuts.triggered.disconnect()
@@ -433,9 +434,9 @@ class SlicePlot(IPlot):
     def update_workspaces(self):
         self._slice_plotter_presenter.update_displayed_workspaces()
 
-    def generate_script(self):
+    def generate_script(self, clipboard=False):
         try:
-            generate_script(self.ws_name, None, self, self.plot_window)
+            generate_script(self.ws_name, None, self, self.plot_window, clipboard)
         except Exception as e:
             self.plot_window.display_error(e.message)
 

--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -5,22 +5,25 @@ from mslice.app.presenters import get_cut_plotter_presenter
 from six import string_types
 
 
-def generate_script(ws_name, filename=None, plot_handler=None, window=None):
-    if filename is None:
+def generate_script(ws_name, filename=None, plot_handler=None, window=None, clipboard=False):
+    if filename is None and not clipboard:
         path = QtWidgets.QFileDialog.getSaveFileName(window, 'Save File')
         if isinstance(path, tuple):
             path = path[0]
         if not path:
             return
         filename = path + '{}'.format('' if path.endswith('.py') else '.py')
-    else:
+    elif not clipboard:
         filename = filename + '{}'.format('' if filename.endswith('.py') else '.py')
 
     ax = window.canvas.figure.axes[0]
     script_lines = preprocess_lines(ws_name, plot_handler, ax)
     script_lines = add_plot_statements(script_lines, plot_handler, ax)
-    with open(filename, 'w') as generated_script:
-        generated_script.writelines(script_lines)
+    if clipboard:
+        QtWidgets.QApplication.clipboard().setText(''.join(script_lines))
+    else:
+        with open(filename, 'w') as generated_script:
+            generated_script.writelines(script_lines)
 
 
 def preprocess_lines(ws_name, plot_handler, ax):


### PR DESCRIPTION
Added a menu option to save the generated script to the system clipboard rather than a file

**To test:**

<!-- Instructions for testing. -->
Load a dataset and make a plot. Click on File->Generate Script to Clipboard. Paste the result in a text editor and check that the script looks ok.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #499
