### PR TITLE
Replace MantidPlot with MantidWorkbench in documentation

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -11,7 +11,7 @@ default (e.g. if the axes titles or limits have been changed or additional infor
 
 .. image:: images/cli/generate_script_menu.png
 
-Generated scripts may be run from the MantidPlot script window (accessible using ``F3``).
+Generated scripts may be run from the MantidWorkbench script window.
 
 Alternatively, the script can also be run from the IPython console in the MSlice GUI using the ``import`` directive and the ``reload`` 
 (``importlib.reload`` in Python 3) function. For example, the first time the script is run, do:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -4,7 +4,7 @@ Quick Start
 Starting MSlice
 ---------------
 
-MSlice is included in the Mantid distribution so the easiest way to start it is from the **Interfaces** menu in *MantidPlot*.
+MSlice is included in the Mantid distribution so the easiest way to start it is from the **Interfaces** menu in *MantidWorkbench*.
 
 .. image:: images/quickstart/mantid_interfaces_menu.png
 
@@ -12,7 +12,7 @@ The version of *MSlice* distributed with Mantid is the last stable version. Howe
 devlopment to the program, which is available only in the development version on `GitHub`. To get this version, please
 download this `zip <https://github.com/mantidproject/mslice/archive/master.zip>`_ and extract it to a folder on your computer.
 You can then either copy the ``mslice`` subfolder (the folder containing a file called ``__init__.py``) to the 
-``scripts/ExternalInterfaces/`` folder of *Mantid*, which will make the new version accessible from *MantidPlot*, or run the
+``scripts/ExternalInterfaces/`` folder of *Mantid*, which will make the new version accessible from *MantidWorkbench*, or run the
 the ``mslicedevel.bat`` (or ``mslicedevel.sh`` for Linux) script to start *MSlice*. You may have to edit the file first if
 you did not install *Mantid* in the default location.
 


### PR DESCRIPTION

**To test:**

MantidPlot should not be mentioned anymore in the MSlice documentation.

Fixes #[605](https://github.com/mantidproject/mslice/issues/605).
