### PR TITLE
Workaround for CLI waterfall crash

### DIFF
--- a/mslice/cli/__init__.py
+++ b/mslice/cli/__init__.py
@@ -12,11 +12,13 @@ from mslice.cli.helperfunctions import (_check_workspace_name, _check_workspace_
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.plotting.globalfiguremanager import GlobalFigureManager
 from mslice.workspace.histogram_workspace import HistogramWorkspace
+from mslice.app import in_mantid as is_in_mantid
 
 # This is not compatible with mslice as we use a separate
 # global figure manager see _mslice_commands.Show
 del show  # noqa: F821
 
+in_mantid = is_in_mantid()
 
 # MSlice Matplotlib Projection
 class MSliceAxes(Axes):
@@ -86,6 +88,9 @@ class MSliceAxes(Axes):
             if y_offset is not None:
                 plot_handler.waterfall_y = y_offset
             plot_handler.toggle_waterfall()
+            global in_mantid
+            if in_mantid:
+                plot_handler.plot_window.action_waterfall.setVisible(False)
         else:
             raise RuntimeError('Waterfall plots may only be applied to cuts')
 


### PR DESCRIPTION
This is a quick work-around to avoid a hard crash of the Workbench when a script generated from a waterfall plot is run in the Workbench script window. 

As explained in the issue #504 - the crash appears to be in some Qt threading issue - it only occurs when the state of the Qt window is changed from within the script in the MSlice CLI - it occurs when the `Waterfall` button (which is a checkable button in a `QToolbar`) is enabled which also triggers two `QLabels` and two `QLineEdits` to be made visible. Even disabling making these visible also triggers the crash so it might be the "depressed" `Waterfall` state which is responsible. In any case `gdb` traces the segfault to a function in `QFontEngineFT`. 

The workaround is to make the `Waterfall` button invisible so these triggers have no effect, and thus avoids the crash. A longer term fix will be made for the next release.

**To test:**

<!-- Instructions for testing. -->
Run MSlice within the Workbench. Make multiple cuts on the same graph and enable a waterfall with some non-zero offset. Make a script of the window and load it in the workbench script window. Run the script - it should reproduce the plot with the waterfall offset but the `Waterfall` button will be invisible. 

Run the script outside the workbench - check that the `Waterfall` button still works as before.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
