### PR TITLE
Properly wrap workspace arithmetic ops

### DIFF
--- a/mslice/util/mantid/_workspace_ops.py
+++ b/mslice/util/mantid/_workspace_ops.py
@@ -1,0 +1,87 @@
+import operator
+import numpy as np
+from uuid import uuid4
+from mantid.api._workspaceops import _do_binary_operation
+from mantid.kernel.funcinspect import lhs_info
+from mslice.workspace.workspace import WorkspaceOperatorMixin
+
+_binary_operator_map = {
+    "Plus": operator.add,
+    "Minus": operator.sub,
+    "Multiply": operator.mul,
+    "Divide": operator.truediv,
+    "LessThan": operator.lt,
+    "GreaterThan": operator.gt,
+    "Or": operator.or_,
+    "And": operator.and_,
+    "Xor": operator.xor
+}
+
+def _binary_op(self, other, algorithm, result_info, inplace, reverse):
+    """
+    Delegate binary operations (+,-,*,/) performed on a workspace depending on type.
+
+    Unwrap mantid workspace (_raw_ws), perform operation, then rewrap.
+
+    Behaviour depends on type of other:
+    List - convert to numpy array, then pass to _binary_op_array method.
+    Numpy array - pass to _binary_op_array method.
+    Workspace wrapper (of the same type and dimensionality) - unwrap, apply operator to each bin, rewrap.
+    Else - try to apply operator to self._raw_ws. Works for numbers, unwrapped workspaces...
+
+    :param other: the rhs (MSlice-wrapped) workspace
+    :param algorithm: A string containing the Mantid binary operator algorithm name (e.g. "Plus")
+    :param result_info: A tuple containing details of the lhs of the assignment, i.e a = b + c, result_info = (1, 'a')
+    :param inplace: True if the operation should be performed inplace
+    :param reverse: True if the reverse operator was called, i.e. 3 + a calls __radd__
+    :return: new workspace wrapper with same type as self.
+    """
+    if isinstance(other, list):
+        other = np.asarray(other)
+    if isinstance(other, self.__class__):
+        if _check_dimensions(self, other):
+            inner_res = _do_binary_operation(algorithm, self._raw_ws, other._raw_ws, result_info, inplace, reverse)
+        else:
+            raise RuntimeError("workspaces must have same dimensionality for binary operations (+, -, *, /)")
+    elif isinstance(other, np.ndarray):
+        inner_res = self._binary_op_array(_binary_operator_map[algorithm], other)
+    else:
+        inner_res = _do_binary_operation(algorithm, self._raw_ws, other, result_info, inplace, reverse)
+    return self.rewrap(inner_res)
+
+def _check_dimensions(self, workspace_to_check):
+    """check if a workspace has the same number of bins as self for each dimension"""
+    for i in range(self._raw_ws.getNumDims()):
+        if self._raw_ws.getDimension(i).getNBins() != workspace_to_check._raw_ws.getDimension(i).getNBins():
+            return False
+    return True
+
+def _attach_binary_operators():
+    def add_operator_func(attr, algorithm, inplace, reverse):
+        def op_wrapper(self, other):
+            result_info = lhs_info()
+            # Replace output workspace name with a unique temporary name hidden in ADS
+            if result_info[0] > 0:
+                result_info = (result_info[0], ('__MSLTMP' + str(uuid4())[:8],) + result_info[1][1:])
+            return _binary_op(self, other, algorithm, result_info, inplace, reverse)
+
+        op_wrapper.__name__ = attr
+        setattr(WorkspaceOperatorMixin, attr, op_wrapper)
+
+    operations = {
+        "Plus": ("__add__", "__radd__", "__iadd__"),
+        "Minus": ("__sub__", "__rsub__", "__isub__"),
+        "Multiply": ("__mul__", "__rmul__", "__imul__"),
+        "Divide": ("__truediv__", "__rtruediv__", "__itruediv__"),
+        "LessThan": "__lt__",
+        "GreaterThan": "__gt__",
+        "Or": "__or__",
+        "And": "__and__",
+        "Xor": "__xor__"
+    }
+
+    for alg, attributes in operations.items():
+        if type(attributes) == str:
+            attributes = [attributes]
+        for attr in attributes:
+            add_operator_func(attr, alg, attr.startswith('__i'), attr.startswith('__r'))

