### PR TITLE
Plotting ads saved cuts bugfix

### DIFF
--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -89,4 +89,5 @@ def add_to_ads(workspaces):
     except TypeError:
         workspaces = [workspaces]
     for workspace in workspaces:
-        AnalysisDataService.Instance().addOrReplace(workspace.name, workspace.raw_ws)
+        startid = (5 if workspace.name.startswith('__mat') else 2) if workspace.name.startswith('__') else 0
+        AnalysisDataService.Instance().addOrReplace(workspace.name[startid:], workspace.raw_ws)

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -33,10 +33,10 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
     def convert_to_matrix(self):
         from mslice.util.mantid.mantid_algorithms import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
         ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization',
-                                                  FindXAxis=False, StoreInADS=False, OutputWorkspace=self.name)
+                                                  FindXAxis=False, StoreInADS=False, OutputWorkspace='__mat'+self.name)
         coord = self.get_coordinates()
         bin_size = coord[coord.keys()[0]][1] - coord[coord.keys()[0]][0]
-        ws_conv = Scale(ws_conv, bin_size, OutputWorkspace=self.name, StoreInADS=False)
+        ws_conv = Scale(ws_conv, bin_size, OutputWorkspace='__mat'+self.name, StoreInADS=False)
         ConvertToDistribution(ws_conv, StoreInADS=False)
         return ws_conv
 

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -33,11 +33,11 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
     def convert_to_matrix(self):
         from mslice.util.mantid.mantid_algorithms import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
         ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization',
-                                                  FindXAxis=False, StoreInADS=False, OutputWorkspace='__mat'+self.name)
+                                                  FindXAxis=False, OutputWorkspace='__mat'+self.name)
         coord = self.get_coordinates()
         bin_size = coord[coord.keys()[0]][1] - coord[coord.keys()[0]][0]
-        ws_conv = Scale(ws_conv, bin_size, OutputWorkspace='__mat'+self.name, StoreInADS=False)
-        ConvertToDistribution(ws_conv, StoreInADS=False)
+        ws_conv = Scale(ws_conv, bin_size, OutputWorkspace='__mat'+self.name)
+        ConvertToDistribution(ws_conv)
         return ws_conv
 
     def save_attributes(self):


### PR DESCRIPTION
Fixes a name collision which resulted in a `MatrixWorkspace` rather than a `MDHistoWorkspace` being passed to `errorbar` which meant that the non-MSlice overloaded `errorbar` function was being called leading to it not recognising a keyword argument and raising an unhandled exception which crashes MantidPlot/workbench.

**To test:**

<!-- Instructions for testing. -->
Run MSlice in MantidPlot or workbench. Make a cut from the data and then in the `MD Histo` tab click on `Save to MantidPlot` / `Save to Workbench`. Then plot the same workspace - a plot should appear correctly.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #502 
