### PR TITLE
Fixed obsolete grabWidget() function error in Qt5

### DIFF
--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -155,7 +155,10 @@ class PlotFigureManagerQT(QtCore.QObject):
         printer.setOrientation(QtWidgets.QPrinter.Landscape)
         print_dialog = QtWidgets.QPrintDialog(printer)
         if print_dialog.exec_():
-            pixmap_image = QtGui.QPixmap.grabWidget(self.canvas)
+            try:
+                pixmap_image = QtWidgets.QWidget.grab(self.canvas)
+            except AttributeError:   # Qt4 needs to use old grabWidget() method
+                pixmap_image = QtGui.QPixmap.grabWidget(self.canvas)
             page_size = printer.pageRect()
             pixmap_image = pixmap_image.scaled(page_size.width(), page_size.height(), Qt.KeepAspectRatio)
             painter = QtGui.QPainter(printer)


### PR DESCRIPTION
The `QPixmap.grabWidget` function in Qt4 was removed in Qt5 and it is recommended to use `QWidget.grab` instead. This change first tries the Qt5 version (for running in Workbench) and if that fails falls back on the Qt4 version (for running in MantidPlot).

**To test:**

<!-- Instructions for testing. -->

Open MSlice in Workbench. Make a slice. Click on the **print** icon and click to print to a pdf. Click ok and check that the file dialog to select a pdf file name appears (instead of an error).

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #521
