### PR TITLE
Apply input fixed final energy to all workspaces if user wants so

### DIFF
--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -34,6 +34,12 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                 file_paths = ['+'.join(file_paths)]
             self._load_ws(file_paths, ws_names, force_overwrite)
 
+    def apply_fixed_final_energy_to_a_workspace(self, ws_name):
+        ws = get_workspace_handle(ws_name)
+        ws.e_fixed = self._EfCache
+        ws.raw_ws.run().addProperty('Efix', self._EfCache, True)
+        get_limits(ws_name, 'DeltaE')  # Necessary to process the limits
+
     def _load_ws(self, file_paths, ws_names, force_overwrite):
         not_loaded = []
         not_opened = []
@@ -57,7 +63,7 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     if not allChecked:
                         allChecked = self.check_efixed(ws_name, multi)
                     else:
-                        get_workspace_handle(ws_name).e_fixed = self._EfCache
+                        self.apply_fixed_final_energy_to_a_workspace(ws_name)
                     if self._main_presenter is not None:
                         self._main_presenter.show_workspace_manager_tab()
                         self._main_presenter.show_tab_for_workspace(get_workspace_handle(ws_name))
@@ -75,9 +81,7 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
         if ws.e_mode == 'Indirect' and not ws.ef_defined:
             Ef, allChecked = self._view.get_workspace_efixed(ws_name, multi, self._EfCache)
             self._EfCache = Ef
-            ws.e_fixed = Ef
-            ws.raw_ws.run().addProperty('Efix', Ef, True)
-            get_limits(ws_name, 'DeltaE')  # This is call needed to process the limits.
+            self.apply_fixed_final_energy_to_a_workspace(ws_name)
             return allChecked
 
     def _confirm_workspace_overwrite(self, ws_name, force_overwrite):


### PR DESCRIPTION
Description of work.

When multiple Indirect related workspaces are loaded and ef_defined is False,
an input dialog box appears to take Efixed value and user may want to apply 
the same Efixed value for all other loaded workspaces by checking apply to all
workspaces. 

Before this fix, for the first workspace following three operations are applied 
        workspace_handle.e_fixed = fixed_final_energy
        workspace_handle.raw_ws.run().addProperty('Efix', fixed_final_energy, True)
        get_limits(workspace_name, 'DeltaE')  # Necessary to process the limits

and for the remaining workspaces only the first operation of the above three is applied.

Now, all three operations are applied for all the workspaces that are loaded together
if the user checks the "Apply to all workspaces" after entering an input value for the
fixed final energy in the input dialog box.



**To test:**

<!-- Instructions for testing. -->

[IrisData.zip](https://github.com/mantidproject/mslice/files/6277524/IrisData.zip)

-> Download "IrisData.zip" and Extract it

-> Open Mantid Workbench
-> Click "Interfaces/Direct/MSlice" (at the top-left corner)

-> Navigate to the above extracted "IrisData" folder
-> Select all three files and click "Load Data"

-> An input dialog box titled "Indirect Ef" will appear
   -> Input a float value (let's say 1.84)
   -> Also check "Apply to all workspaces"
   -> Click "OK"

-> Copy the following and paste in the Mantid Workbench Jupyter IPython Console
   and Enter

    workspace_handle = get_workspace_handle('iris77511_graphite002_red')

    print(workspace_handle.e_fixed)
    print(workspace_handle.raw_ws.run().getProperty('Efix').value)
    limits = workspace_handle.limits
    print(limits is not None and len(limits) > 0)
    print("\n")

    workspace_handle = get_workspace_handle('iris77512_graphite002_red')

    print(workspace_handle.e_fixed)
    print(workspace_handle.raw_ws.run().getProperty('Efix').value)
    limits = workspace_handle.limits
    print(limits is not None and len(limits) > 0)
    print("\n")

    workspace_handle = get_workspace_handle('iris77513_graphite002_red')

    print(workspace_handle.e_fixed)
    print(workspace_handle.raw_ws.run().getProperty('Efix').value)
    limits = workspace_handle.limits
    print(limits is not None and len(limits) > 0)
    print("\n")

-> The following lines should appear three times (once for each workspace)

   1.84 (or value provided in the "Indirect Ef" input dialog box)
   1.84
   True

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #578.
