### PR TITLE
Release active interactive cuts on existing slice plots to enable a new slice plot

### DIFF
--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -12,6 +12,18 @@ from mslice.plotting.plot_window.plot_window import PlotWindow
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.cut_plot import CutPlot
 import mslice.plotting.pyplot as plt
+from mslice.plotting.globalfiguremanager import GlobalFigureManager
+
+
+def release_active_interactive_cuts_on_slice_plots() -> None:
+    for each_figure in GlobalFigureManager.all_figures():
+        plot_handler = each_figure.plot_handler
+        if isinstance(plot_handler, SlicePlot):
+            action_icuts = plot_handler.plot_window.action_interactive_cuts
+            if not action_icuts.isChecked():
+                continue
+            plot_handler.toggle_interactive_cuts()
+            action_icuts.setChecked(False)
 
 
 class PlotFigureManagerQT(QtCore.QObject):
@@ -87,6 +99,7 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.window.flag_as_current()
 
     def add_slice_plot(self, slice_plotter_presenter, workspace):
+        release_active_interactive_cuts_on_slice_plots()
         if self.plot_handler is None:
             # Move the top right corner of all slice plot windows to the left of the screen centre by 1.05
             # the window width and above the screen center by half the window height to prevent cuts/interactive cuts

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -164,7 +164,7 @@ class SlicePlot(IPlot):
 
     def update_legend(self):
         axes = self._canvas.figure.gca()
-        lgn = axes.legend()
+        lgn = axes.get_legend()
         if lgn:
             legend_set_draggable(lgn, True)
 

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -141,7 +141,8 @@ def hide_lines(script_lines, plot_handler, ax):
     are also hidden.
     """
     script_lines.append("from mslice.cli.helperfunctions import hide_a_line_and_errorbars,"
-                        " append_visible_handle_and_label\n\n")
+                        " append_visible_handle_and_label\n")
+    script_lines.append("from mslice.util.compat import legend_set_draggable\n\n")
 
     script_lines.append("# hide lines, errorbars, and legends\n")
     script_lines.append("handles, labels = ax.get_legend_handles_labels()\n")
@@ -157,7 +158,8 @@ def hide_lines(script_lines, plot_handler, ax):
                 f"\nappend_visible_handle_and_label(visible_handles, handles, visible_labels, labels, {idx:d})\n")
         else:
             script_lines.append(f"\nhide_a_line_and_errorbars(ax, {idx:d})\n")
-    script_lines.append("\nax.legend(visible_handles, visible_labels, fontsize='medium').set_draggable(True)\n\n")
+    script_lines.append("\nlegend_set_draggable(ax.legend(visible_handles, visible_labels,"
+                        " fontsize='medium'), True)\n\n")
 
 
 def add_cut_lines_with_width(errorbars, script_lines, cuts):

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -91,7 +91,7 @@ class SlicePlotTest(unittest.TestCase):
 
         self.slice_plot.update_legend()
 
-        self.axes.legend.assert_called_once()
+        self.axes.get_legend.assert_called_once()
         if hasattr(Legend, "set_draggable"):
             self.axes.legend().set_draggable.assert_called_once()
         else:

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -93,9 +93,9 @@ class SlicePlotTest(unittest.TestCase):
 
         self.axes.get_legend.assert_called_once()
         if hasattr(Legend, "set_draggable"):
-            self.axes.legend().set_draggable.assert_called_once()
+            self.axes.get_legend().set_draggable.assert_called_once()
         else:
-            self.axes.legend().draggable.assert_called_once()
+            self.axes.get_legend().draggable.assert_called_once()
 
         self.assertEqual(self.slice_plot._canvas.manager.plot_handler.icut.rect.ax, self.axes)
 


### PR DESCRIPTION
**Description of work.**

The function added in this fix goes through all the existing slice plots, releases (toggles) active interactive_cuts.
When a slice plot is requested, the function is called.

**To test:**

<!-- Instructions for testing. -->
Please see #601

With this fix, a crash should not happen.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #601