--- a/mslice/util/mantid/init_mantid.py
+++ b/mslice/util/mantid/init_mantid.py
@@ -9,6 +9,7 @@ from mslice.models.cut.cut_algorithm import Cut
 from mslice.models.projection.powder.make_projection import MakeProjection
 from mslice.models.slice.slice_algorithm import Slice
 from mslice.models.workspacemanager.rebose_algorithm import Rebose
+from ._workspace_ops import _attach_binary_operators
 
 AlgorithmFactory.subscribe(MakeProjection)
 AlgorithmFactory.subscribe(Slice)
@@ -18,3 +19,5 @@ s_api._create_algorithm_function('MakeProjection', 1, MakeProjection())
 s_api._create_algorithm_function('Slice', 1, Slice())
 s_api._create_algorithm_function('Cut', 1, Cut())
 s_api._create_algorithm_function('Rebose', 1, Rebose())
+
+_attach_binary_operators()

--- a/mslice/workspace/base.py
+++ b/mslice/workspace/base.py
@@ -26,26 +26,6 @@ class WorkspaceBase(object):
         return
 
     @abc.abstractmethod
-    def __add__(self, other):
-        return
-
-    @abc.abstractmethod
-    def __sub__(self, other):
-        return
-
-    @abc.abstractmethod
-    def __mul__(self, other):
-        return
-
-    @abc.abstractmethod
-    def __truediv__(self, other):
-        return
-
-    @abc.abstractmethod
-    def __pow__(self, other):
-        return
-
-    @abc.abstractmethod
     def __neg__(self):
         return
 

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -1,14 +1,14 @@
 from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .histo_mixin import HistoMixin
-from .workspace_mixin import WorkspaceMixin
+from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import IMDHistoWorkspace
 from mantid.simpleapi import DeleteWorkspace
 
 
-class HistogramWorkspace(HistoMixin, WorkspaceMixin, WorkspaceBase):
+class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
     """workspace wrapper for MDHistoWorkspace"""
 
     def __init__(self, mantid_ws, name):

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .histogram_workspace import HistogramWorkspace
 from .pixel_mixin import PixelMixin
-from .workspace_mixin import WorkspaceMixin
+from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import IMDEventWorkspace
@@ -10,7 +10,7 @@ from mantid.simpleapi import DeleteWorkspace
 
 
 
-class PixelWorkspace(PixelMixin, WorkspaceMixin, WorkspaceBase):
+class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
     """workspace wrapper for MDEventWorkspace. Converts to HistogramWorkspace internally."""
 
     def __init__(self, mantid_ws, name):

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -1,13 +1,13 @@
 from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
-from .workspace_mixin import WorkspaceMixin
+from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
 from .helperfunctions import attribute_from_log, attribute_to_log
 
 from mantid.api import MatrixWorkspace
 from mantid.simpleapi import DeleteWorkspace
 
 
-class Workspace(WorkspaceMixin, WorkspaceBase):
+class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
     """workspace wrapper for MatrixWorkspace"""
 
     def __init__(self, mantid_ws, name):

--- a/mslice/workspace/workspace_mixin.py
+++ b/mslice/workspace/workspace_mixin.py
@@ -1,9 +1,17 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
-import operator
+
 from mantid.simpleapi import CloneWorkspace, PowerMD
 from mslice.util.numpy_helper import apply_with_corrected_shape
 
+# Other operators are defined when MSlice is imported in _workspace_ops.attach_binary_operators()
+class WorkspaceOperatorMixin(object):
+    def __neg__(self):
+        return self * -1
+
+    def __pow__(self, exponent):
+        return self.rewrap(PowerMD(InputWorkspace=self._raw_ws, OutputWorkspace="_",
+                                   Exponent=exponent, StoreInADS=False))
 
 class WorkspaceMixin(object):
 
@@ -38,35 +46,6 @@ class WorkspaceMixin(object):
         for i in range(raw_ws.getNumberHistograms()):
             raw_ws.setY(i, signal[i])
 
