### PR TITLE
Add __del__ method to workspace wrappers to delete temp ws

### DIFF
--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -5,6 +5,7 @@ from .workspace_mixin import WorkspaceMixin
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import IMDHistoWorkspace
+from mantid.simpleapi import DeleteWorkspace
 
 
 class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
@@ -30,6 +31,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         new_ws.axes = self.axes
         return new_ws
 
+
     def convert_to_matrix(self):
         from mslice.util.mantid.mantid_algorithms import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
         ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization',
@@ -50,3 +52,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
 
     def remove_saved_attributes(self):
         attribute_from_log(None, self.raw_ws)
+
+    def __del__(self):
+        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN'):
+            DeleteWorkspace(self._raw_ws)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -6,6 +6,7 @@ from .workspace_mixin import WorkspaceMixin
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import IMDEventWorkspace
+from mantid.simpleapi import DeleteWorkspace
 
 
 
@@ -50,3 +51,9 @@ class PixelWorkspace(PixelMixin, WorkspaceMixin, WorkspaceBase):
 
     def remove_saved_attributes(self):
         attribute_from_log(None, self.raw_ws)
+
+    def __del__(self):
+        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN'):
+            DeleteWorkspace(self._raw_ws)
+        if hasattr(self, '_histo_ws') and self._histo_ws.name().endswith('_HIDDEN'):
+            DeleteWorkspace(self._histo_ws)

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -4,6 +4,7 @@ from .workspace_mixin import WorkspaceMixin
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import MatrixWorkspace
+from mantid.simpleapi import DeleteWorkspace
 
 
 class Workspace(WorkspaceMixin, WorkspaceBase):
@@ -44,3 +45,7 @@ class Workspace(WorkspaceMixin, WorkspaceBase):
 
     def remove_saved_attributes(self):
         attribute_from_log(None, self.raw_ws)
+
+    def __del__(self):
+        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN'):
+            DeleteWorkspace(self._raw_ws)


### PR DESCRIPTION
Description of work.

Changes the `__del__` methods for the workspace wrapper classes to call `DeleteWorkspace` on associated mantid workspaces in the ADS if the workspaces are supposed to be temporary (`store=False` so the name has `_HIDDEN` appended).

**To test:**

<!-- Instructions for testing. -->

Run MSlice inside the Workbench or MantidPlot and set the option to show hidden workspaces in the ADS. Make a slice and the activate `Interactive Cut` - move the selection box around - you should not see any `_HIDDEN` workspace appear in the ADS.

Click on `Save Workspace` in the cut window showing the interactive cut then close both the cut and slice windows. In the main MSlice window go to the `MD Histo` tab and checked that the workspace you saved is there. Plot it - it should show the same cut as you had last.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #512 
