### PR TITLE
Implement floating/ontop window behaviour for mslice

### DIFF
--- a/mslice/app/__init__.py
+++ b/mslice/app/__init__.py
@@ -1,6 +1,8 @@
 """Package defining top-level MSlice application
 and entry points.
 """
+import sys
+
 import mslice.util.mantid.init_mantid # noqa: F401
 from mslice.util.mantid import in_mantid
 from mslice.util.qt import QT_VERSION
@@ -35,4 +37,12 @@ def show_gui():
     if MAIN_WINDOW is None:
         from mslice.app.mainwindow import MainWindow
         MAIN_WINDOW = MainWindow(in_mantid())
+
+    if 'workbench' in sys.modules:
+        from workbench.config import get_window_config
+
+        # Ensures any change to workbench Floating/Ontop window setting is propagated to MSlice.
+        parent, flags = get_window_config()
+        MAIN_WINDOW.setParent(parent)
+        MAIN_WINDOW.setWindowFlags(flags)
     MAIN_WINDOW.show()

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -1,7 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 
-import sys
-
 from mslice.util.qt.QtWidgets import QApplication, QMainWindow, QLabel, QMenu, QStackedLayout
 
 from mslice.models.units import EnergyUnits

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -1,5 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
+import sys
+
 from mslice.util.qt.QtWidgets import QApplication, QMainWindow, QLabel, QMenu, QStackedLayout
 
 from mslice.models.units import EnergyUnits
@@ -28,6 +30,11 @@ TAB_POWDER = 0
 class MainWindow(MainView, QMainWindow):
 
     def __init__(self, in_mantid=False):
+        # if 'workbench' in sys.modules:
+        #     from workbench.config import get_window_config
+        #     parent, flags = get_window_config()
+        #     QMainWindow.__init__(self, parent, flags)
+        # else:
         QMainWindow.__init__(self)
         load_ui(__file__, 'mainwindow.ui', self)
         self.init_ui()


### PR DESCRIPTION
Implements floating/ontop window behaviour (that can be set in workbench settings) on mslice, as described in [this PR on the mantid repo](https://github.com/mantidproject/mantid/pull/30129).

**To test:**
- Launch mslice and check it opens correctly, and that without mantid the window is 'floating'.
- If possible, test the behaviour in workbench. "Floating" means that mslice would disappear behind the workbench window when the user changes the window in focus. "On top" means mslice would stay on top of workbench.
