### PR TITLE
Pickup workspace from its name and rewrap the resulting workspace

### DIFF
--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -18,7 +18,8 @@ def _parse_ws_names(args, kwargs):
         input_workspace = get_workspace_handle(kwargs['InputWorkspace'])
         kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(kwargs['InputWorkspace'])
     elif len(args) > 0:
-        input_workspace = get_workspace_handle(args[0])
+        if isinstance(args[0], MsliceWorkspace) or isinstance(args[0], string_types):
+            input_workspace = get_workspace_handle(args[0])
         args = (_name_or_wrapper_to_workspace(args[0]),) + args[1:]
 
     output_name = ''

--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -10,30 +10,35 @@ from mslice.workspace import wrap_workspace
 from mslice.workspace.base import WorkspaceBase as MsliceWorkspace
 from mslice.workspace.workspace import Workspace as MsliceWorkspace2D
 
+
 def _parse_ws_names(args, kwargs):
     input_workspace = None
+
     if 'InputWorkspace' in kwargs:
-        input_workspace = kwargs['InputWorkspace']
+        input_workspace = get_workspace_handle(kwargs['InputWorkspace'])
         kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(kwargs['InputWorkspace'])
     elif len(args) > 0:
-        input_workspace = args[0]
+        input_workspace = get_workspace_handle(args[0])
         args = (_name_or_wrapper_to_workspace(args[0]),) + args[1:]
 
     output_name = ''
     if 'OutputWorkspace' in kwargs:
         output_name = kwargs.pop('OutputWorkspace')
 
-    for ws in [k for k in kwargs.keys() if isinstance(kwargs[k], MsliceWorkspace)]:
-        if input_workspace is None and 'LHS' in ws:
-            input_workspace = kwargs[ws]
-        if 'Input' not in ws and 'Output' not in ws:
-            kwargs[ws] = _name_or_wrapper_to_workspace(kwargs[ws])
+    for key in kwargs.keys():
+        if input_workspace is None and 'LHS' in key:
+            input_workspace = get_workspace_handle(kwargs[key])
+        if 'Input' not in key and 'Output' not in key:
+            if isinstance(kwargs[key], MsliceWorkspace):
+                kwargs[key] = _name_or_wrapper_to_workspace(kwargs[key])
 
-    return (input_workspace, output_name, args, kwargs)
+    return input_workspace, output_name, args, kwargs
+
 
 def _alg_has_outputws(wrapped_alg):
     alg = AlgorithmManager.create(wrapped_alg.__name__)
     return any(['OutputWorkspace' in prop.name for prop in alg.getProperties()])
+
 
 def wrap_algorithm(algorithm):
     def alg_wrapper(*args, **kwargs):
@@ -71,6 +76,7 @@ def wrap_algorithm(algorithm):
                     from mslice.app.presenters import get_slice_plotter_presenter
                     get_slice_plotter_presenter().update_displayed_workspaces()
         return result
+
     return alg_wrapper
 
 


### PR DESCRIPTION
**Description of work.**

Resulting workspace is wrapped 
https://github.com/mantidproject/mslice/blob/c817c9ee255f33eb8ba05b714f0d52bc10be4ac3/mslice/util/mantid/algorithm_wrapper.py#L68-L69

conditionally based on the instance of input_workspace returned by _parse_ws_names . https://github.com/mantidproject/mslice/blob/c817c9ee255f33eb8ba05b714f0d52bc10be4ac3/mslice/util/mantid/algorithm_wrapper.py#L14
https://github.com/mantidproject/mslice/blob/c817c9ee255f33eb8ba05b714f0d52bc10be4ac3/mslice/util/mantid/algorithm_wrapper.py#L36


For this reason, if the workspace is provided through its name, the corresponding workspace_handle was not acquired and the rewrap of the result has been ignored. 

In this fix, if the workspace_name is provided, its handle is acquired using get_workspace_handle and assigned to input_workspace in _parse_ws_names.

**To test:**

<!-- Instructions for testing. -->

In Workbench IPython

import mslice.cli as mc

ws_MAR21335_Ei60meV = mc.Load(Filename='.../build/ExternalData/Testing/Data/UnitTest\MAR21335_Ei60meV.nxs', OutputWorkspace='MAR21335_Ei60meV') #  Provide correct path
ws1 = mc.Scale('MAR21335_Ei60meV', 2, OutputWorkspace='ws_scale')
ws2 = mc.Minus(LHSWorkspace='ws_scale', RHSWorkspace='MAR21335_Ei60meV', OutputWorkspace='ws_minus')
sl = mc.Slice('ws_minus', Axis1='|Q|', Axis2='DeltaE')

The above lines should not raise any error.

On master branch, before merging this branch, the above lines raise an error.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #531.
