### PR TITLE
536 close all feature

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,44 @@
+name: MSlice unit tests
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout MSlice
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.1
+        with:
+          activate-environment: mslice
+          environment-file: environment.yml
+          python-version: 3.6
+          auto-activate-base: false
+
+      - name: Install Mantid
+        run: |
+          sudo apt-add-repository ppa:mantid/mantid -y && sudo apt-get update -qq
+          sudo apt-get install gdebi -y
+          export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/master/releases/nightly.txt | grep ubuntu)
+          wget http://downloads.sourceforge.net/project/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
+          sudo gdebi --option=APT::Get::force-yes=1,APT::Get::Assume-Yes=1 -n /tmp/mtn.deb
+          echo "PYTHONPATH=/opt/mantidnightly/bin:/opt/mantidnightly/lib" >> $GITHUB_ENV
+          echo "HDF5_DISABLE_VERSION_CHECK=1" >> $GITHUB_ENV
+          sudo apt-get install libglu1-mesa
+
+      - name: Flake8
+        run: |
+          python setup.py flake8
+
+      - name: Nosetests
+        run: |
+          xvfb-run '--server-args=-screen 0 640x480x24' --auto-servernum python setup.py nosetests
+

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -62,6 +62,9 @@ class PlotFigureManagerQT(QtCore.QObject):
             self.plot_handler.window_closing()
         plt.close(self.number)
 
+    def destroy(self):
+        self.window.close()
+
     def resize(self, width, height):
         self.window.resize(width, height)
 

--- a/mslice/plotting/pyplot.py
+++ b/mslice/plotting/pyplot.py
@@ -437,7 +437,7 @@ def close(*args):
             GlobalFigureManager.destroy(figManager.num)
     elif len(args) == 1:
         arg = args[0]
-        if arg == 'all':
+        if arg == 'all' or arg == 'All':
             GlobalFigureManager.destroy_all()
         elif isinstance(arg, int):
             GlobalFigureManager.destroy(arg)

--- a/mslice/tests/figure_manager_test.py
+++ b/mslice/tests/figure_manager_test.py
@@ -132,12 +132,13 @@ class CurrentFigureTest(unittest.TestCase):
         self.assertTrue(fig2 == mock_figures[0])
 
     def test_destroy_all(self, mock_figure_class):
-        mock_figures = [mock.Mock()]
+        mock_figures = [mock.Mock(), mock.Mock()]
         mock_figure_class.side_effect = mock_figures
         fig1 = GlobalFigureManager.get_active_figure()
+        fig2 = GlobalFigureManager.get_active_figure()
         GlobalFigureManager.destroy_all()
 
-        self.assertTrue(fig1 == mock_figures[0])
+        self.assertFalse(GlobalFigureManager.get_all_fig_managers())
 
     def test_categorizing_of_uncategorized_plot(self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock(), mock.Mock()]

--- a/mslice/tests/figure_manager_test.py
+++ b/mslice/tests/figure_manager_test.py
@@ -138,7 +138,8 @@ class CurrentFigureTest(unittest.TestCase):
         fig2 = GlobalFigureManager.get_active_figure()
         GlobalFigureManager.destroy_all()
 
-        self.assertFalse(GlobalFigureManager.get_all_fig_managers())
+        self.assertRaises(KeyError, GlobalFigureManager.figure_closed, 1)
+        self.assertRaises(KeyError, GlobalFigureManager.figure_closed, 2)
 
     def test_categorizing_of_uncategorized_plot(self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock(), mock.Mock()]

--- a/mslice/tests/figure_manager_test.py
+++ b/mslice/tests/figure_manager_test.py
@@ -141,7 +141,7 @@ class CurrentFigureTest(unittest.TestCase):
         fig2 = GlobalFigureManager.get_active_figure()
         self.assertTrue(GlobalFigureManager.get_active_figure() == fig2)
         GlobalFigureManager.destroy_all()
-        
+
         # check that both figures were destroyed
         self.assertRaises(KeyError, GlobalFigureManager.figure_closed, 1)
         self.assertRaises(KeyError, GlobalFigureManager.figure_closed, 2)

--- a/mslice/tests/figure_manager_test.py
+++ b/mslice/tests/figure_manager_test.py
@@ -131,6 +131,14 @@ class CurrentFigureTest(unittest.TestCase):
         self.assertTrue(fig1 == mock_figures[0])
         self.assertTrue(fig2 == mock_figures[0])
 
+    def test_destroy_all(self, mock_figure_class):
+        mock_figures = [mock.Mock()]
+        mock_figure_class.side_effect = mock_figures
+        fig1 = GlobalFigureManager.get_active_figure()
+        GlobalFigureManager.destroy_all()
+
+        self.assertTrue(fig1 == mock_figures[0])
+
     def test_categorizing_of_uncategorized_plot(self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock(), mock.Mock()]
         fig1_mock_manager = mock.Mock()

--- a/mslice/tests/figure_manager_test.py
+++ b/mslice/tests/figure_manager_test.py
@@ -135,7 +135,9 @@ class CurrentFigureTest(unittest.TestCase):
         mock_figures = [mock.Mock(), mock.Mock()]
         mock_figure_class.side_effect = mock_figures
         fig1 = GlobalFigureManager.get_active_figure()
+        self.assertTrue(GlobalFigureManager.get_active_figure() == fig1)
         fig2 = GlobalFigureManager.get_active_figure()
+        self.assertTrue(GlobalFigureManager.get_active_figure() == fig2)
         GlobalFigureManager.destroy_all()
 
         self.assertRaises(KeyError, GlobalFigureManager.figure_closed, 1)

--- a/mslice/tests/figure_manager_test.py
+++ b/mslice/tests/figure_manager_test.py
@@ -134,12 +134,15 @@ class CurrentFigureTest(unittest.TestCase):
     def test_destroy_all(self, mock_figure_class):
         mock_figures = [mock.Mock(), mock.Mock()]
         mock_figure_class.side_effect = mock_figures
+        # Get first figure
         fig1 = GlobalFigureManager.get_active_figure()
         self.assertTrue(GlobalFigureManager.get_active_figure() == fig1)
+        # Get second figure
         fig2 = GlobalFigureManager.get_active_figure()
         self.assertTrue(GlobalFigureManager.get_active_figure() == fig2)
         GlobalFigureManager.destroy_all()
-
+        
+        # check that both figures were destroyed
         self.assertRaises(KeyError, GlobalFigureManager.figure_closed, 1)
         self.assertRaises(KeyError, GlobalFigureManager.figure_closed, 2)
 


### PR DESCRIPTION
The pyplot-like API for MSlice now allows closing plot windows with the close('all') command. 

**To test:**

Via the command line interface of MSlice, open several plot windows. Use close('all') to close all of them.

Fixes #[536](https://github.com/mantidproject/mslice/issues/536).
