### PR TITLE
MSlice - fix overplot crash when plots have different axes

### DIFF
--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -59,14 +59,14 @@ class CutWidgetPresenter(PresenterUtility):
             try:
                 self._cut_plotter_presenter.run_cut(workspace, Cut(*params), plot_over=plot_over, save_only=save_only)
             except RuntimeError as e:
-                self._cut_view.display_error(e.message)
+                self._cut_view.display_error(str(e))
             plot_over = True  # The first plot will respect which button the user pressed. The rest will over plot
 
     def _cut_from_workspace(self, plot_over):
         try:
             self._cut_plotter_presenter.plot_cut_from_selected_workspace(plot_over)
         except RuntimeError as e:
-            self._cut_view.display_error(e.message)
+            self._cut_view.display_error(str(e))
 
     def _parse_step(self):
         step = self._cut_view.get_cut_axis_step()


### PR DESCRIPTION
**Description of work**
This PR fixes a crash on MSlice when attempting to overplot a cut which has different axes to the plot which is currently open.

**To test:**
1. Open Mslice and Load an appropriate file: [LET36360_1.05meV_rings.nxspe.zip](https://github.com/mantidproject/mslice/files/4792934/LET36360_1.05meV_rings.nxspe.zip)
2. Under Workspace Manager > 2D > select the loaded data 
3. Under the Cut tab, select
along `DeltaE` from 0 to 1, 
over`Q` from 0 to 1 
and click `Plot` to plot this Energy cut
4. Now change it to 
along `Q` from 0 to 1
over `DeltaE` from 0 to 1 
this time clicking `Plot Over`.
5. There should be no crash. Instead a red error message will appear at the bottom of the MSlice GUI.

**Release notes** will be added in a separate mantid repo PR

Fixes #534