### PR TITLE
Fixes problems for empty plots

### DIFF
--- a/mslice/plotting/globalfiguremanager.py
+++ b/mslice/plotting/globalfiguremanager.py
@@ -69,6 +69,9 @@ class GlobalFigureManager(object):
         """
         if not cls.has_fignum(num):
             return
+        if num in cls._unclassified_figures:
+            cls._unclassified_figures.remove(num)
+            return
         category = cls.get_category(num)
         if cls._active_figure == num:
             cls._active_figure = None

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -40,7 +40,10 @@ class PlotWindow(QtWidgets.QMainWindow):
 
     def showEvent(self, evt):
         if not self._first_time_show:
-            self.canvas.manager.plot_handler.save_default_options()
+            try:
+                self.canvas.manager.plot_handler.save_default_options()
+            except AttributeError:
+                pass
             self._first_time_show = True
         super(PlotWindow, self).showEvent(evt)
 


### PR DESCRIPTION
There are two fixes combined in here:
1. When displaying an empty plot window the AttributeError when calling save_default_options() without having a Cut or Slice window is caught.
2. When destroying a plot window that is neither Cut nor Slice window this window is removed from _unclassified_figures but not treated as a plot window with a category which would cause an exception and crash Mantid.

**To test:**

Use data and script from original issue: https://github.com/mantidproject/mslice/issues/610 and the current beta version from Mantid (with Mantid 6.0 this will be masked by a different bug).

Fixes #[610](https://github.com/mantidproject/mslice/issues/610).
