### PR TITLE
Fixed MSlice crash when entering unexpected values into width box

### DIFF
--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -91,7 +91,7 @@ class Cut(object):
 
     @width.setter
     def width(self, width_str):
-        if width_str is not None and width_str.strip():
+        if width_str is not None and not width_str.startswith('e') and not width_str.endswith('e') and not width_str.startswith('-') and width_str.strip():
             try:
                 self._width = float(width_str)
             except ValueError:

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -91,13 +91,14 @@ class Cut(object):
 
     @width.setter
     def width(self, width_str):
-        if width_str.startswith('e') or width_str.endswith('e') or width_str.startswith('-'):
-            self._width = None
-        elif width_str is not None and width_str.strip():
-            try:
-                self._width = float(width_str)
-            except ValueError:
-                raise ValueError("Invalid width")
+        if width_str is not None and width_str.strip():
+            if width_str.startswith('e') or width_str.endswith('e') or width_str.startswith('-'):
+                self._width = None
+            else:
+                try:
+                    self._width = float(width_str)
+                except ValueError:
+                    raise ValueError("Invalid width")
         elif width_str == '':
             self._width = self.end - self.start
         else:

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -91,7 +91,9 @@ class Cut(object):
 
     @width.setter
     def width(self, width_str):
-        if width_str is not None and not width_str.startswith('e') and not width_str.endswith('e') and not width_str.startswith('-') and width_str.strip():
+        if width_str.startswith('e') or width_str.endswith('e') or width_str.startswith('-'):
+            self._width = None
+        elif width_str is not None and width_str.strip():
             try:
                 self._width = float(width_str)
             except ValueError:


### PR DESCRIPTION
Modified width function to not accept negative values or a standalone 'e'. Double values in proper e notation are still allowed.

**To test:**
1. Open MSlice.
2. Load any data
3. Go to the Workspace Manager tab
4. Click on the Cut tab
5. Attempt to enter a negative value into the width box. 
6. Also try to enter a standalone 'e' into the width box.

Fixes [#556](https://github.com/mantidproject/mslice/issues/556)
