### PR TITLE
Keep hidden cuts hidden while using exported script

### DIFF
--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -57,7 +57,6 @@ def _update_overplot_checklist(key):
 
 
 def _get_overplot_key(element, rmm):
-
     if element is not None and rmm is not None:
         raise RuntimeError('Cannot use both element name and relative molecular mass')
     if element is None and rmm is None:
@@ -157,3 +156,41 @@ def is_cut(*args):
         return True
     else:
         return False
+
+
+def append_visible_handle(visible_handles, handles, idx: int):
+    handle = handles[idx]
+    visible_handles.append(handle[0])
+    return None
+
+
+def append_visible_label(visible_labels, labels, idx: int):
+    label = labels[idx]
+    visible_labels.append(label)
+    return None
+
+
+def append_visible_handle_and_label(visible_handles, handles, visible_labels, labels, idx: int):
+    append_visible_handle(visible_handles, handles, idx)
+    append_visible_label(visible_labels, labels, idx)
+    return None
+
+
+def show_or_hide_errorbars_of_a_line(container, alpha: float):
+    elements = container.get_children()[1:]
+    for element in elements:
+        element.set_alpha(alpha)
+    return None
+
+
+def show_or_hide_a_line(container, show_or_hide: bool):
+    line = container.get_children()[0]
+    line.set_visible(show_or_hide)
+    return None
+
+
+def hide_a_line_and_errorbars(ax, idx: int):
+    container = ax.containers[idx]
+    show_or_hide_a_line(container, False)
+    show_or_hide_errorbars_of_a_line(container, 0.0)
+    return None

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -222,7 +222,7 @@ class CutPlot(IPlot):
         container = containers[line_index]
         container[0].remove()
         for i in range(2):
-            for line in container[i+1]:
+            for line in container[i + 1]:
                 line.remove()
         containers.remove(container)
 
@@ -308,13 +308,19 @@ class CutPlot(IPlot):
             line_containers[line] = container
         return line_containers
 
-    def get_line_visible(self, line_index):
+    def get_line_visible(self, line_index: int) -> bool:
         try:
-            ret = self._lines_visible[line_index]
-            return ret
+            line_visible = self._lines_visible[line_index]
+            return line_visible
         except KeyError:
-            self._lines_visible[line_index] = True
-            return True
+            try:
+                container = self._canvas.figure.gca().containers[line_index]
+                line = container.get_children()[0]
+                line_visible = line.get_visible()
+            except IndexError:
+                line_visible = True
+            self._lines_visible[line_index] = line_visible
+            return line_visible
 
     def toggle_waterfall(self):
         if self.waterfall:

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -291,12 +291,12 @@ class CutPlot(IPlot):
     def xy_config(self):
         return {'x_log': self.x_log, 'y_log': self.y_log, 'x_range': self.x_range, 'y_range': self.y_range}
 
-    def legend_visible(self, index):
+    def legend_visible(self, index: int) -> bool:
         try:
             v = self._legends_visible[index]
         except IndexError:
-            v = True
-            self._legends_visible.append(True)
+            v = self.get_line_visible(index)
+            self._legends_visible.append(v)
         return v
 
     def line_containers(self):

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -132,6 +132,41 @@ def add_cut_lines(script_lines, plot_handler, ax):
     cuts = plot_handler._cut_plotter_presenter._cut_cache_dict[ax]
     errorbars = plot_handler._canvas.figure.gca().containers
     add_cut_lines_with_width(errorbars, script_lines, cuts)
+    hide_lines(script_lines, plot_handler, ax)
+
+
+def hide_errorbars(script_lines):
+    script_lines.append("elements = container.get_children()[1:] \n")
+    script_lines.append("for element in elements: \n")
+    script_lines.append("    element.set_alpha(0.0) \n\n")
+
+
+def hide_lines(script_lines, plot_handler, ax):
+    """ Check if the line needs to be shown or not (hidden).
+    If the line is hidden, corresponding errorbars and legend
+    are also hidden.
+    """
+    script_lines.append("# hide lines, errorbars, and legends \n")
+    script_lines.append("handles, labels = ax.get_legend_handles_labels() \n")
+    script_lines.append("visible_handles = [] \n")
+    script_lines.append("visible_labels = [] \n\n")
+    idx = -1
+    for container in ax.containers:
+        idx += 1
+        line_options = plot_handler.get_line_options_by_index(idx)
+        if line_options['shown']:
+            # only add handles and labels if the corresponding line is shown
+            script_lines.append(f"handle = handles[{idx:d}] \n")
+            script_lines.append("visible_handles.append(handle[0]) \n")
+            script_lines.append(f"label  = labels[{idx:d}] \n")
+            script_lines.append("visible_labels.append(label) \n\n")
+        else:
+            # Set line visibility to false and alpha of errorbars to 0.0
+            script_lines.append(f"container = ax.containers[{idx:d}] \n")
+            script_lines.append("line = container.get_children()[0] \n")
+            script_lines.append("line.set_visible(False) \n")
+            hide_errorbars(script_lines)
+    script_lines.append("ax.legend(visible_handles, visible_labels, fontsize='medium').set_draggable(True) \n\n")
 
 
 def add_cut_lines_with_width(errorbars, script_lines, cuts):

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -135,57 +135,13 @@ def add_cut_lines(script_lines, plot_handler, ax):
     hide_lines(script_lines, plot_handler, ax)
 
 
