### PR TITLE
Fix calls to mantid.plots apis after changes

### DIFF
--- a/buildscripts/buildscript.sh
+++ b/buildscripts/buildscript.sh
@@ -13,13 +13,9 @@ venv_dir=$PWD/venv-${py_ver}
 
 # determine python executable
 case "$py_ver" in
-    py2)
-        py_exe=/usr/bin/python
-        pkg_name=mantidnightly
-    ;;
     py3)
         py_exe=/usr/bin/python3
-        pkg_name=mantidnightly-python3
+        pkg_name=mantidnightly
     ;;
     *)
         echo "Unknown python version requested '$py_ver'"

--- a/mslice/cli/plotfunctions.py
+++ b/mslice/cli/plotfunctions.py
@@ -11,7 +11,7 @@ from mslice.util.compat import legend_set_draggable
 from mslice.util.mantid.mantid_algorithms import Transpose
 from mslice.models.labels import get_display_name, CUT_INTENSITY_LABEL
 from mslice.models.cut.cut import Cut
-from mantid.plots import plotfunctions
+import mantid.plots.axesfunctions as axesfunctions
 from mslice.views.slice_plotter import create_slice_figure
 from mslice.views.slice_plotter import PICKER_TOL_PTS as SLICE_PICKER_TOL_PTS
 from mslice.views.cut_plotter import PICKER_TOL_PTS as CUT_PICKER_TOL_PTS
@@ -56,7 +56,7 @@ def errorbar(axes, workspace, *args, **kwargs):
                     raise RuntimeError('Wrong energy unit for cut. '
                                        'Expected {}, got {}'.format(cached_cuts[0].cut_axis.e_unit, cut_axis.e_unit))
 
-    plotfunctions.errorbar(axes, workspace.raw_ws, label=label, *args, **kwargs)
+    axesfunctions.errorbar(axes, workspace.raw_ws, label=label, *args, **kwargs)
 
     axes.set_ylim(*intensity_range) if intensity_range is not None else axes.autoscale()
     intensity_min, intensity_max = axes.get_ylim()
@@ -128,7 +128,7 @@ def pcolormesh(axes, workspace, *args, **kwargs):
 
     if not workspace.is_PSD and not slice_cache.rotated:
         workspace = Transpose(OutputWorkspace=workspace.name, InputWorkspace=workspace, store=False)
-    plotfunctions.pcolormesh(axes, workspace.raw_ws, *args, **kwargs)
+    axesfunctions.pcolormesh(axes, workspace.raw_ws, *args, **kwargs)
     axes.set_title(workspace.name[2:], picker=SLICE_PICKER_TOL_PTS)
     x_axis = slice_cache.energy_axis if slice_cache.rotated else slice_cache.momentum_axis
     y_axis = slice_cache.momentum_axis if slice_cache.rotated else slice_cache.energy_axis

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -219,7 +219,7 @@ class CommandLineTest(unittest.TestCase):
         PlotCut(cut)
         cpp.plot_cut_from_workspace.assert_called_once_with(cut, intensity_range=None, plot_over=False)
 
-    @mock.patch('mantid.plots.plotfunctions.errorbar')
+    @mock.patch('mantid.plots.axesfunctions.errorbar')
     @mock.patch('mslice.cli._mslice_commands.is_gui')
     def test_errorbar_command(self, is_gui, mantid_errorbar):
         is_gui.return_value = True


### PR DESCRIPTION
Description of work

plotfunctions module was renamed to axesfunctions.

**To test:**

Any quick testing of slicing and cutting should now not produce an error.

To test the changes in a development version of Workbench:

* clone this repo and checkout this pull request branch
* assuming the mslice repo root is `<msliceroot>` then from the `mantid` build directory:
```
PYTHONPATH=<msliceroot> bin/workbench
```

Fixes #519 
