### PR TITLE
Added exception handling for different input values for GDOS to prevent MSlice crashes.

### DIFF
--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -9,6 +9,7 @@ from scipy import constants
 
 from mslice.models.alg_workspace_ops import get_number_of_steps
 from mslice.models.labels import is_momentum, is_twotheta
+from mslice.models.units import get_sample_temperature_from_string
 from mslice.models.workspacemanager.workspace_algorithms import propagate_properties
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.util.mantid.mantid_algorithms import LoadCIF, CloneWorkspace
@@ -140,18 +141,6 @@ def sample_temperature(ws_name, sample_temp_fields):
     if isinstance(sample_temp, np.ndarray) or isinstance(sample_temp, list):
         sample_temp = np.mean(sample_temp)
     return sample_temp
-
-
-def get_sample_temperature_from_string(string):
-    if string is not None and string.strip():
-        if string.endswith('K'):
-            string = string[:-1]
-        try:
-            sample_temp = float(string)
-            return sample_temp
-        except ValueError:
-            return None
-    return None
 
 
 def compute_recoil_line(ws_name, axis, relative_mass=1):

--- a/mslice/models/slice/slice_functions.py
+++ b/mslice/models/slice/slice_functions.py
@@ -143,12 +143,15 @@ def sample_temperature(ws_name, sample_temp_fields):
 
 
 def get_sample_temperature_from_string(string):
-    pos_k = string.find('K')
-    if pos_k == -1:
-        return None
-    k_string = string[pos_k - 3:pos_k]
-    sample_temp = float(''.join(c for c in k_string if c.isdigit()))
-    return sample_temp
+    if string is not None and string.strip():
+        if string.endswith('K'):
+            string = string[:-1]
+        try:
+            sample_temp = float(string)
+            return sample_temp
+        except ValueError:
+            return None
+    return None
 
 
 def compute_recoil_line(ws_name, axis, relative_mass=1):
@@ -228,4 +231,8 @@ def is_sliceable(workspace):
         return True
     else:
         validator = WorkspaceUnitValidator('DeltaE')
-        return isinstance(ws, Workspace) and validator.isValid(ws.raw_ws) == ''
+        try:
+            isvalid = isinstance(ws, Workspace) and validator.isValid(ws.raw_ws) == ''
+        except RuntimeError:
+            return False
+        return isvalid

--- a/mslice/models/units.py
+++ b/mslice/models/units.py
@@ -13,6 +13,17 @@ def _scale_string_or_float(value, scale):
     except (ValueError, TypeError):
         return value
 
+def get_sample_temperature_from_string(string):
+    if string is not None and string.strip():
+        if string.endswith('K'):
+            string = string[:-1]
+        try:
+            sample_temp = float(string)
+            return sample_temp
+        except ValueError:
+            return None
+    return None
+
 class EnergyUnits(object):
 
     _available_units = ['meV', 'cm-1']

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -342,19 +342,22 @@ class SlicePlot(IPlot):
                 self._slice_plotter_presenter.add_sample_temperature_field(temp_value)
                 self._slice_plotter_presenter.update_sample_temperature(self.ws_name)
             else:
