### PR TITLE
Move MSlice issue templates to new GitHub system

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable/possible, add screenshots to help explain your problem.
+
+**Mantid Version (please complete the following information):**
+ - Mantid Version [e.g. 6.0.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,9 @@
+---
+name: Custom issue template
+about: Blank issue
+title: ''
+labels: ''
+assignees: ''
+
+---
+


### PR DESCRIPTION
**Description of work.**

Added two new issue templates for MSlice.

**To test:**

Code review. Check the wording of the new bug report template.

This does not require release notes because **it is an internal process change.**