### PR TITLE
Raise or bring forward plot window for plotover

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -250,7 +250,9 @@ class CutPlot(IPlot):
         self.plot_window.action_gen_script.setVisible(not is_icut)
         self.plot_window.action_waterfall.setVisible(not is_icut)
 
-        self.plot_window.show()
+        self.plot_window.showNormal()
+        self.plot_window.activateWindow()
+        self.plot_window.raise_()
         self._is_icut = is_icut
 
     def save_icut(self):


### PR DESCRIPTION
**Description of work.**

When a `cut plot` is requested via the `plotover` option on an existing plot window, this fix brings the `plot window` to the top if it was minimized or forward if it was in the background.

The fix is inspired by

https://github.com/mantidproject/mslice/blob/33239062a80caf9d61f2b8167f9551e8b8768f82/mslice/plotting/plot_window/plot_figure_manager.py#L55-L58

**To test:**

-> Make a cut plot using `MSlice`
-> Minimize the above cut plot window (or bring forward some other window so that the plot window goes to the background)
-> Plot another cut using the plotover option 
-> Check if the plot window raises to the top if it was minimized or comes forward if it was in the background

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #612.
