### PR TITLE
Prevent MSlice crash by stopping the entry of comma's into QLineEdits expecting double's

### DIFF
--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -4,7 +4,8 @@ from matplotlib.figure import Figure
 from mantidqt.icons import get_icon
 
 from mslice.plotting.backend import get_canvas_and_toolbar_cls
-from mslice.util.qt import QtCore, QtWidgets, QtGui
+from mslice.util.qt import QtCore, QtWidgets
+from mslice.util.qt.validator_helper import double_validator_without_separator
 
 FigureCanvas, NavigationToolbar2QT = get_canvas_and_toolbar_cls()
 
@@ -158,7 +159,7 @@ class PlotWindow(QtWidgets.QMainWindow):
         sz.setWidth(60)
         self.waterfall_x_edt.setMaximumSize(sz)
         self.waterfall_y_edt.setMaximumSize(sz)
-        validator = QtGui.QDoubleValidator(self)
+        validator = double_validator_without_separator()
         self.waterfall_x_edt.setValidator(validator)
         self.waterfall_y_edt.setValidator(validator)
         self.waterfall_x_lbl_act = parent.addWidget(self.waterfall_x_lbl)

--- a/mslice/util/qt/validator_helper.py
+++ b/mslice/util/qt/validator_helper.py
@@ -1,0 +1,12 @@
+from mslice.util.qt.QtCore import QLocale
+from mslice.util.qt.QtGui import QDoubleValidator
+
+
+def double_validator_without_separator():
+    """Returns a QDoubleValidator which doesn't accept a comma separator as input."""
+    locale = QLocale(QLocale.C)
+    locale.setNumberOptions(QLocale.RejectGroupSeparator)
+
+    double_validator = QDoubleValidator()
+    double_validator.setLocale(locale)
+    return double_validator

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -6,9 +6,9 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mslice.util.qt import load_ui
-from mslice.util.qt.QtGui import QDoubleValidator
 from mslice.util.qt.QtCore import Signal
 from mslice.util.qt.QtWidgets import QWidget
+from mslice.util.qt.validator_helper import double_validator_without_separator
 
 from mslice.presenters.cut_widget_presenter import CutWidgetPresenter
 
@@ -303,8 +303,10 @@ class CutWidget(CutView, QWidget):
         line_edits = [self.lneCutStart, self.lneCutEnd, self.lneCutIntegrationStart,
                       self.lneCutIntegrationEnd, self.lneCutIntegrationWidth, self.lneEditCutIntensityStart,
                       self.lneCutIntensityEnd]
+
+        double_validator = double_validator_without_separator()
         for line_edit in line_edits:
-            line_edit.setValidator(QDoubleValidator())
+            line_edit.setValidator(double_validator)
 
     def force_normalization(self):
         self.rdoCutNormToOne.setEnabled(False)

--- a/mslice/widgets/slice/slice.py
+++ b/mslice/widgets/slice/slice.py
@@ -6,9 +6,9 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mslice.util.qt import load_ui
-from mslice.util.qt.QtGui import QDoubleValidator
 from mslice.util.qt.QtCore import Signal
 from mslice.util.qt.QtWidgets import QWidget
+from mslice.util.qt.validator_helper import double_validator_without_separator
 
 from mslice.models.units import EnergyUnits
 from mslice.presenters.slice_widget_presenter import SliceWidgetPresenter
@@ -251,8 +251,10 @@ class SliceWidget(SliceView, QWidget):
     def set_validators(self):
         line_edits = [self.lneSliceXStart, self.lneSliceXEnd, self.lneSliceXStep, self.lneSliceYStart,
                       self.lneSliceYEnd, self.lneSliceYStep, self.lneSliceIntensityStart, self.lneSliceIntensityEnd]
+
+        double_validator = double_validator_without_separator()
         for line_edit in line_edits:
-            line_edit.setValidator(QDoubleValidator())
+            line_edit.setValidator(double_validator)
 
     def set_energy_default(self, en_default):
         self._en_default = en_default

--- a/mslice/widgets/workspacemanager/input_boxes.py
+++ b/mslice/widgets/workspacemanager/input_boxes.py
@@ -1,6 +1,6 @@
 from mslice.util.qt import load_ui
-from mslice.util.qt.validator_helper import double_validator_without_separator
 from mslice.util.qt.QtWidgets import QDialog, QFormLayout, QLabel, QLineEdit, QPushButton
+from mslice.util.qt.validator_helper import double_validator_without_separator
 
 
 class SubtractInputBox(QDialog):

--- a/mslice/widgets/workspacemanager/input_boxes.py
+++ b/mslice/widgets/workspacemanager/input_boxes.py
@@ -29,6 +29,7 @@ class ScaleInputBox(QDialog):
         double_validator = double_validator_without_separator()
         self.edit1 = QLineEdit(self)
         self.edit1.setValidator(double_validator)
+        self.edit1.setText('1.0')
         self.edit2 = QLineEdit(self)
         self.edit2.setValidator(double_validator)
 

--- a/mslice/widgets/workspacemanager/input_boxes.py
+++ b/mslice/widgets/workspacemanager/input_boxes.py
@@ -1,6 +1,6 @@
 from mslice.util.qt import load_ui
+from mslice.util.qt.validator_helper import double_validator_without_separator
 from mslice.util.qt.QtWidgets import QDialog, QFormLayout, QLabel, QLineEdit, QPushButton
-from mslice.util.qt.QtGui import QDoubleValidator
 
 
 class SubtractInputBox(QDialog):
@@ -16,6 +16,7 @@ class SubtractInputBox(QDialog):
         background_ws = self.listWidget.selectedItems()[0].text()
         return background_ws, self.ssf.value()
 
+
 class ScaleInputBox(QDialog):
 
     def __init__(self, is_bose=False, parent=None):
@@ -24,10 +25,13 @@ class ScaleInputBox(QDialog):
         layout = QFormLayout(self)
         self.text1 = QLabel(self)
         self.text2 = QLabel(self)
+
+        double_validator = double_validator_without_separator()
         self.edit1 = QLineEdit(self)
-        self.edit1.setValidator(QDoubleValidator())
+        self.edit1.setValidator(double_validator)
         self.edit2 = QLineEdit(self)
-        self.edit2.setValidator(QDoubleValidator())
+        self.edit2.setValidator(double_validator)
+
         if is_bose:
             self.text1.setText('Current temperature (K)')
             self.text2.setText('Target temperature (K)')


### PR DESCRIPTION
**Description of work:**
Fixes the possibility of a crash by restricting the input of the line edits used for entering doubles. 

By default, a `QDoubleValidator` allows the entry of a comma. This will cause a crash when attempting to convert the entered data to a float. This PR prevents the entry of comma's into the relevant line edits thereby preventing a crash.

**To test:**
1. Open MSlice.
2. Load any data (e.g. `MAR25087`)
3. Go to the `Workspace Manager` tab
4. Click the down arrow next to `Compose` and select `Scale`
5. Attempt to enter a comma into the line edit. This should not be allowed.
6. Also try to enter a comma into the line edits seen on the `Slice` and `Cut` tabs. This should not be allowed.

Fixes #551.
