### PR TITLE
Fixed user defined algorithm import bug

### DIFF
--- a/mslice/util/mantid/mantid_algorithms.py
+++ b/mslice/util/mantid/mantid_algorithms.py
@@ -1,10 +1,21 @@
 """Wraps all Mantid algorithms so they use mslice's wrapped workspaces"""
 
 from mantid.simpleapi import * # noqa: F401
+from mantid.simpleapi import _create_algorithm_function
 from mslice.util.mantid.algorithm_wrapper import wrap_algorithm
-from mantid.api import AlgorithmFactory
+from mantid.api import AlgorithmFactory, AlgorithmManager
+from six import iteritems
 
 algorithms = AlgorithmFactory.getRegisteredAlgorithms(False)
 
-for algorithm in algorithms.keys():
-    globals()[algorithm] = wrap_algorithm(globals()[algorithm])
+for algorithm, versions in iteritems(algorithms):
+    try:
+        globals()[algorithm] = wrap_algorithm(globals()[algorithm])
+    except KeyError:   # Possibly a user defined algorithm
+        try:
+            alg_obj = AlgorithmManager.createUnmanaged(algorithm, max(versions))
+            alg_obj.initialize()
+        except Exception:
+            pass
+        else:
+            globals()[algorithm] = wrap_algorithm(_create_algorithm_function(algorithm, max(versions), alg_obj))


### PR DESCRIPTION
Adds a `try` block to check if the algorithm which MSlice is trying to wrap is a user defined algorithm (is not in the `simpleapi` namespace), and if so imports it directly.

**To test:**

<!-- Instructions for testing. -->

*Before* starting MSlice, run the following script from the issue:

```py
from mantid.kernel import *
from mantid.api import *

class PrintNumber(PythonAlgorithm):
	def PyInit(self):
		self.declareProperty('Nsteps',1000)
		
	def PyExec(self):
		Nsteps = self.getProperty("Nsteps").value
		print(Nsteps)

AlgorithmFactory.subscribe(PrintNumber)
```

Now start MSlice and check it starts. In the MSlice cli you should be able to type `PrintNumber(5)` or similar and get that output.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #516
