### PR TITLE
Wrap set_waterfall to force a call in the qapp thread

### DIFF
--- a/mslice/cli/__init__.py
+++ b/mslice/cli/__init__.py
@@ -11,6 +11,7 @@ from mslice.cli.helperfunctions import (_check_workspace_name, _check_workspace_
                                         _update_overplot_checklist, _update_legend)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.plotting.globalfiguremanager import GlobalFigureManager
+from mslice.util.qt.qapp import call_in_qapp_thread
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 
 # This is not compatible with mslice as we use a separate
@@ -75,6 +76,7 @@ class MSliceAxes(Axes):
             elif axis == 'y':
                 plot_handler.manager._ygrid = b
 
+    @call_in_qapp_thread
     def set_waterfall(self, isWaterfall=True, x_offset=None, y_offset=None):
         """ Change the plot to/from a waterfall """
         from mslice.plotting.plot_window.cut_plot import CutPlot

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -4,7 +4,7 @@ import weakref
 import six
 from mslice.util.qt.QtCore import Qt
 from mslice.util.qt import QtCore, QtGui, QtWidgets
-from mslice.util.qt.qapp import create_qapp_if_required, QAppThreadCall
+from mslice.util.qt.qapp import create_qapp_if_required, call_in_qapp_thread
 from mslice.models.workspacemanager.file_io import get_save_directory
 from mslice.models.workspacemanager.workspace_algorithms import save_workspaces
 from mslice.plotting.plot_window.plot_window import PlotWindow
@@ -51,12 +51,11 @@ class PlotFigureManagerQT(QtCore.QObject):
 
         self.window.raise_()
 
+    @call_in_qapp_thread
     def show(self):
-        def _show():
-            self.window.show()
-            self.window.activateWindow()
-            self.window.raise_()
-        QAppThreadCall(_show)()
+        self.window.show()
+        self.window.activateWindow()
+        self.window.raise_()
 
     def window_closing(self):
         if self.plot_handler is not None:

--- a/mslice/util/qt/qapp.py
+++ b/mslice/util/qt/qapp.py
@@ -7,6 +7,7 @@
 #  This file is part of the mantid workbench.
 #
 from __future__ import (absolute_import, unicode_literals)
+from functools import wraps
 import sys
 
 from mslice.util.qt.QtCore import Qt, QMetaObject, QObject, QThread, Slot
@@ -74,6 +75,18 @@ class QAppThreadCall(QObject):
         self._result = None
         self._exc_info = None
 
+
+def call_in_qapp_thread(func):
+    """
+    Decorator to force a call onto the QApplication thread
+    :param func: The function to decorate
+    :return The wrapped function
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return QAppThreadCall(func)(*args, **kwargs)
+
+    return wrapper
 
 def create_qapp_if_required():
     """


### PR DESCRIPTION
Description of work.

Forces the set_waterfall call to always happen in the thread that the QApplication object lives in. Allows scripts ran in the interpreters in both MantidPlot and MantidWorkbench to execute these scripts.

**To test:**

Try the steps described in the issue and MantidPlot or Workbench should not crash.

Fixes #504 
