### PR TITLE
Allow selection of more than one workspace for addition in workspace panel of MSlice

### DIFF
--- a/mslice/presenters/workspace_manager_presenter.py
+++ b/mslice/presenters/workspace_manager_presenter.py
@@ -154,12 +154,11 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         if not selected_ws:
             self._workspace_manager_view.error_select_one_or_more_workspaces()
             return
-        if len(selected_ws) != 1:
-            return
-        new_ws = self._workspace_manager_view.add_workspace_dialog()
-        if new_ws is None:
-            return
-        selected_ws.append(new_ws)
+        if len(selected_ws) == 1:
+            new_ws = self._workspace_manager_view.add_workspace_dialog()
+            if new_ws is None:
+                return
+            selected_ws.append(new_ws)
         try:
             add_workspace_runs(selected_ws)
         except ValueError as e:


### PR DESCRIPTION
Fixed bug that only one workspace can be selected from the workspace panel so the Add Workspace dialog had to be used to select additional workspaces. Now the Add Workspace dialog only opens when one workspace was selected from the workspace panel. In case of a selection of more than one workspace clicking the Add button is enough to add the selected workspaces.

**To test:**
1. Open MSlice.
2. Load any data
3. Go to the Workspace Manager tab
4. Select more than one workspace
5. Click on Add
6. Check that new workspace with suffix '_sum' is created without opening the Add Workspace dialog

Fixes [#559](https://github.com/mantidproject/mslice/issues/559)
