### PR TITLE
Minor modification to workflow for html doc update

### DIFF
--- a/.github/workflows/onlinedocupdate.yml
+++ b/.github/workflows/onlinedocupdate.yml
@@ -15,6 +15,8 @@ jobs:
         fetch-depth: 0
     - name: Build and Commit
       uses: sphinx-notes/pages@master
+      with:
+        documentation_path: docs/source
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/onlinedocupdate.yml
+++ b/.github/workflows/onlinedocupdate.yml
@@ -1,9 +1,9 @@
 name: MSlice online documentation update
 
 on:
-  push
-    #paths:
-      #- 'mslice\__init__.py'
+  push:
+    paths:
+      - 'mslice\__init__.py'
 
 jobs:
   build:

--- a/.github/workflows/onlinedocupdate.yml
+++ b/.github/workflows/onlinedocupdate.yml
@@ -1,9 +1,9 @@
 name: MSlice online documentation update
 
 on:
-  push:
-    paths:
-      - 'mslice\__init__.py'
+  push
+    #paths:
+      #- 'mslice\__init__.py'
 
 jobs:
   build:

--- a/mslice/__init__.py
+++ b/mslice/__init__.py
@@ -6,6 +6,6 @@ A PyQt-based version of the MSlice (http://mslice.isis.rl.ac.uk) program based
 on Mantid (http://www.mantidproject.org).
 """
 
-version_info = (2, 3, 0, "dev0")
+version_info = (2, 3, 0, "dev")
 __version__ = '.'.join(map(str, version_info))
 __project_url__ = 'https://github.com/mantidproject/mslice'


### PR DESCRIPTION
The workflow for the html doc update needed a minor update as sphinx could not find the documentation source code. This is fixed now and after a successful test https://mantidproject.github.io/mslice/ is updated to the current MSlice version in development.

**To Test**

https://mantidproject.github.io/mslice/ should have the version number "2.3.0.dev "