### PR TITLE
Updated online documentation and added Github workflow for this

### DIFF
--- a/.github/workflows/onlinedocupdate.yml
+++ b/.github/workflows/onlinedocupdate.yml
@@ -1,0 +1,22 @@
+name: MSlice online documentation update
+
+on:
+  push:
+    paths:
+      - 'mslice\__init__.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+    - name: Build and Commit
+      uses: sphinx-notes/pages@master
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: gh-pages

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
 ]
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'MSlice'
-copyright = u'2016, Mantid Project'
+copyright = u'2021, Mantid Project'
 author = u'Mantid Project'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/mslice/__init__.py
+++ b/mslice/__init__.py
@@ -6,6 +6,6 @@ A PyQt-based version of the MSlice (http://mslice.isis.rl.ac.uk) program based
 on Mantid (http://www.mantidproject.org).
 """
 
-version_info = (2, 2, 0, "dev0")
+version_info = (2, 2, 0)
 __version__ = '.'.join(map(str, version_info))
 __project_url__ = 'https://github.com/mantidproject/mslice'

--- a/mslice/__init__.py
+++ b/mslice/__init__.py
@@ -6,6 +6,6 @@ A PyQt-based version of the MSlice (http://mslice.isis.rl.ac.uk) program based
 on Mantid (http://www.mantidproject.org).
 """
 
-version_info = (1, 2, 0, "dev0")
+version_info = (2, 2, 0, "dev0")
 __version__ = '.'.join(map(str, version_info))
 __project_url__ = 'https://github.com/mantidproject/mslice'


### PR DESCRIPTION
The gh-pages branch is used to populate https://mantidproject.github.io/mslice/ 
For this the *.rst files in docs have to be converted into html using Sphinx.

The work included
- Updating the MSlice version number
- Updating the Sphinx configuration file conf.py
- Adding a GitHub workflow to run Sphinx automatically whenever the MSlice version number is updated and push the html docs to the gh-pages branch

**To test:**

Please note that the new Github workflow can only be tested once this PR is merged into master.

To test the first two changes install Sphinx locally (`pip install -U sphinx`) and run `make html` in the docs folder of mslice.

Fixes #[617](https://github.com/mantidproject/mslice/issues/617).
