### PR TITLE
Export correct output workspace_handles to script

### DIFF
--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -87,7 +87,9 @@ def get_algorithm_kwargs(algorithm, existing_ws_refs):
     output_ws = None
     for prop in algorithm.getProperties():
         if not prop.isDefault():
-            pname, pval, output_ws, hidden = _parse_prop(prop)
+            pname, pval, tmp_output_ws, hidden = _parse_prop(prop)
+            if pname == "OutputWorkspace":
+                output_ws = tmp_output_ws
             if hidden:
                 arguments += ["store=False"]
                 continue


### PR DESCRIPTION
Export correct output workspace handles to script

**To test:**

<!-- Instructions for testing. -->
[IrisData.zip](https://github.com/mantidproject/mslice/files/6277713/IrisData.zip)

-> Download "IrisData.zip" and Extract it

-> Open Mantid Workbench
-> Click "Interfaces/Direct/MSlice" (at the top-left corner)

-> Navigate to the above extracted "IrisData" folder
-> Select one of the files and click "Load Data"

-> An input dialog box titled "Indirect Ef" will appear
   -> Input a float value (let's say 1.84)
   -> Click "OK"

-> Choose "Scale" algorithm from the "Compose" options
-> An input dialog box titled "Scale parameters" will appear
   -> Input a float value for scale factor (let's say 0.9)
   -> Click "OK"

-> Choose "Subtract" algorithm
-> A dialog box appears asking to select a workspace to be subtracted
   -> Select second workspace that has "_scaled" in its display name
   -> Click "OK"

-> Among the three available/visible workspaces in the "Workspace Manager" current selection
   would be on the first workspace. Change the selection to the last workspace
   by clicking on it.

-> Go to the right edge and click on "Display" ("Slice" tab should be the active tab among "Powder", "Slice", and "Cut")
-> Matplotlib figure will pop-up
-> Click "File/Generate Script to Clipboard" and close the figure

-> Go to Mantid Workbench Jupyter Python Console and paste the content
   from the buffer (from the "File/Generate Script to Clipboard" click)

-> Check that workspace_handles (left hand side of =) are indeed different and meaningful in relation with the algorithm

-> Refer to #572 to see how the workspace_handles were before this fix

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #572.