-def append_handles_and_labels(script_lines):
-    script_lines.append("def append_visible_handle(visible_handles, handles, idx: int):\n")
-    script_lines.append("    handle = handles[idx]\n")
-    script_lines.append("    visible_handles.append(handle[0])\n")
-    script_lines.append("    return None\n\n")
-
-    script_lines.append("def append_visible_label(visible_labels, labels, idx: int):\n")
-    script_lines.append("    label = labels[idx]\n")
-    script_lines.append("    visible_labels.append(label)\n")
-    script_lines.append("    return None\n\n")
-
-    script_lines.append(
-        "def append_visible_handle_and_label(visible_handles, handles, visible_labels, labels, idx: int):\n")
-    script_lines.append("    append_visible_handle(visible_handles, handles, idx)\n")
-    script_lines.append("    append_visible_label(visible_labels, labels, idx)\n")
-    script_lines.append("    return None\n\n")
-
-
-def hide_errorbars_of_a_line(script_lines):
-    script_lines.append("def show_or_hide_errorbars_of_a_line(container, alpha: float):\n")
-    script_lines.append("    elements = container.get_children()[1:]\n")
-    script_lines.append("    for element in elements:\n")
-    script_lines.append("        element.set_alpha(alpha)\n")
-    script_lines.append("    return None\n\n")
-
-
-def hide_a_line(script_lines):
-    script_lines.append("def show_or_hide_a_line(container, show_or_hide: bool):\n")
-    script_lines.append("    line = container.get_children()[0]\n")
-    script_lines.append("    line.set_visible(show_or_hide)\n")
-    script_lines.append("    return None\n\n")
-
-
-def hide_a_line_and_errorbars(script_lines):
-    script_lines.append("def hide_a_line_and_errorbars(ax, idx: int):\n")
-    script_lines.append("    container = ax.containers[idx]\n")
-    script_lines.append("    show_or_hide_a_line(container, False)\n")
-    script_lines.append("    show_or_hide_errorbars_of_a_line(container, 0.0)\n")
-    script_lines.append("    return None\n\n")
-
-
 def hide_lines(script_lines, plot_handler, ax):
     """ Check if the line needs to be shown or not (hidden).
     If the line is hidden, corresponding errorbars and legend
     are also hidden.
     """
-    script_lines.append("# Definitions of necessary functions\n")
-    hide_a_line(script_lines)
-    hide_errorbars_of_a_line(script_lines)
-    hide_a_line_and_errorbars(script_lines)
-    append_handles_and_labels(script_lines)
+    script_lines.append("from mslice.cli.helperfunctions import hide_a_line_and_errorbars,"
+                        " append_visible_handle_and_label\n\n")
 
     script_lines.append("# hide lines, errorbars, and legends\n")
     script_lines.append("handles, labels = ax.get_legend_handles_labels()\n")

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -154,25 +154,25 @@ def append_handles_and_labels(script_lines):
 
 
 def hide_errorbars_of_a_line(script_lines):
-    script_lines.append("def hide_errorbars_of_a_line(container):\n")
+    script_lines.append("def show_or_hide_errorbars_of_a_line(container, alpha: float):\n")
     script_lines.append("    elements = container.get_children()[1:]\n")
     script_lines.append("    for element in elements:\n")
-    script_lines.append("        element.set_alpha(0.0)\n")
+    script_lines.append("        element.set_alpha(alpha)\n")
     script_lines.append("    return None\n\n")
 
 
 def hide_a_line(script_lines):
-    script_lines.append("def hide_a_line(container):\n")
+    script_lines.append("def show_or_hide_a_line(container, show_or_hide: bool):\n")
     script_lines.append("    line = container.get_children()[0]\n")
-    script_lines.append("    line.set_visible(False)\n")
+    script_lines.append("    line.set_visible(show_or_hide)\n")
     script_lines.append("    return None\n\n")
 
 
 def hide_a_line_and_errorbars(script_lines):
     script_lines.append("def hide_a_line_and_errorbars(ax, idx: int):\n")
     script_lines.append("    container = ax.containers[idx]\n")
-    script_lines.append("    hide_a_line(container)\n")
-    script_lines.append("    hide_errorbars_of_a_line(container)\n")
+    script_lines.append("    show_or_hide_a_line(container, False)\n")
+    script_lines.append("    show_or_hide_errorbars_of_a_line(container, 0.0)\n")
     script_lines.append("    return None\n\n")
 
 


### PR DESCRIPTION
Description of work.

While exporting to a script, the information regarding hidden cuts is lost and the cuts were being shown despite they were hidden. This fix adds the missing information to script and keeps the hidden cuts hidden even while using the exported script.

**To test:**

<!-- Instructions for testing. -->
[hide_curves_start_script.txt](https://github.com/mantidproject/mslice/files/6272766/hide_curves_start_script.txt)
-> Update 'SET_CORRECT_PATH_TO_BUILD_PARENT' to parent directory of build directory in the attached 'hide_curves_start_script.txt'

-> Copy the python script from hide_curves_start_script.txt (make sure the above step is done to be able to read the input file correctly) and paste it in Mantid Workbench Jupyter IPython Console and Enter
-> Matplotlib figure with four lines and legends should show up.

-> Click on 'Plot Options (settings)' symbol on the figure. 
-> In the pop-up Qt window, right side column contains a tab for each and individual cut options
-> Uncheck 'show line' for one or more cuts and click 'Ok' at the bottom

-> Going back to the figure, check that lines, errorbars and legends are not shown for the cuts for which "show line" was unchecked
-> Click 'File-> Generate Script to Clipboard' on the top-left corner of the figure
-> Close the figure
-> Paste the script (in the buffer) in Jupyter IPython Console and Enter

-> Now a new matplotlib figure should show up. Make sure that the cuts for which "show line" was unchecked  are not shown 
-> Also verify that "show line" option for the cuts in "Plot Options (settings)" Qt window is unchecked.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #547.
