### PR TITLE
Restore checked over-plot lines on a re-plotted slice

### DIFF
--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -36,6 +36,8 @@ def _show_plot(slice_cache, workspace):
     if cur_fig.canvas.manager.plot_handler.icut is not None:
         cur_fig.canvas.manager.plot_handler.icut.rect.ax = ax
 
+    cur_fig.canvas.manager.plot_handler._update_lines()
+
     cur_fig.canvas.draw_idle()
     cur_fig.show()
 


### PR DESCRIPTION
**Description of work.**

Let say over-plots lines are plotted on an existing slice plot and then
the slice plot is re-plotted on the same plot window.

Previously plotted (checked) over-plot lines do not appear on the new slice plot.

This fix plots previously over-plotted lines on the re-plotted slice.

**To test:**
<!-- Instructions for testing. -->
--> Plot a slice of a workspace (using Display)
--> Over-plot lines using Information/ recoil lines (or) Bragg  peaks from the menu
--> Re-plot slice (using Display)
--> Without this fix, only the slice would appear when re-plotted
--> With this fix, all the previously over-plotted lines should also appear when the slice is re-plotted


<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #515.