### PR TITLE
Force figuremanager calls to be on same thread as QApplication object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ ENV/
 # Vim files
 *.swp
 *.swo
+
+# vscode files
+.vscode/

--- a/mslice/plotting/globalfiguremanager.py
+++ b/mslice/plotting/globalfiguremanager.py
@@ -30,9 +30,6 @@ from __future__ import (absolute_import, division, print_function)
 # system imports
 from functools import wraps
 
-# local imports
-from mslice.util.qt.qapp import QAppThreadCall
-
 # Labels for each category
 CATEGORY_CUT, CATEGORY_SLICE = "1d", "2d"
 
@@ -49,7 +46,10 @@ class GlobalFigureManager(object):
     """
     # if there is a current figure it should be both current and active
     _active_category = None
-    _category_current_figures = {CATEGORY_CUT: None, CATEGORY_SLICE: None}  # Current_figures receive decorated commands
+    _category_current_figures = {
+        CATEGORY_CUT: None,
+        CATEGORY_SLICE: None
+    }  # Current_figures receive decorated commands
     _figures_by_category = {CATEGORY_CUT: [], CATEGORY_SLICE: []}
     _unclassified_figures = []
     _active_figure = None
@@ -105,7 +105,10 @@ class GlobalFigureManager(object):
         for manager in list(cls._figures.values()):
             manager.destroy()
         cls._active_figure = None
-        cls._category_current_figures = {CATEGORY_CUT: None, CATEGORY_SLICE: None}
+        cls._category_current_figures = {
+            CATEGORY_CUT: None,
+            CATEGORY_SLICE: None
+        }
         cls._figures.clear()
 
     @classmethod
@@ -126,7 +129,10 @@ class GlobalFigureManager(object):
     def reset(cls):
         """Reset all class variables to initial state. This function exists for testing purposes """
         cls._active_category = None
-        cls._category_current_figures = {CATEGORY_CUT: None, CATEGORY_SLICE: None}  # Current _figures are overplotted
+        cls._category_current_figures = {
+            CATEGORY_CUT: None,
+            CATEGORY_SLICE: None
+        }  # Current _figures are overplotted
         cls._figures_by_category = {CATEGORY_CUT: [], CATEGORY_SLICE: []}
         cls._unclassified_figures = []
         cls._active_figure = None
@@ -136,12 +142,15 @@ class GlobalFigureManager(object):
     def _new_figure(cls, num=None):
         # local import to avoid circular dependency in figure_manager_test.py
         # mock.patch can't patch a class where the module has already been imported
-        from mslice.plotting.plot_window.plot_figure_manager import PlotFigureManagerQT
+        from mslice.plotting.plot_window.plot_figure_manager import new_plot_figure_manager
         if num is None:
             num = 1
-            while any([num == existing_fig_num for existing_fig_num in cls._figures.keys()]):
+            while any([
+                    num == existing_fig_num
+                    for existing_fig_num in cls._figures.keys()
+            ]):
                 num += 1
-        new_fig = QAppThreadCall(PlotFigureManagerQT)(num, GlobalFigureManager)
+        new_fig = new_plot_figure_manager(num, GlobalFigureManager)
         cls._figures[num] = new_fig
         cls._active_figure = num
         cls._unclassified_figures.append(num)
@@ -169,14 +178,18 @@ class GlobalFigureManager(object):
     def get_active_figure(cls):
         if cls._active_category:
             if cls._active_figure in cls._unclassified_figures:
-                cls.assign_figure_to_category(cls._active_figure, cls._active_category,
+                cls.assign_figure_to_category(cls._active_figure,
+                                              cls._active_category,
                                               make_current=True)
             elif cls._category_current_figures[cls._active_category] is None:
                 _, num = cls._new_figure()
-                cls.assign_figure_to_category(num, cls._active_category, make_current=True)
+                cls.assign_figure_to_category(num,
+                                              cls._active_category,
+                                              make_current=True)
                 cls._active_figure = num
             else:
-                cls._active_figure = cls._category_current_figures[cls._active_category]
+                cls._active_figure = cls._category_current_figures[
+                    cls._active_category]
         else:
             if cls._active_figure is None:
                 fig, num = cls._new_figure()
@@ -235,7 +248,9 @@ class GlobalFigureManager(object):
         try:
             del cls._figures[num]
         except KeyError:
-            raise KeyError('The key "%s" does not exist. The figure cannot be closed' % num)
+            raise KeyError(
+                'The key "%s" does not exist. The figure cannot be closed' %
+                num)
 
     @classmethod
     def get_category(cls, num):
@@ -245,7 +260,8 @@ class GlobalFigureManager(object):
                 figure_category = category
                 break
         else:
-            raise KeyError("Figure no. %i was not found in any category " % num if num else 0)
+            raise KeyError("Figure no. %i was not found in any category " %
+                           num if num else 0)
             # in-line if handles the case num is None
         return figure_category
 
@@ -372,6 +388,7 @@ def set_category(category):
             finally:
                 GlobalFigureManager.deactivate_category()
             return return_value
+
         return wrapper
 
     return activate_impl

--- a/mslice/plotting/pyplot.py
+++ b/mslice/plotting/pyplot.py
@@ -36,7 +36,7 @@ from matplotlib.artist import setp as _setp
 from matplotlib.axes import Axes, Subplot
 from matplotlib.projections import PolarAxes
 from matplotlib import mlab  # for csv2rec, detrend_none, window_hanning
-from matplotlib.scale import get_scale_docs, get_scale_names
+from matplotlib.scale import get_scale_names
 
 from matplotlib import cm
 from matplotlib.cm import get_cmap, register_cmap

--- a/mslice/tests/figure_manager_test.py
+++ b/mslice/tests/figure_manager_test.py
@@ -1,32 +1,44 @@
 from __future__ import (absolute_import, division, print_function)
-import mock
-from mock import call
 import unittest
+from unittest import mock
+from unittest.mock import call
 
 from mslice.plotting.globalfiguremanager import GlobalFigureManager, set_category
 
+# Class/function locations for mock
+PLOTFIGUREMANAGER_CLS = 'mslice.plotting.plot_window.plot_figure_manager.PlotFigureManagerQT'
+FORCE_METHOD_CALLS_TO_QAPP_THREAD = 'mslice.plotting.plot_window.plot_figure_manager.force_method_calls_to_qapp_thread'
 
+
+@mock.patch(PLOTFIGUREMANAGER_CLS, autospec=True)
 class CurrentFigureTest(unittest.TestCase):
     # In the case of more plot figures being created than expected then a StopIteration Exception will be raised
     # by the mock module. The number of expected plots is defined by the list at the beginning of each unit test
 
-    # Define the location of the plot figure manager class for mock
-    _plot_window_class = 'mslice.plotting.plot_window.plot_figure_manager.PlotFigureManagerQT'
-
     def setUp(self):
         GlobalFigureManager.reset()
+        # The getattr_static call in the real implementation does not play well
+        # with mocks
+        self.mock_force_qapp = mock.patch(
+            FORCE_METHOD_CALLS_TO_QAPP_THREAD).start()
+        # make it a noop
+        self.mock_force_qapp.side_effect = lambda arg: arg
 
-    @mock.patch(_plot_window_class)
+    def tearDown(self):
+        self.mock_force_qapp.stop()
+
     def test_create_single_unclassified_plot_success(self, mock_figure_class):
         mock_figures = [mock.Mock()]
         mock_figure_class.side_effect = mock_figures
 
         GlobalFigureManager.get_figure_number()
-        self.assertTrue(1 in GlobalFigureManager.all_figure_numbers()) #Check that a new figure with number=1 was created
-        self.assertRaises(KeyError, GlobalFigureManager.get_category, 1) #Check that figure has no category
-        self.assertTrue(GlobalFigureManager.get_active_figure() == mock_figures[0]) # Check that it is set as the active figure
+        self.assertTrue(1 in GlobalFigureManager.all_figure_numbers()
+                        )  #Check that a new figure with number=1 was created
+        self.assertRaises(KeyError, GlobalFigureManager.get_category,
+                          1)  #Check that figure has no category
+        self.assertTrue(
+            GlobalFigureManager.get_active_figure() == mock_figures[0])
 
-    @mock.patch(_plot_window_class)
     def test_create_multiple_unclassified_figures(self, mock_figure_class):
         """Test that n calls to GlobalFigureManager create n unclassified _figures numbered 1 to n """
         n = 10  # number of unclassfied _figures to be created
@@ -34,48 +46,56 @@ class CurrentFigureTest(unittest.TestCase):
         mock_figure_class.side_effect = mock_figures
 
         for i in range(n):
-            GlobalFigureManager.get_figure_number() # Create a new figure
-        for i in range(1, n+1):
-            self.assertTrue(i in GlobalFigureManager.all_figure_numbers()) #Check that a new figure with number=i was created
-            self.assertRaises(KeyError, GlobalFigureManager.get_category, i) #Check that figure has no category
+            GlobalFigureManager.get_figure_number()  # Create a new figure
+        for i in range(1, n + 1):
+            self.assertTrue(i in GlobalFigureManager.all_figure_numbers(
+            ))  #Check that a new figure with number=i was created
+            self.assertRaises(KeyError, GlobalFigureManager.get_category,
+                              i)  #Check that figure has no category
 
-    @mock.patch(_plot_window_class)
-    def test_create_single_categorised_figure(self,mock_figure_class):
+    def test_create_single_categorised_figure(self, mock_figure_class):
         mock_figures = [mock.Mock()]
         mock_figure_class.side_effect = mock_figures
         category = '1d'
         # The following line is equivalent to applying the decorator setcategory with the parameter category
         # to function GlobalFigureManager.get_active_figure
-        categorised_get_active_figure = set_category(category)(GlobalFigureManager.get_active_figure)
+        categorised_get_active_figure = set_category(category)(
+            GlobalFigureManager.get_active_figure)
         fig = categorised_get_active_figure()
-        self.assertTrue(fig == mock_figures[0]) # Assert Figure object came from right place
+        # Assert Figure object came from right place
+        self.assertTrue(fig == mock_figures[0])
         self.assertTrue(GlobalFigureManager.get_category(1) == category)
-        self.assertTrue(GlobalFigureManager.get_active_figure() == mock_figures[0]) # Check that it is set as the active figure
+        # Check that it is set as the active figure
+        self.assertTrue(GlobalFigureManager.get_active_figure() == mock_figures[0])
 
-    @mock.patch(_plot_window_class)
-    def test_create_categorised_figure_then_uncategorised_figure(self,mock_figure_class):
+    def test_create_categorised_figure_then_uncategorised_figure(
+            self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock()]
         mock_figure_class.side_effect = mock_figures
         category = '1d'
-        categorised_get_active_figure = set_category(category)(GlobalFigureManager.get_active_figure)
+        categorised_get_active_figure = set_category(category)(
+            GlobalFigureManager.get_active_figure)
 
         fig1 = categorised_get_active_figure()
         fig2 = GlobalFigureManager.get_figure_number()
         fig1_number = GlobalFigureManager.number_of_figure(fig1)
         fig2_number = GlobalFigureManager.number_of_figure(fig2)
         self.assertTrue(GlobalFigureManager.get_active_figure() == fig2)
-        self.assertTrue(GlobalFigureManager.get_category(fig1_number) == category)
-        self.assertRaises(KeyError, GlobalFigureManager.get_category, fig2_number)
-        self.assertTrue( fig1_number == 1 and fig2_number == 2)
+        self.assertTrue(
+            GlobalFigureManager.get_category(fig1_number) == category)
+        self.assertRaises(KeyError, GlobalFigureManager.get_category,
+                          fig2_number)
+        self.assertTrue(fig1_number == 1 and fig2_number == 2)
 
-    @mock.patch(_plot_window_class)
-    def test_category_switching(self,mock_figure_class):
-        mock_figures = [mock.Mock(),mock.Mock()]
+    def test_category_switching(self, mock_figure_class):
+        mock_figures = [mock.Mock(), mock.Mock()]
         mock_figure_class.side_effect = mock_figures
         cat1 = '1d'
         cat2 = '2d'
-        cat1_get_active_figure = set_category(cat1)(GlobalFigureManager.get_active_figure)
-        cat2_get_active_figure = set_category(cat2)(GlobalFigureManager.get_active_figure)
+        cat1_get_active_figure = set_category(cat1)(
+            GlobalFigureManager.get_active_figure)
+        cat2_get_active_figure = set_category(cat2)(
+            GlobalFigureManager.get_active_figure)
         # test is an arbitrary method just to make sure the correct figures are returned
         cat1_get_active_figure().test(1)
         cat2_get_active_figure().test(2)
@@ -85,8 +105,7 @@ class CurrentFigureTest(unittest.TestCase):
         mock_figures[1].test.assert_has_calls([call(2)])
         self.assertTrue(GlobalFigureManager._active_figure == 1)
 
-    @mock.patch(_plot_window_class)
-    def test_close_only_window(self,mock_figure_class):
+    def test_close_only_window(self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock()]
         mock_figure_class.side_effect = mock_figures
         # Get a figure
@@ -99,8 +118,7 @@ class CurrentFigureTest(unittest.TestCase):
         self.assertTrue(fig1 == mock_figures[0])
         self.assertTrue(fig2 == mock_figures[1])
 
-    @mock.patch(_plot_window_class)
-    def test_close_non_existant_window_fail(self,mock_figure_class):
+    def test_close_non_existant_window_fail(self, mock_figure_class):
         mock_figures = [mock.Mock()]
         mock_figure_class.side_effect = mock_figures
         # Get a figure
@@ -113,62 +131,77 @@ class CurrentFigureTest(unittest.TestCase):
         self.assertTrue(fig1 == mock_figures[0])
         self.assertTrue(fig2 == mock_figures[0])
 
-    @mock.patch(_plot_window_class)
     def test_categorizing_of_uncategorized_plot(self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock(), mock.Mock()]
         fig1_mock_manager = mock.Mock()
         # This manager is used to compare the relative order of calls of two differebc functions
-        fig1_mock_manager.attach_mock(mock_figures[0].flag_as_kept, 'fig1_kept')
-        fig1_mock_manager.attach_mock(mock_figures[0].flag_as_current, 'fig1_current')
+        fig1_mock_manager.attach_mock(mock_figures[0].flag_as_kept,
+                                      'fig1_kept')
+        fig1_mock_manager.attach_mock(mock_figures[0].flag_as_current,
+                                      'fig1_current')
         mock_figure_class.side_effect = mock_figures
         cat1 = '1d'
         cat2 = '2d'
-        cat1_get_active_figure = set_category(cat1)(GlobalFigureManager.get_active_figure)
-        cat2_get_active_figure = set_category(cat2)(GlobalFigureManager.get_active_figure)
+        cat1_get_active_figure = set_category(cat1)(
+            GlobalFigureManager.get_active_figure)
+        cat2_get_active_figure = set_category(cat2)(
+            GlobalFigureManager.get_active_figure)
 
         # test is an arbitrary method just to make sure the correct figures are returned
 
         cat1_get_active_figure().test(1)  # create a figure of category 1
         cat2_get_active_figure().test(2)  # create a figure of category 2
-        GlobalFigureManager.set_figure_as_kept(2) # now there is no active figure
+        GlobalFigureManager.set_figure_as_kept(
+            2)  # now there is no active figure
 
-        GlobalFigureManager.get_active_figure().test(3) # create an uncategorized figure
-        cat1_get_active_figure().test(4) # the previously uncategorized figure should now be categorized as cat1
+        GlobalFigureManager.get_active_figure().test(
+            3)  # create an uncategorized figure
+        cat1_get_active_figure().test(
+            4
+        )  # the previously uncategorized figure should now be categorized as cat1
 
         mock_figures[0].test.assert_has_calls([call(1)])
         mock_figures[1].test.assert_has_calls([call(2)])
         mock_figures[2].test.assert_has_calls([call(3), call(4)])
 
-        self.assertTrue(fig1_mock_manager.mock_calls[-1] == call.fig1_kept())  # assert final status of fig1 is kept
+        # assert final status of fig1 is kept
+        self.assertTrue(
+            fig1_mock_manager.mock_calls[-1] == call.fig1_kept())
         self.assertTrue(GlobalFigureManager._active_figure == 3)
 
-    @mock.patch(_plot_window_class)
     def test_make_current_with_single_category(self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock()]
         # These manager is used to compare the relative order of calls of two different functions
         mock_managers = [mock.Mock(), mock.Mock()]
 
         for i in range(len(mock_figures)):
-            mock_managers[i].attach_mock(mock_figures[i].flag_as_kept, 'fig_kept')
-            mock_managers[i].attach_mock(mock_figures[i].flag_as_current, 'fig_current')
+            mock_managers[i].attach_mock(mock_figures[i].flag_as_kept,
+                                         'fig_kept')
+            mock_managers[i].attach_mock(mock_figures[i].flag_as_current,
+                                         'fig_current')
         mock_figure_class.side_effect = mock_figures
         cat1 = '1d'
-        cat1_get_active_figure = set_category(cat1)(GlobalFigureManager.get_active_figure)
+        cat1_get_active_figure = set_category(cat1)(
+            GlobalFigureManager.get_active_figure)
         # test is an arbitrary method just to make sure the correct figures are returned
 
         cat1_get_active_figure().test(1)  # create a figure of category 1
-        GlobalFigureManager.set_figure_as_kept(1)  # now there is no active figure
-        cat1_get_active_figure().test(2)  # this command should go to a new figure
+        GlobalFigureManager.set_figure_as_kept(
+            1)  # now there is no active figure
+        cat1_get_active_figure().test(
+            2)  # this command should go to a new figure
 
-        self.assertTrue(mock_managers[0].mock_calls[-1] == call.fig_kept())     # assert fig1 now displays kept
-        self.assertTrue(mock_managers[1].mock_calls[-1] == call.fig_current())  # assert fig2 now displays current
+        # assert fig1 now displays kept
+        self.assertTrue(mock_managers[0].mock_calls[-1] == call.fig_kept())
+        # assert fig2 now displays current
+        self.assertTrue(mock_managers[1].mock_calls[-1] == call.fig_current())
 
         GlobalFigureManager.set_figure_as_current(1)
-        self.assertTrue(mock_managers[0].mock_calls[-1] == call.fig_current())     # assert fig1 now displays current
-        self.assertTrue(mock_managers[1].mock_calls[-1] == call.fig_kept())        # assert fig2 now displays kept
+        self.assertTrue(mock_managers[0].mock_calls[-1] == call.fig_current())
+        self.assertTrue(mock_managers[1].mock_calls[-1] == call.fig_kept())
 
-        cat1_get_active_figure().test(3)                # This should go to fig1
-        GlobalFigureManager.get_active_figure().test(4)       # This should go to fig1 as well
+        cat1_get_active_figure().test(3)  # This should go to fig1
+        GlobalFigureManager.get_active_figure().test(4) # so should this
 
         mock_figures[0].test.assert_has_calls([call(1), call(3), call(4)])
         mock_figures[1].test.assert_has_calls([call(2)])

--- a/mslice/util/qt/qapp.py
+++ b/mslice/util/qt/qapp.py
@@ -8,77 +8,19 @@
 #
 from __future__ import (absolute_import, unicode_literals)
 from functools import wraps
-import sys
 
-from mslice.util.qt.QtCore import Qt, QMetaObject, QObject, QThread, Slot
+# make these available in this module for the rest of codebase
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall, force_method_calls_to_qapp_thread  # noqa: F401
+
 from mslice.util.qt.QtWidgets import QApplication
 
-from six import reraise
-
-
+# Global QApplication instance reference to keep it alive
 qApp = None
-
-
-class QAppThreadCall(QObject):
-    """
-    Wraps a callable object and forces any calls made to it to be executed
-    on the same thread as the qApp object. This is required for anything
-    called by the matplotlib figures, which run on a separate thread.
-    """
-
-    def __init__(self, callee):
-        global qApp
-        create_qapp_if_required()
-        super(QAppThreadCall, self).__init__()
-        self.moveToThread(qApp.thread())
-        self.callee = callee
-        # Help should then give the correct doc
-        self.__call__.__func__.__doc__ = callee.__doc__
-        self._args = None
-        self._kwargs = None
-        self._result = None
-        self._exc_info = None
-
-    def __call__(self, *args, **kwargs):
-        """
-        If the current thread is the qApp thread then this
-        performs a straight call to the wrapped callable_obj. Otherwise
-        it invokes the do_call method as a slot via a
-        BlockingQueuedConnection.
-        """
-        global qApp
-        if QThread.currentThread() == qApp.thread():
-            return self.callee(*args, **kwargs)
-        else:
-            self._store_function_args(*args, **kwargs)
-            QMetaObject.invokeMethod(self, "on_call",
-                                     Qt.BlockingQueuedConnection)
-            if self._exc_info is not None:
-                reraise(*self._exc_info)
-            return self._result
-
-    @Slot()
-    def on_call(self):
-        """Perform a call to a GUI function across a
-        thread and return the result
-        """
-        try:
-            self._result = \
-                self.callee(*self._args, **self._kwargs)
-        except Exception: # pylint: disable=broad-except
-            self._exc_info = sys.exc_info()
-
-    def _store_function_args(self, *args, **kwargs):
-        self._args = args
-        self._kwargs = kwargs
-        # Reset return value and exception
-        self._result = None
-        self._exc_info = None
 
 
 def call_in_qapp_thread(func):
     """
-    Decorator to force a call onto the QApplication thread
+    Method decorator to force a call onto the QApplication thread
     :param func: The function to decorate
     :return The wrapped function
     """
@@ -87,6 +29,7 @@ def call_in_qapp_thread(func):
         return QAppThreadCall(func)(*args, **kwargs)
 
     return wrapper
+
 
 def create_qapp_if_required():
     """


### PR DESCRIPTION
Description of work.

This should be a more robust method for ensuring future updates of matplotlib don't introduce further calls that need to be forced onto the GUI thread when run from mantid's script editor.

**To test:**

Run any mslice script in the workbench script editor.

Fixes #535.