-                try:
-                    temp_value = float(temp_value)
-                    if temp_value < 0:
-                        raise ValueError
-                except ValueError:
-                    self.plot_window.error_box("Invalid value entered for sample temperature. Enter a value in Kelvin \
+                if temp_value is not None and temp_value.strip():
+                    if temp_value.endswith('K'):
+                        temp_value = temp_value[:-1]
+                    try:
+                        temp_value = float(temp_value)
+                        if temp_value < 0:
+                            raise ValueError
+                    except ValueError:
+                        self.plot_window.display_error("Invalid value entered for sample temperature. Enter a value in Kelvin \
                                                or a sample log field.")
-                    self.set_intensity(previous)
-                    return False
-                else:
-                    self.default_options['temp'] = temp_value
-                    self.temp = temp_value
-                    self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
+                        self.set_intensity(previous)
+                        return False
+                    else:
+                        self.default_options['temp'] = temp_value
+                        self.temp = temp_value
+                        self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
             slice_plotter_method(self.ws_name)
         return True
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -7,6 +7,7 @@ import os.path as path
 import matplotlib.colors as colors
 
 from mslice.models.colors import to_hex
+from mslice.models.units import get_sample_temperature_from_string
 from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
@@ -330,34 +331,35 @@ class SlicePlot(IPlot):
         self._canvas.draw()
 
     def _run_temp_dependent(self, slice_plotter_method, previous):
+        temp_value_raw = None
+        temp_value = None
         try:
             slice_plotter_method(self.ws_name)
         except ValueError:  # sample temperature not yet set
             try:
-                temp_value, field = self.ask_sample_temperature_field(str(self.ws_name))
+                temp_value_raw, field = self.ask_sample_temperature_field(str(self.ws_name))
             except RuntimeError:  # if cancel is clicked, go back to previous selection
                 self.set_intensity(previous)
                 return False
+            temp_value = get_sample_temperature_from_string(temp_value_raw)
             if field:
                 self._slice_plotter_presenter.add_sample_temperature_field(temp_value)
                 self._slice_plotter_presenter.update_sample_temperature(self.ws_name)
             else:
-                if temp_value is not None and temp_value.strip():
-                    if temp_value.endswith('K'):
-                        temp_value = temp_value[:-1]
+                if temp_value is not None:
                     try:
                         temp_value = float(temp_value)
-                        if temp_value < 0:
-                            raise ValueError
                     except ValueError:
-                        self.plot_window.display_error("Invalid value entered for sample temperature. Enter a value in Kelvin \
+                        temp_value = None
+                if temp_value is None or temp_value < 0:
+                    self.plot_window.display_error("Invalid value entered for sample temperature. Enter a value in Kelvin \
                                                or a sample log field.")
-                        self.set_intensity(previous)
-                        return False
-                    else:
-                        self.default_options['temp'] = temp_value
-                        self.temp = temp_value
-                        self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
+                    self.set_intensity(previous)
+                    return False
+                else:
+                    self.default_options['temp'] = temp_value
+                    self.temp = temp_value
+                    self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
             slice_plotter_method(self.ws_name)
         return True
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -341,11 +341,11 @@ class SlicePlot(IPlot):
             except RuntimeError:  # if cancel is clicked, go back to previous selection
                 self.set_intensity(previous)
                 return False
-            temp_value = get_sample_temperature_from_string(temp_value_raw)
             if field:
-                self._slice_plotter_presenter.add_sample_temperature_field(temp_value)
+                self._slice_plotter_presenter.add_sample_temperature_field(temp_value_raw)
                 self._slice_plotter_presenter.update_sample_temperature(self.ws_name)
             else:
+                temp_value = get_sample_temperature_from_string(temp_value_raw)
                 if temp_value is not None:
                     try:
                         temp_value = float(temp_value)


### PR DESCRIPTION
Mslice crashed often when converting Intensity from S(Q,E) to GDOS. One of the problems are unexpected input values.
Also, temperature input in Kelvin will not always have the unit appended. This fix allows both values with and without unit.
When selecting a pre-configured setting for GDOS, for instance 'MSlice', this also often resulted in crashes whenever there is no valid entry for temperature. 

- When entering an invalid temperature an error message is displayed. 
- The function trying to convert an input value with or without 'K' as a unit is more robust now (get_sample_temperature_from_string).
- Selecting a pre-configured setting for GDOS that does not have a valid temperature now throws the exception 'sample temperature not found' instead of crashing MSlice.

**To test:**

1. Open MSlice
2. Load any data
3. Go to the Workspace Manager tab
4. Click on the Slice tab and then on Display.
5. Click on Intensity
6. Select GDOS
7. Try different selections from drop down menu. 'MSlice' seemed to cause crashes quite often, now it should at most throw an exception. 
8. Also, try different values as temperature input. A double or integer with or without 'K' appended should work. Any other entry should result in a pop up error message, but no crash.

Fixes #[573](https://github.com/mantidproject/mslice/issues/573).
