### PR TITLE
549 delete curve feature

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,9 +1,6 @@
 name: MSlice unit tests
 
-on: 
-  push:
-    branches:
-      - 549_delete_curve_feature
+on: push
 
 jobs:
   test:
@@ -16,7 +13,7 @@ jobs:
       - name: Checkout MSlice
         uses: actions/checkout@v2
         with:
-          ref: 549_delete_curve_feature
+          fetch-depth: 0
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2.0.1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,46 @@
+name: MSlice unit tests
+
+on: 
+  push:
+    branches:
+      - 549_delete_curve_feature
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout MSlice
+        uses: actions/checkout@v2
+        with:
+          ref: 549_delete_curve_feature
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.1
+        with:
+          activate-environment: mslice
+          environment-file: environment.yml
+          python-version: 3.6
+          auto-activate-base: false
+
+      - name: Install Mantid
+        run: |
+          sudo apt-add-repository ppa:mantid/mantid -y && sudo apt-get update -qq
+          sudo apt-get install gdebi -y
+          export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/master/releases/nightly.txt | grep ubuntu)
+          wget http://downloads.sourceforge.net/project/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
+          sudo gdebi --option=APT::Get::force-yes=1,APT::Get::Assume-Yes=1 -n /tmp/mtn.deb
+          echo "PYTHONPATH=/opt/mantidnightly/bin:/opt/mantidnightly/lib" >> $GITHUB_ENV
+          echo "HDF5_DISABLE_VERSION_CHECK=1" >> $GITHUB_ENV
+          sudo apt-get install libglu1-mesa
+
+      - name: Flake8
+        run: |
+          python setup.py flake8
+
+      - name: Nosetests
+        run: |
+          xvfb-run '--server-args=-screen 0 640x480x24' --auto-servernum python setup.py nosetests

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -217,6 +217,16 @@ class CutPlot(IPlot):
 
         self._lines_visible[line_index] = line_options['shown']
 
+    def remove_line_by_index(self, line_index):
+        container = self._canvas.figure.gca().containers[line_index]
+        containers = self._canvas.figure.gca().containers
+        container[0].remove()
+        for line in container[1]:
+            line.remove()
+        for line in container[2]:
+            line.remove()
+        containers.remove(container)
+
     def toggle_errorbar(self, line_index, line_options):
         container = self._canvas.figure.gca().containers[line_index]
         error_bar_elements = container.get_children()[1:]

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -218,13 +218,12 @@ class CutPlot(IPlot):
         self._lines_visible[line_index] = line_options['shown']
 
     def remove_line_by_index(self, line_index):
-        container = self._canvas.figure.gca().containers[line_index]
         containers = self._canvas.figure.gca().containers
+        container = containers[line_index]
         container[0].remove()
-        for line in container[1]:
-            line.remove()
-        for line in container[2]:
-            line.remove()
+        for i in range(2)
+            for line in container[i+1]
+                line.remove()
         containers.remove(container)
 
     def toggle_errorbar(self, line_index, line_options):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -221,8 +221,8 @@ class CutPlot(IPlot):
         containers = self._canvas.figure.gca().containers
         container = containers[line_index]
         container[0].remove()
-        for i in range(2)
-            for line in container[i+1]
+        for i in range(2):
+            for line in container[i+1]:
                 line.remove()
         containers.remove(container)
 

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -345,6 +345,13 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
 
+        if line_options['shown'] is None or line_options['legend'] is None:
+            row5 = QtWidgets.QHBoxLayout()
+            layout.addLayout(row5)
+
+        self.delete_button = QtWidgets.QPushButton("Delete", self)
+        row5.addWidget(self.delete_button)
+
         separator = QtWidgets.QFrame()
         separator.setFrameShape(QtWidgets.QFrame.HLine)
         separator.setFrameShadow(QtWidgets.QFrame.Sunken)

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -317,6 +317,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         row3.addWidget(self.line_width)
         row3.addWidget(self.marker_label)
         row3.addWidget(self.line_marker)
+        row5 = QtWidgets.QHBoxLayout()
+        layout.addLayout(row5)
 
         if line_options['error_bar'] is not None:
             self.error_bar_checkbox = QtWidgets.QCheckBox("Show Error Bars")
@@ -338,9 +340,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
             self.show_legend.setEnabled(line_options['shown'])
 
