### PR TITLE
Fixed save dialog unhandled exception

### DIFF
--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -47,6 +47,8 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
                 path += sel[-5:-1]
             ext = path[path.rfind('.'):]
             return os.path.dirname(path), os.path.basename(path), ext
+        else:
+            return None, None, None
 
 
 def save_nexus(workspace, path, is_slice):

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -165,6 +165,8 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def save_plot(self):
         file_path, save_name, ext = get_save_directory(save_as_image=True)
+        if file_path is None:
+            return
         if hasattr(self.plot_handler, 'ws_list'):
             workspaces = self.plot_handler.ws_list
         else:


### PR DESCRIPTION
Fixed unhandled exception when user cancels the save dialog.

**To test:**

<!-- Instructions for testing. -->
Plot a slice. Click the save icon and then cancel the dialog. Nothing should happen (previously lead to a crash).

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #503 
