### PR TITLE
Update mslicedevel.bat

### DIFF
--- a/mslicedevel.bat
+++ b/mslicedevel.bat
@@ -5,6 +5,5 @@
 ::
 @set THIS_DIR=%~dp0
 @set PYTHON_EXE=C:\MantidInstall\bin\python.exe
-@set QT_API=pyqt
 
 %THIS_DIR%\scripts\mslice.bat


### PR DESCRIPTION
The line '@set QT_API=pyqt' can be removed now. It is not necessary anymore and causes problems when using mslicedevel.bat.

Description of work.

**To test:**
Ensure that Mantid 6.0 is installed. Ensure that in MantidInstall\bin\mantidpython.bat the following section is included:
if "%QT_API%"=="" (
  set QT_API=pyqt5
  set QT_PLUGIN_PATH=%_BIN_DIR%\..\plugins\qt5
)

N.B. In the future QT_PLUGIN_PATH will be included in mantidpython.bat automatically. 
Run mslicedevel.bat. MSlice standalone should open.