-    def _binary_op(self, operator, other):
-        """
-        Delegate binary operations (+,-,*,/) performed on a workspace depending on type.
-
-        Unwrap mantid workspace (_raw_ws), perform operation, then rewrap.
-
-        Behaviour depends on type of other:
-        List - convert to numpy array, then pass to _binary_op_array method.
-        Numpy array - pass to _binary_op_array method.
-        Workspace wrapper (of the same type and dimensionality) - unwrap, apply operator to each bin, rewrap.
-        Else - try to apply operator to self._raw_ws. Works for numbers, unwrapped workspaces...
-
-        :param operator: binary operator (add, sub, mul, div)
-        :param other: object to add/sub/mul/div with self - can be list, numpy array, workspace, number...
-        :return: new workspace wrapper with same type as self.
-        """
-        if isinstance(other, list):
-            other = np.asarray(other)
-        if isinstance(other, self.__class__):
-            if self.check_dimensions(other):
-                inner_res = operator(self._raw_ws, other._raw_ws)
-            else:
-                raise RuntimeError("workspaces must have same dimensionality for binary operations (+, -, *, /)")
-        elif isinstance(other, np.ndarray):
-            inner_res = self._binary_op_array(operator, other)
-        else:
-            inner_res = operator(self._raw_ws, other)
-        return self.rewrap(inner_res)
-
     def _binary_op_array(self, operator, other):
         """Perform binary operation using a numpy array with the same number of elements as an axis of _raw_ws signal"""
         signal = self.get_signal()
@@ -76,13 +55,6 @@ class WorkspaceMixin(object):
         self._set_signal_raw(new_ws, new_signal)
         # scale errors?
         return new_ws
-
-    def check_dimensions(self, workspace_to_check):
-        """check if a workspace has the same number of bins as self for each dimension"""
-        for i in range(self._raw_ws.getNumDims()):
-            if self._raw_ws.getDimension(i).getNBins() != workspace_to_check._raw_ws.getDimension(i).getNBins():
-                return False
-        return True
 
     def get_saved_cut_parameters(self, axis=None):
         try:
@@ -102,27 +74,3 @@ class WorkspaceMixin(object):
     @property
     def raw_ws(self):
         return self._raw_ws
-
-    def __add__(self, other):
-        return self._binary_op(operator.add, other)
-
-    def __sub__(self, other):
-        return self._binary_op(operator.sub, other)
-
-    def __mul__(self, other):
-        return self._binary_op(operator.mul, other)
-
-    def __rmul__(self, other):
-        return self._binary_op(operator.mul, other)
-
-    def __div__(self, other):
-        return self._binary_op(operator.div, other)
-
-    def __truediv__(self, other):
-        return self._binary_op(operator.truediv, other)
-
-    def __neg__(self):
-        return self * -1
-
-    def __pow__(self, exponent):
-        return self.rewrap(PowerMD(InputWorkspace=self._raw_ws, OutputWorkspace="_", Exponent=exponent, StoreInADS=False))


### PR DESCRIPTION
Moved operator methods in WorkspaceMixin to new WorkspaceOperatorMixin
Wrap operators to Mantid internal API _do_binary_operation() function
Attach this operators to WorkspaceOperatorMixin when MSlice is imported

Description of work.

Split the `WorkspaceMixin` class into `WorkspaceMixin` and `WorkspaceOperatorMixin` where the overloaded arithmetic operators are now in `WorkspaceOperatorMixin`. Binary operators are not defined in this new mixin class directly but are instead wrapped at initialisation (when MSlice is imported) to use the Mantid internal API `_do_binary_operation` function. The unary operators `__neg__` and `__pow__` remain defined.

The wrapping of `_do_binary_operation` allows us to specify an output workspace name, since by the default using the (Mantid workspace) overloaded operators triggers a call to `funcinspect.lhs_info` to determine what the output workspace name is. This then means that the resulting workspaces are in the ADS with the name `inner_res`, and caused bug #510. Now, we automatically generate a hidden MSlice workspace name for the Mantid-facing calls (still stored in the ADS but hidden since the name begins with `__`).

**To test:**

<!-- Instructions for testing. -->

Run the script in the issue:

```py
import mslice.cli as mc
ws = mc.Load(Filename=r'C:\Users\vqq25957\src\mslice\MAR21335_Ei60.00meV.nxs', 
             OutputWorkspace='MAR21335_Ei60.00meV')

ws2 = ws + ws
ws3 = ws2 / 2

print(ws2.raw_ws)
print(ws3.raw_ws)

mc.CompareWorkspaces(ws2, ws3)
```

CompareWorkspaces should now say that `ws2` and `ws3` are different. 
Check that all tests still pass and that operations which implicitly rely on the overloaded arithmetic operators (such as the intensity conversions to `chi` etc in slices) still work.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #510 
