### PR TITLE
Prevent crashes on cancel for rename- and add-workspace dialogs

### DIFF
--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -157,8 +157,15 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         if not selected_ws:
             self._workspace_manager_view.error_select_one_or_more_workspaces()
             return
-        if len(selected_ws) == 1:
-            selected_ws.append(self._workspace_manager_view.add_workspace_dialog())
+        if len(selected_ws) != 1:
+            return
+        try:
+            new_ws = self._workspace_manager_view.add_workspace_dialog()
+        except RuntimeError as e:
+            if str(e) == 'dialog cancelled':
+                return
+            raise RuntimeError(e)
+        selected_ws.append(new_ws)
         try:
             add_workspace_runs(selected_ws)
         except ValueError as e:

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -127,7 +127,12 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_select_only_one_workspace()
             return
         selected_workspace = selected_workspaces[0]
-        new_name = self._workspace_manager_view.get_workspace_new_name()
+        try:
+            new_name = self._workspace_manager_view.get_workspace_new_name()
+        except RuntimeError as e:
+            if str(e) == 'dialog cancelled':
+                return
+            raise RuntimeError(e)
         rename_workspace(selected_workspace, new_name)
         self.update_displayed_workspaces()
 

--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -127,12 +127,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_select_only_one_workspace()
             return
         selected_workspace = selected_workspaces[0]
-        try:
-            new_name = self._workspace_manager_view.get_workspace_new_name()
-        except RuntimeError as e:
-            if str(e) == 'dialog cancelled':
-                return
-            raise RuntimeError(e)
+        new_name = self._workspace_manager_view.get_workspace_new_name()
+        if new_name is None:
+            return
         rename_workspace(selected_workspace, new_name)
         self.update_displayed_workspaces()
 
@@ -159,12 +156,9 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         if len(selected_ws) != 1:
             return
-        try:
-            new_ws = self._workspace_manager_view.add_workspace_dialog()
-        except RuntimeError as e:
-            if str(e) == 'dialog cancelled':
-                return
-            raise RuntimeError(e)
+        new_ws = self._workspace_manager_view.add_workspace_dialog()
+        if new_ws is None:
+            return
         selected_ws.append(new_ws)
         try:
             add_workspace_runs(selected_ws)

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -166,10 +166,10 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         return paths[0] if isinstance(paths, tuple) else [str(filename) for filename in paths]
 
     def get_workspace_new_name(self):
-        name, success = QInputDialog.getText(self,"Workspace New Name","Enter the new name for the workspace :      ")
+        name, success = QInputDialog.getText(self, "Workspace New Name", "Enter the new name for the workspace :      ")
         # The message above was padded with spaces to allow the whole title to show up
         if not success:
-            raise ValueError('No Valid Name supplied')
+            raise RuntimeError('dialog cancelled')
         return str(name)
 
     def error_select_only_one_workspace(self):

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -119,7 +119,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         dialog.setOptions(QInputDialog.UseListViewForComboBoxItems)
         dialog.setComboBoxItems(items)
         if dialog.exec_() != QInputDialog.Accepted:
-            raise RuntimeError('dialog cancelled')
+            return None  # User cancelled dialog
         return dialog.textValue()
 
     def subtraction_input(self):
@@ -170,7 +170,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         name, success = QInputDialog.getText(self, "Workspace New Name", "Enter the new name for the workspace :      ")
         # The message above was padded with spaces to allow the whole title to show up
         if not success:
-            raise RuntimeError('dialog cancelled')
+            return None  # User cancelled dialog
         return str(name)
 
     def error_select_only_one_workspace(self):

--- a/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/mslice/widgets/workspacemanager/workspacemanager.py
@@ -118,7 +118,8 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         dialog.setLabelText("Choose a workspace to add:")
         dialog.setOptions(QInputDialog.UseListViewForComboBoxItems)
         dialog.setComboBoxItems(items)
-        dialog.exec_()
+        if dialog.exec_() != QInputDialog.Accepted:
+            raise RuntimeError('dialog cancelled')
         return dialog.textValue()
 
     def subtraction_input(self):


### PR DESCRIPTION
Fixes crashes associated with the rename workpsace and add workspace dialogs when the user clicked cancel. This was fixed by raising `RuntimeErrors` when the dialogs were cancelled, which are caught by the `workspace_manager_presenter`.

**To test:**
1. Load a workspace, e.g. `164198.nxs` in `TrainingCourseData`
2. In the Workspace Manager tab, click add. 
3. Cancel the dialog, check MSlice doesn't crash.
4. Repeat for rename workspace.

Fixes #542
