### PR TITLE
Fix indexing error into dict.keys generator

### DIFF
--- a/mslice/tests/histogram_workspace_test.py
+++ b/mslice/tests/histogram_workspace_test.py
@@ -4,6 +4,7 @@ import numpy as np
 from mantid.simpleapi import CreateMDHistoWorkspace
 
 from mslice.tests.workspace_test import BaseWorkspaceTest
+from mslice.models.workspacemanager.workspace_provider import add_workspace, remove_workspace
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 
 
@@ -21,6 +22,18 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
 
     def test_invalid_workspace(self):
         self.assertRaises(TypeError, lambda: HistogramWorkspace(4, 'name'))
+
+    def test_convert_to_matrix(self):
+        # workspace needs to be registered with mslice for conversion
+        try:
+            add_workspace(self.workspace, self.workspace.name)
+            matrix_ws = self.workspace.convert_to_matrix()
+
+            self.assertEqual(10, matrix_ws.raw_ws.getNumberHistograms())
+            self.assertEqual(10, matrix_ws.raw_ws.getNumberBins())
+        finally:
+            # remove mslice tracking
+            remove_workspace(self.workspace)
 
     def test_get_coordinates(self):
         expected = np.linspace(0, 100, 10)

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -31,13 +31,13 @@ class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
         new_ws.axes = self.axes
         return new_ws
 
-
     def convert_to_matrix(self):
         from mslice.util.mantid.mantid_algorithms import ConvertMDHistoToMatrixWorkspace, Scale, ConvertToDistribution
         ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization',
                                                   FindXAxis=False, OutputWorkspace='__mat'+self.name)
         coord = self.get_coordinates()
-        bin_size = coord[coord.keys()[0]][1] - coord[coord.keys()[0]][0]
+        first_dim = coord[self.raw_ws.getDimension(0).getName()]
+        bin_size = first_dim[1] - first_dim[0]
         ws_conv = Scale(ws_conv, bin_size, OutputWorkspace='__mat'+self.name)
         ConvertToDistribution(ws_conv)
         return ws_conv


### PR DESCRIPTION
**Description of work**

In Python 3 dict.keys() returns a generator and cannot
be accessed like a list using an index. Instead
use the name of the first dimension and look up
the coordinates like this.

Added a unit test for this method that was missing.

**To test:**

See instructions in mantidproject/mantid#28173

Fixes #525
