### PR TITLE
Fixed bug that overwrote selection of background workspace when subtracting

### DIFF
--- a/mslice/widgets/workspacemanager/input_boxes.py
+++ b/mslice/widgets/workspacemanager/input_boxes.py
@@ -14,7 +14,7 @@ class SubtractInputBox(QDialog):
         self.listWidget.setCurrentRow(0)
 
     def user_input(self):
-        background_ws = self.listWidget.item(0).text()
+        background_ws = self.listWidget.currentItem().text()
         return background_ws, self.ssf.value()
 
 


### PR DESCRIPTION
Subtraction of one workspace from another did not result in the expected workspace in MSlice

Description of work.
Modified user_input function in input_boxes.py to return the workspace selected by the user as the background workspace.

**To test:**

1. Open MSlice in IDAaaS
2. Load two datasets that result in compatible workspaces
3. Go to the Workspace Manager tab
4. Scale the first workspace with a random scale factor
5. Select the second workspace
6. Click on Subtract
7. Select the scaled workspace
8. Ensure that the subtracted workspace uses the scaled workspace as the background workspace


Fixes [#576](https://github.com/mantidproject/mslice/issues/576).

