### PR TITLE
Fix for colorcycle problem for multiple curves on one plot

### DIFF
--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -262,7 +262,12 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         self.color_label.setText("Color:")
         self.line_color = QtWidgets.QComboBox(self)
         self.line_color.addItems(named_cycle_colors())
-        self.line_color.setCurrentIndex(self.line_color.findText(color_to_name(line_options['color'])))
+        color_index = self.line_color.findText(color_to_name(line_options['color']))
+        if color_index != -1:
+            self.line_color.setCurrentIndex(color_index)
+        else:
+            self.line_color.addItem(color_to_name(line_options['color']))
+            self.line_color.setCurrentIndex(self.line_color.count()-1)
         self.previous_color = self.line_color.currentIndex()
 
         self.style_label = QtWidgets.QLabel(self)


### PR DESCRIPTION
Adding curves via Python script with colors that are not in the pre-defined color list caused an unhandled exception.
Now these additional colors are temporarily added to the color list used in settings.

**To test:**
Follow instructions in issue description.

Fixes [#550](https://github.com/mantidproject/mslice/issues/550)