-            row5 = QtWidgets.QHBoxLayout()
-            layout.addLayout(row5)
-
             row5.addWidget(self.show_line)
             row4.addWidget(self.show_legend)
 
@@ -351,10 +350,6 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
-
-        if line_options['shown'] is None or line_options['legend'] is None:
-            row5 = QtWidgets.QHBoxLayout()
-            layout.addLayout(row5)
 
         self.delete_button = QtWidgets.QPushButton("Delete Line", self)
         row5.addWidget(self.delete_button)

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -72,6 +72,7 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         self._view.showLegendsEdited.connect(partial(self._value_modified, 'show_legends'))
         self._view.xLogEdited.connect(partial(self._xy_config_modified, 'x_log'))
         self._view.yLogEdited.connect(partial(self._xy_config_modified, 'y_log'))
+        self._view.removed_line.connect(self.remove_container)
 
         line_options = self._model.get_all_line_options()
         self._view.set_line_options(line_options)
@@ -84,6 +85,9 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
                       'x_grid', 'y_grid', 'show_legends']
         for p in properties:
             setattr(self._view, p, getattr(self._model, p))
+
+    def remove_container(self, index):
+        self._model.remove_line_by_index(index)
 
     def get_new_config(self):
         if self._xy_config['modified']:

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -212,7 +212,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
     def test_remove_line(self):
         self.remove_line_by_index = Mock()
         self.presenter = CutPlotOptionsPresenter(self.view, self.model)
-        
+
         # check line with correct index removed
         self.presenter.remove_container(9)
         self.model.remove_line_by_index.assert_called_once_with(9)

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -208,3 +208,12 @@ class PlotOptionsPresenterTest(unittest.TestCase):
 
         self.view.get_line_options.assert_called_once_with()
         self.model.set_all_line_options.assert_called_once_with(line_data2)
+
+    def test_remove_line(self):
+        self.model.remove_line_by_index = Mock()
+        self.presenter = CutPlotOptionsPresenter(self.view, self.model)
+
+        self.model.remove_line_by_index.assert_called_once_with(3)
+
+        self.presenter.remove_container(7)
+        self.model.remove_line_by_index.assert_called_once_with(7)

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -212,7 +212,8 @@ class PlotOptionsPresenterTest(unittest.TestCase):
     def test_remove_line(self):
         self.model.remove_line_by_index = Mock()
         self.presenter = CutPlotOptionsPresenter(self.view, self.model)
-
+        line_widget_mock = Mock()
+        self.view.remove_line_widget(line_widget_mock, 3)
         self.model.remove_line_by_index.assert_called_once_with(3)
 
         self.presenter.remove_container(7)

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -210,8 +210,9 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.model.set_all_line_options.assert_called_once_with(line_data2)
 
     def test_remove_line(self):
-        self.model.remove_line_by_index = Mock()
+        self.remove_line_by_index = Mock()
         self.presenter = CutPlotOptionsPresenter(self.view, self.model)
-
-        self.presenter.remove_container(7)
-        self.model.remove_line_by_index.assert_called_once_with(7)
+        
+        # check line with correct index removed
+        self.presenter.remove_container(9)
+        self.model.remove_line_by_index.assert_called_once_with(9)

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -212,9 +212,6 @@ class PlotOptionsPresenterTest(unittest.TestCase):
     def test_remove_line(self):
         self.model.remove_line_by_index = Mock()
         self.presenter = CutPlotOptionsPresenter(self.view, self.model)
-        line_widget_mock = Mock()
-        self.view.remove_line_widget(line_widget_mock, 3)
-        self.model.remove_line_by_index.assert_called_once_with(3)
 
         self.presenter.remove_container(7)
         self.model.remove_line_by_index.assert_called_once_with(7)


### PR DESCRIPTION
Added a 'Delete Line' button in the settings dialog for 1D plots. Clicking it removes the LegendAndLineOptionsSetter widget for the respective line as well as the corresponding line in the cut plot.

**To test:**

1. Open a cut plot with several lines.
2. Open the settings dialog from the plot window.
3. Delete one of the lines.
4. Check that the corresponding settings widget is removed from the settings dialog.
5. Check that the corresponding line and its legend is removed from the plot.

Fixes #[549](https://github.com/mantidproject/mslice/issues/549).
