### PR TITLE
Fixed MSlice crashes when not manually selecting a second workspace for subtracting

### DIFF
--- a/mslice/widgets/workspacemanager/input_boxes.py
+++ b/mslice/widgets/workspacemanager/input_boxes.py
@@ -11,9 +11,10 @@ class SubtractInputBox(QDialog):
         for i in range(ws_list.count()):
             item = ws_list.item(i).clone()
             self.listWidget.insertItem(i, item)
+        self.listWidget.setCurrentRow(0)
 
     def user_input(self):
-        background_ws = self.listWidget.selectedItems()[0].text()
+        background_ws = self.listWidget.item(0).text()
         return background_ws, self.ssf.value()
 
 


### PR DESCRIPTION
The Subtract Workspace dialog selects the first workspace by default but failed to use it. This resulted in crashes. This is fixed now.

**To test:**

1. Open MSlice.
2. Load any data
3. Go to the Workspace Manager tab
4. Select a workspace
5. Click on Subtract
6. In the Subtract Workspace dialog click on Ok

Fixes [#560](https://github.com/mantidproject/mslice/issues/560) 
