### PR TITLE
Fixed runtime error when trying to delete workspace for the second time

### DIFF
--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -55,7 +55,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
 
     def __del__(self):
         try:
-            if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN') and self._raw_ws is not None:
+            if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
                 DeleteWorkspace(self._raw_ws)
                 self._raw_ws = None
         except RuntimeError:

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -55,8 +55,9 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
 
     def __del__(self):
         try:
-            if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN'):
+            if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN') and self._raw_ws is not None:
                 DeleteWorkspace(self._raw_ws)
+                self._raw_ws = None
         except RuntimeError:
             # On exit the workspace can get deleted before __del__ is called
             # where you receive a RuntimeError: Variable invalidated, data has been deleted.

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -53,9 +53,9 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN') and self._raw_ws is not None:
+        if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
             DeleteWorkspace(self._raw_ws)
             self._raw_ws = None
-        if hasattr(self, '_histo_ws') and self._histo_ws.name().endswith('_HIDDEN') and self._histo_ws is not None:
+        if hasattr(self, '_histo_ws') and self._histo_ws is not None and self._histo_ws.name().endswith('_HIDDEN'):
             DeleteWorkspace(self._histo_ws)
             self._histo_ws = None

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -53,7 +53,9 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN'):
+        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN') and self._raw_ws is not None:
             DeleteWorkspace(self._raw_ws)
-        if hasattr(self, '_histo_ws') and self._histo_ws.name().endswith('_HIDDEN'):
+            self._raw_ws = None
+        if hasattr(self, '_histo_ws') and self._histo_ws.name().endswith('_HIDDEN') and self._histo_ws is not None:
             DeleteWorkspace(self._histo_ws)
+            self._histo_ws = None

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -47,6 +47,6 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN') and self._raw_ws is not None:
+        if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
             DeleteWorkspace(self._raw_ws)
             self._raw_ws = None

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -47,5 +47,6 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN'):
+        if hasattr(self, '_raw_ws') and self._raw_ws.name().endswith('_HIDDEN') and self._raw_ws is not None:
             DeleteWorkspace(self._raw_ws)
+            self._raw_ws = None


### PR DESCRIPTION
Occasionally temporary workspaces are already deleted when the clean up function is called. If not caught this causes runtime errors.
Now there is a check if the respective workspace is still present.

**To test:**

1. Open MSlice.
2. Load any data
3. Go to the Workspace Manager tab
4. Select a workspace
5. Click on Subtract
6. In the Subtract Workspace dialog click on Ok
7. Select the initial workspace once more
8. Click on Subtract
9. In the Subtract Workspace dialog click on Ok

Fixes [#528](https://github.com/mantidproject/mslice/issues/528)
