### PR TITLE
Enable powder(Bragg) peaks on cut plots

### DIFF
--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -16,6 +16,7 @@ class Cut(object):
         self.width = width
         self.algorithm = algorithm
         self.workspace_name = 'None'
+        self.rotated = False
 
     def reset_integration_axis(self, start, end):
         self.integration_axis.start = start

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -14,11 +14,14 @@ DELTA_E_LABEL = 'DeltaE'
 TWOTHETA_UNITS = ('Degrees', '2Theta')
 MOMENTUM_UNITS = ('MomentumTransfer', '|Q|')
 
+
 def is_twotheta(unit):
     return any([unit in val for val in TWOTHETA_UNITS])
 
+
 def is_momentum(unit):
     return any([unit in val for val in MOMENTUM_UNITS])
+
 
 def get_recoil_key(label):
     for key, value in recoil_labels.items():
@@ -47,3 +50,11 @@ def generate_legend(workspace_name, integrated_dim, integration_start, integrati
     integrated_dim = mappings[integrated_dim] if integrated_dim in mappings else integrated_dim
     return workspace_name + " " + "%.2f" % integration_start + "<" + integrated_dim + "<" + \
         "%.2f" % integration_end
+
+
+def get_recoil_label(key) -> str:
+    if key in recoil_labels:
+        label = recoil_labels[key]
+    else:
+        label = 'Relative mass ' + str(key)
+    return label

--- a/mslice/models/powder/powder_functions.py
+++ b/mslice/models/powder/powder_functions.py
@@ -64,6 +64,4 @@ def _crystal_structure(ws_name, element, cif_file):
         LoadCIF(Workspace=ws, InputFile=cif_file)
         return ws.sample().getCrystalStructure()
     else:
-        return CrystalStructure(crystal_structure[element][0],
-                                crystal_structure[element][1],
-                                crystal_structure[element][2])
+        return CrystalStructure(*crystal_structure[element])

--- a/mslice/models/powder/powder_functions.py
+++ b/mslice/models/powder/powder_functions.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+from scipy import constants
+
+from mantid.geometry import CrystalStructure, ReflectionGenerator, ReflectionConditionFilter
+
+from mslice.models.labels import is_momentum, is_twotheta
+from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
+from mslice.util.mantid.mantid_algorithms import LoadCIF
+
+# energy to wavelength conversion E = h^2/(2*m_n*l^2)
+E2L = 1.e23 * constants.h ** 2 / (2 * constants.m_n * constants.e)
+
+crystal_structure = {'Copper': ['3.6149 3.6149 3.6149', 'F m -3 m', 'Cu 0 0 0 1.0 0.05'],
+                     'Aluminium': ['4.0495 4.0495 4.0495', 'F m -3 m', 'Al 0 0 0 1.0 0.05'],
+                     'Niobium': ['3.3004 3.3004 3.3004', 'I m -3 m', 'Nb 0 0 0 1.0 0.05'],
+                     'Tantalum': ['3.3013 3.3013 3.3013', 'I m -3 m', 'Ta 0 0 0 1.0 0.05']}
+
+
+def compute_dvalues(d_min, d_max, structure):
+    generator = ReflectionGenerator(structure)
+    hkls = generator.getUniqueHKLsUsingFilter(d_min, d_max,
+                                              ReflectionConditionFilter.StructureFactor)
+    dvalues = np.sort(np.array(generator.getDValues(hkls)))[::-1]
+    return dvalues
+
+
+def _compute_powder_line_momentum(ws_name, q_axis, element, cif_file):
+    two_pi = 2.0 * np.pi
+    d_min = two_pi / q_axis.end
+    d_max = two_pi / q_axis.start
+    structure = _crystal_structure(ws_name, element, cif_file)
+    dvalues = compute_dvalues(d_min, d_max, structure)
+    x = two_pi / dvalues
+    return x
+
+
+def _compute_powder_line_degrees(ws_name, theta_axis, element, efixed, cif_file):
+    wavelength = np.sqrt(E2L / efixed)
+    d_min = wavelength / (2 * np.sin(np.deg2rad(theta_axis.end * 0.5)))
+    d_max = wavelength / (2 * np.sin(np.deg2rad(theta_axis.start * 0.5)))
+    structure = _crystal_structure(ws_name, element, cif_file)
+    dvalues = compute_dvalues(d_min, d_max, structure)
+    x = 2 * np.arcsin(wavelength / 2 / dvalues) * 180 / np.pi
+    return x
+
+
+def compute_powder_line(ws_name, axis, element, cif_file=False):
+    efixed = get_workspace_handle(ws_name).e_fixed
+    if is_momentum(axis.units):
+        x0 = _compute_powder_line_momentum(ws_name, axis, element, cif_file)
+    elif is_twotheta(axis.units):
+        x0 = _compute_powder_line_degrees(ws_name, axis, element, efixed, cif_file)
+    else:
+        raise RuntimeError("units of axis not recognised")
+    x = sum([[xv, xv, np.nan] for xv in x0], [])
+    y = sum([[efixed / 20, -efixed / 20, np.nan] for xv in x0], [])
+    return x, y
+
+
+def _crystal_structure(ws_name, element, cif_file):
+    if cif_file:
+        ws = get_workspace_handle(ws_name).raw_ws
+        LoadCIF(Workspace=ws, InputFile=cif_file)
+        return ws.sample().getCrystalStructure()
+    else:
+        return CrystalStructure(crystal_structure[element][0],
+                                crystal_structure[element][1],
+                                crystal_structure[element][2])

--- a/mslice/models/powder/powder_functions.py
+++ b/mslice/models/powder/powder_functions.py
@@ -28,7 +28,7 @@ def compute_dvalues(d_min, d_max, structure):
 def _compute_powder_line_momentum(ws_name, q_axis, element, cif_file):
     two_pi = 2.0 * np.pi
     d_min = two_pi / q_axis.end
-    d_max = two_pi / q_axis.start
+    d_max = two_pi / np.max([q_axis.start, 0.01])
     structure = _crystal_structure(ws_name, element, cif_file)
     dvalues = compute_dvalues(d_min, d_max, structure)
     x = two_pi / dvalues

--- a/mslice/models/units.py
+++ b/mslice/models/units.py
@@ -98,4 +98,4 @@ class EnergyUnits(object):
 
 def convert_energy_to_meV(y, energy_axis_units):
     if 'meV' not in energy_axis_units:
-        y = np.array(y) * EnergyUnits(energy_axis_units).factor_from_meV()
+        return np.array(y) * EnergyUnits(energy_axis_units).factor_from_meV()

--- a/mslice/models/units.py
+++ b/mslice/models/units.py
@@ -7,11 +7,15 @@ are defined, but they are separated into a module for possible future expansion.
 from __future__ import (absolute_import, division, print_function)
 from mslice.util import MPL_COMPAT
 
+import numpy as np
+
+
 def _scale_string_or_float(value, scale):
     try:
         return '{:.5f}'.format(float(value) * scale)
     except (ValueError, TypeError):
         return value
+
 
 def get_sample_temperature_from_string(string):
     if string is not None and string.strip():
@@ -23,6 +27,7 @@ def get_sample_temperature_from_string(string):
         except ValueError:
             return None
     return None
+
 
 class EnergyUnits(object):
 
@@ -89,3 +94,8 @@ class EnergyUnits(object):
     @classmethod
     def get_all_units(cls):
         return cls._available_units
+
+
+def convert_energy_to_meV(y, energy_axis_units):
+    if 'meV' not in energy_axis_units:
+        y = np.array(y) * EnergyUnits(energy_axis_units).factor_from_meV()

--- a/mslice/models/units.py
+++ b/mslice/models/units.py
@@ -99,3 +99,5 @@ class EnergyUnits(object):
 def convert_energy_to_meV(y, energy_axis_units):
     if 'meV' not in energy_axis_units:
         return np.array(y) * EnergyUnits(energy_axis_units).factor_from_meV()
+    else:
+        return y

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -61,6 +61,7 @@ class CutPlot(IPlot):
     def setup_connections(self, plot_window):
         plot_window.redraw.connect(self._canvas.draw)
         plot_window.menu_intensity.setDisabled(True)
+        plot_window.menu_recoil_lines.setDisabled(True)
         plot_window.action_interactive_cuts.setVisible(False)
         plot_window.action_save_cut.setVisible(False)
         plot_window.action_save_cut.triggered.connect(self.save_icut)

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from matplotlib.container import ErrorbarContainer
 from matplotlib.legend import Legend
 import warnings
@@ -8,6 +10,8 @@ from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.plotting.plot_window.plot_options import CutPlotOptions
 from mslice.plotting.plot_window.iplot import IPlot
+from mslice.plotting.plot_window.overplot_interface import toggle_overplot_line,\
+    cif_file_powder_line
 from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
 
@@ -57,7 +61,6 @@ class CutPlot(IPlot):
     def setup_connections(self, plot_window):
         plot_window.redraw.connect(self._canvas.draw)
         plot_window.menu_intensity.setDisabled(True)
-        plot_window.menu_information.setDisabled(True)
         plot_window.action_interactive_cuts.setVisible(False)
         plot_window.action_save_cut.setVisible(False)
         plot_window.action_save_cut.triggered.connect(self.save_icut)
@@ -69,12 +72,27 @@ class CutPlot(IPlot):
         plot_window.waterfall_x_edt.editingFinished.connect(self.toggle_waterfall)
         plot_window.waterfall_y_edt.editingFinished.connect(self.toggle_waterfall)
         self.mpl_axes_changed = self._canvas.figure.gca().add_callback(self.on_newplot)
+        plot_window.action_aluminium.triggered.connect(
+            partial(toggle_overplot_line, self, self._cut_plotter_presenter, 'Aluminium', False))
+        plot_window.action_copper.triggered.connect(
+            partial(toggle_overplot_line, self, self._cut_plotter_presenter, 'Copper', False))
+        plot_window.action_niobium.triggered.connect(
+            partial(toggle_overplot_line, self, self._cut_plotter_presenter, 'Niobium', False))
+        plot_window.action_tantalum.triggered.connect(
+            partial(toggle_overplot_line, self, self._cut_plotter_presenter, 'Tantalum', False))
+        plot_window.action_cif_file.triggered.connect(partial(cif_file_powder_line, self,
+                                                              self._cut_plotter_presenter))
 
     def disconnect(self, plot_window):
         plot_window.action_save_cut.triggered.disconnect()
         plot_window.action_flip_axis.triggered.disconnect()
         plot_window.action_gen_script.triggered.disconnect()
         self._canvas.figure.gca().remove_callack(self.mpl_axes_changed)
+        plot_window.action_aluminium.triggered.disconnect()
+        plot_window.action_copper.triggered.disconnect()
+        plot_window.action_niobium.triggered.disconnect()
+        plot_window.action_tantalum.triggered.disconnect()
+        plot_window.action_cif_file.triggered.disconnect()
 
     def window_closing(self):
         icut = self._cut_plotter_presenter.get_icut()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -372,6 +372,11 @@ class CutPlot(IPlot):
         num_lines = len(line_containers)
         self.plot_window.action_waterfall.setEnabled(num_lines > 1)
         self.plot_window.toggle_waterfall_edit()
+        self.plot_window.action_aluminium.setChecked(False)
+        self.plot_window.action_copper.setChecked(False)
+        self.plot_window.action_niobium.setChecked(False)
+        self.plot_window.action_tantalum.setChecked(False)
+        self.plot_window.action_cif_file.setChecked(False)
         all_lines = [line for container in line_containers for line in container.get_children()]
         for cached_lines in list(self._waterfall_cache.keys()):
             if cached_lines not in all_lines:

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -1,0 +1,34 @@
+def _update_overplot_lines(plotter_presenter, ws_name, lines):
+    for line in lines:
+        if line.isChecked():
+            plotter_presenter.add_overplot_line(ws_name, *lines[line])
+
+
+def _update_powder_lines(plot_handler, plotter_presenter):
+    """ Updates the powder overplots lines when intensity type changes """
+    lines = {plot_handler.plot_window.action_aluminium: ['Aluminium', False, ''],
+             plot_handler.plot_window.action_copper: ['Copper', False, ''],
+             plot_handler.plot_window.action_niobium: ['Niobium', False, ''],
+             plot_handler.plot_window.action_tantalum: ['Tantalum', False, ''],
+             plot_handler.plot_window.action_cif_file: [plot_handler._cif_file, False, plot_handler._cif_path]}
+    _update_overplot_lines(plotter_presenter, plot_handler.ws_name, lines)
+
+
+def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, cif_file=None):
+    last_active_figure_number = None
+    if plot_handler.manager._current_figs._active_figure is not None:
+        last_active_figure_number = plot_handler.manager._current_figs.get_active_figure().number
+    plot_handler.manager.report_as_current()
+
+    if checked:
+        plotter_presenter.add_overplot_line(plot_handler.ws_name, key, recoil, cif_file)
+    else:
+        plotter_presenter.hide_overplot_line(plot_handler.ws_name, key)
+
+    plot_handler.update_legend()
+    plot_handler._canvas.draw()
+
+    # Reset current active figure
+    if last_active_figure_number is not None:
+        plot_handler.manager._current_figs.set_figure_as_current(last_active_figure_number)
+

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -31,4 +31,3 @@ def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, 
     # Reset current active figure
     if last_active_figure_number is not None:
         plot_handler.manager._current_figs.set_figure_as_current(last_active_figure_number)
-

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -1,3 +1,8 @@
+from qtpy.QtWidgets import QFileDialog
+
+import os.path as path
+
+
 def _update_overplot_lines(plotter_presenter, ws_name, lines):
     for line in lines:
         if line.isChecked():
@@ -10,7 +15,8 @@ def _update_powder_lines(plot_handler, plotter_presenter):
              plot_handler.plot_window.action_copper: ['Copper', False, ''],
              plot_handler.plot_window.action_niobium: ['Niobium', False, ''],
              plot_handler.plot_window.action_tantalum: ['Tantalum', False, ''],
-             plot_handler.plot_window.action_cif_file: [plot_handler._cif_file, False, plot_handler._cif_path]}
+             plot_handler.plot_window.action_cif_file: [plot_handler._cif_file,
+                                                        False, plot_handler._cif_path]}
     _update_overplot_lines(plotter_presenter, plot_handler.ws_name, lines)
 
 
@@ -31,3 +37,21 @@ def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, 
     # Reset current active figure
     if last_active_figure_number is not None:
         plot_handler.manager._current_figs.set_figure_as_current(last_active_figure_number)
+
+
+def cif_file_powder_line(plot_handler, plotter_presenter, checked):
+    if checked:
+        cif_path = QFileDialog().getOpenFileName(plot_handler.plot_window,
+                                                 'Open CIF file', '/home',
+                                                 'Files (*.cif)')
+        cif_path = str(cif_path[0]) if isinstance(cif_path, tuple) else str(cif_path)
+        key = path.basename(cif_path).rsplit('.')[0]
+        plot_handler._cif_file = key
+        plot_handler._cif_path = cif_path
+    else:
+        key = plot_handler._cif_file
+        cif_path = None
+    if key:
+        recoil = False
+        toggle_overplot_line(plot_handler, plotter_presenter, key, recoil,
+                             checked, cif_file=cif_path)

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -2,6 +2,13 @@ from qtpy.QtWidgets import QFileDialog
 
 import os.path as path
 
+from mslice.models.labels import get_recoil_label
+import mslice.plotting.pyplot as plt
+
+OVERPLOT_COLORS = {1: 'b', 2: 'g', 4: 'r', 'Aluminium': 'g',
+                   'Copper': 'm', 'Niobium': 'y', 'Tantalum': 'b'}
+PICKER_TOL_PTS = 5
+
 
 def _update_overplot_lines(plotter_presenter, ws_name, lines):
     for line in lines:
@@ -55,3 +62,24 @@ def cif_file_powder_line(plot_handler, plotter_presenter, checked):
         recoil = False
         toggle_overplot_line(plot_handler, plotter_presenter, key, recoil,
                              checked, cif_file=cif_path)
+
+
+def remove_line(line):
+    plt.gca().lines.remove(line)
+
+
+def plot_overplot_line(x, y, key, recoil, cache):
+    color = OVERPLOT_COLORS[key] if key in OVERPLOT_COLORS else 'c'
+    if recoil:
+        return overplot_line(x, y, color, get_recoil_label(key), cache.rotated)
+    else:
+        return overplot_line(x, y, color, key, cache.rotated)
+
+
+def overplot_line(x, y, color, label, rotated):
+    if rotated:
+        return plt.gca().plot(y, x, color=color, label=label, alpha=.7,
+                              picker=PICKER_TOL_PTS)[0]
+    else:
+        return plt.gca().plot(x, y, color=color, label=label, alpha=.7,
+                              picker=PICKER_TOL_PTS)[0]

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -18,6 +18,41 @@ from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
 
 
+def _update_overplot_lines(plotter_presenter, ws_name, lines):
+    for line in lines:
+        if line.isChecked():
+            plotter_presenter.add_overplot_line(ws_name, *lines[line])
+
+
+def _update_powder_lines(plot_handler, plotter_presenter):
+    """ Updates the powder overplots lines when intensity type changes """
+    lines = {plot_handler.plot_window.action_aluminium: ['Aluminium', False, ''],
+             plot_handler.plot_window.action_copper: ['Copper', False, ''],
+             plot_handler.plot_window.action_niobium: ['Niobium', False, ''],
+             plot_handler.plot_window.action_tantalum: ['Tantalum', False, ''],
+             plot_handler.plot_window.action_cif_file: [plot_handler._cif_file, False, plot_handler._cif_path]}
+    _update_overplot_lines(plotter_presenter, plot_handler.ws_name, lines)
+
+
+def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, cif_file=None):
+    last_active_figure_number = None
+    if plot_handler.manager._current_figs._active_figure is not None:
+        last_active_figure_number = plot_handler.manager._current_figs.get_active_figure().number
+    plot_handler.manager.report_as_current()
+
+    if checked:
+        plotter_presenter.add_overplot_line(plot_handler.ws_name, key, recoil, cif_file)
+    else:
+        plotter_presenter.hide_overplot_line(plot_handler.ws_name, key)
+
+    plot_handler.update_legend()
+    plot_handler._canvas.draw()
+
+    # Reset current active figure
+    if last_active_figure_number is not None:
+        plot_handler.manager._current_figs.set_figure_as_current(last_active_figure_number)
+
+
 class SlicePlot(IPlot):
 
     def __init__(self, figure_manager, slice_plotter_presenter, workspace_name):
@@ -96,20 +131,20 @@ class SlicePlot(IPlot):
             partial(self.show_intensity_plot, plot_window.action_gdos, self._slice_plotter_presenter.show_gdos, True))
 
         plot_window.action_hydrogen.triggered.connect(
-            partial(self.toggle_overplot_line, 1, True))
+            partial(toggle_overplot_line, self, self._slice_plotter_presenter, 1, True))
         plot_window.action_deuterium.triggered.connect(
-            partial(self.toggle_overplot_line, 2, True))
+            partial(toggle_overplot_line, self, self._slice_plotter_presenter, 2, True))
         plot_window.action_helium.triggered.connect(
-            partial(self.toggle_overplot_line, 4, True))
+            partial(toggle_overplot_line, self, self._slice_plotter_presenter, 4, True))
         plot_window.action_arbitrary_nuclei.triggered.connect(self.arbitrary_recoil_line)
         plot_window.action_aluminium.triggered.connect(
-            partial(self.toggle_overplot_line, 'Aluminium', False))
+            partial(toggle_overplot_line, self, self._slice_plotter_presenter, 'Aluminium', False))
         plot_window.action_copper.triggered.connect(
-            partial(self.toggle_overplot_line, 'Copper', False))
+            partial(toggle_overplot_line, self, self._slice_plotter_presenter, 'Copper', False))
         plot_window.action_niobium.triggered.connect(
-            partial(self.toggle_overplot_line, 'Niobium', False))
+            partial(toggle_overplot_line, self, self._slice_plotter_presenter, 'Niobium', False))
         plot_window.action_tantalum.triggered.connect(
-            partial(self.toggle_overplot_line, 'Tantalum', False))
+            partial(toggle_overplot_line, self, self._slice_plotter_presenter, 'Tantalum', False))
         plot_window.action_cif_file.triggered.connect(partial(self.cif_file_powder_line))
         plot_window.action_gen_script.triggered.connect(self.generate_script)
         plot_window.action_gen_script_clipboard.triggered.connect(lambda: self.generate_script(clipboard=True))
@@ -226,24 +261,6 @@ class SlicePlot(IPlot):
         bounds['x_label'] = fig_y * 0.05
         return bounds
 
-    def toggle_overplot_line(self, key, recoil, checked, cif_file=None):
-        last_active_figure_number = None
-        if self.manager._current_figs._active_figure is not None:
-            last_active_figure_number = self.manager._current_figs.get_active_figure().number
-        self.manager.report_as_current()
-
-        if checked:
-            self._slice_plotter_presenter.add_overplot_line(self.ws_name, key, recoil, cif_file)
-        else:
-            self._slice_plotter_presenter.hide_overplot_line(self.ws_name, key)
-
-        self.update_legend()
-        self._canvas.draw()
-
-        # Reset current active figure
-        if last_active_figure_number is not None:
-            self.manager._current_figs.set_figure_as_current(last_active_figure_number)
-
     def arbitrary_recoil_line(self):
         recoil = True
         checked = self.plot_window.action_arbitrary_nuclei.isChecked()
@@ -251,11 +268,11 @@ class SlicePlot(IPlot):
             self._arb_nuclei_rmm, confirm = QtWidgets.QInputDialog.getInt(
                 self.plot_window, 'Arbitrary Nuclei', 'Enter relative mass:', min=1)
             if confirm:
-                self.toggle_overplot_line(self._arb_nuclei_rmm, recoil, checked)
+                toggle_overplot_line(self, self._slice_plotter_presenter, self._arb_nuclei_rmm, recoil, checked)
             else:
                 self.plot_window.action_arbitrary_nuclei.setChecked(not checked)
         else:
-            self.toggle_overplot_line(self._arb_nuclei_rmm, recoil, checked)
+            toggle_overplot_line(self, self._slice_plotter_presenter, self._arb_nuclei_rmm, recoil, checked)
 
     def cif_file_powder_line(self, checked):
         if checked:
@@ -270,7 +287,7 @@ class SlicePlot(IPlot):
             cif_path = None
         if key:
             recoil = False
-            self.toggle_overplot_line(key, recoil, checked, cif_file=cif_path)
+            toggle_overplot_line(self, self._slice_plotter_presenter, key, recoil, checked, cif_file=cif_path)
 
     def _reset_intensity(self):
         options = self.plot_window.menu_intensity.actions()
@@ -376,32 +393,18 @@ class SlicePlot(IPlot):
         else:
             return str(temp_field), temp_field in keys
 
-    def _update_overplot_lines(self, lines):
-        for line in lines:
-            if line.isChecked():
-                self._slice_plotter_presenter.add_overplot_line(self.ws_name, *lines[line])
-
     def _update_recoil_lines(self):
         """ Updates the recoil overplots lines when intensity type changes """
         lines = {self.plot_window.action_hydrogen: [1, True, ''],
                  self.plot_window.action_deuterium: [2, True, ''],
                  self.plot_window.action_helium: [4, True, ''],
                  self.plot_window.action_arbitrary_nuclei: [self._arb_nuclei_rmm, True, '']}
-        self._update_overplot_lines(lines)
-
-    def _update_powder_lines(self):
-        """ Updates the powder overplots lines when intensity type changes """
-        lines = {self.plot_window.action_aluminium: ['Aluminium', False, ''],
-                 self.plot_window.action_copper: ['Copper', False, ''],
-                 self.plot_window.action_niobium: ['Niobium', False, ''],
-                 self.plot_window.action_tantalum: ['Tantalum', False, ''],
-                 self.plot_window.action_cif_file: [self._cif_file, False, self._cif_path]}
-        self._update_overplot_lines(lines)
+        _update_overplot_lines(self._slice_plotter_presenter, self.ws_name, lines)
 
     def _update_lines(self):
         """ Updates the powder/recoil overplots lines when intensity type changes """
         self._update_recoil_lines()
-        self._update_powder_lines()
+        _update_powder_lines(self, self._slice_plotter_presenter)
         self.update_legend()
         self._canvas.draw()
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -376,20 +376,32 @@ class SlicePlot(IPlot):
         else:
             return str(temp_field), temp_field in keys
 
-    def _update_lines(self):
-        """ Updates the powder/recoil overplots lines when intensity type changes """
+    def _update_overplot_lines(self, lines):
+        for line in lines:
+            if line.isChecked():
+                self._slice_plotter_presenter.add_overplot_line(self.ws_name, *lines[line])
+
+    def _update_recoil_lines(self):
+        """ Updates the recoil overplots lines when intensity type changes """
         lines = {self.plot_window.action_hydrogen: [1, True, ''],
                  self.plot_window.action_deuterium: [2, True, ''],
                  self.plot_window.action_helium: [4, True, ''],
-                 self.plot_window.action_arbitrary_nuclei: [self._arb_nuclei_rmm, True, ''],
-                 self.plot_window.action_aluminium: ['Aluminium', False, ''],
+                 self.plot_window.action_arbitrary_nuclei: [self._arb_nuclei_rmm, True, '']}
+        self._update_overplot_lines(lines)
+
+    def _update_powder_lines(self):
+        """ Updates the powder overplots lines when intensity type changes """
+        lines = {self.plot_window.action_aluminium: ['Aluminium', False, ''],
                  self.plot_window.action_copper: ['Copper', False, ''],
                  self.plot_window.action_niobium: ['Niobium', False, ''],
                  self.plot_window.action_tantalum: ['Tantalum', False, ''],
                  self.plot_window.action_cif_file: [self._cif_file, False, self._cif_path]}
-        for line in lines:
-            if line.isChecked():
-                self._slice_plotter_presenter.add_overplot_line(self.ws_name, *lines[line])
+        self._update_overplot_lines(lines)
+
+    def _update_lines(self):
+        """ Updates the powder/recoil overplots lines when intensity type changes """
+        self._update_recoil_lines()
+        self._update_powder_lines()
         self.update_legend()
         self._canvas.draw()
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -3,7 +3,6 @@ from functools import partial
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
-import os.path as path
 import matplotlib.colors as colors
 
 from mslice.models.colors import to_hex
@@ -178,24 +177,20 @@ class SlicePlot(IPlot):
         current_axis = self._canvas.figure.gca()
         colormesh = current_axis.collections[0]
         vmin, vmax = colorbar_range
+
         if logarithmic:
-            label = self.colorbar_label
-            colormesh.colorbar.remove()
             if vmin <= float(0):
                 vmin = 0.001
-            colormesh.set_clim((vmin, vmax))
             norm = colors.LogNorm(vmin, vmax)
-            colormesh.set_norm(norm)
-            self._canvas.figure.colorbar(colormesh)
-            self.colorbar_label = label
         else:
-            label = self.colorbar_label
-            colormesh.colorbar.remove()
-            colormesh.set_clim((vmin, vmax))
             norm = colors.Normalize(vmin, vmax)
-            colormesh.set_norm(norm)
-            self._canvas.figure.colorbar(colormesh)
-            self.colorbar_label = label
+
+        label = self.colorbar_label
+        colormesh.colorbar.remove()
+        colormesh.set_clim((vmin, vmax))
+        colormesh.set_norm(norm)
+        self._canvas.figure.colorbar(colormesh)
+        self.colorbar_label = label
 
     def get_line_options(self, target):
         line_options = {

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -15,7 +15,7 @@ from mslice.plotting.plot_window.iplot import IPlot
 from mslice.plotting.plot_window.interactive_cut import InteractiveCut
 from mslice.plotting.plot_window.plot_options import SlicePlotOptions
 from mslice.plotting.plot_window.overplot_interface import _update_overplot_lines, _update_powder_lines,\
-    toggle_overplot_line
+    toggle_overplot_line, cif_file_powder_line
 from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
 
@@ -112,7 +112,8 @@ class SlicePlot(IPlot):
             partial(toggle_overplot_line, self, self._slice_plotter_presenter, 'Niobium', False))
         plot_window.action_tantalum.triggered.connect(
             partial(toggle_overplot_line, self, self._slice_plotter_presenter, 'Tantalum', False))
-        plot_window.action_cif_file.triggered.connect(partial(self.cif_file_powder_line))
+        plot_window.action_cif_file.triggered.connect(partial(cif_file_powder_line, self,
+                                                              self._slice_plotter_presenter))
         plot_window.action_gen_script.triggered.connect(self.generate_script)
         plot_window.action_gen_script_clipboard.triggered.connect(lambda: self.generate_script(clipboard=True))
 
@@ -240,21 +241,6 @@ class SlicePlot(IPlot):
                 self.plot_window.action_arbitrary_nuclei.setChecked(not checked)
         else:
             toggle_overplot_line(self, self._slice_plotter_presenter, self._arb_nuclei_rmm, recoil, checked)
-
-    def cif_file_powder_line(self, checked):
-        if checked:
-            cif_path = QtWidgets.QFileDialog().getOpenFileName(self.plot_window, 'Open CIF file', '/home',
-                                                               'Files (*.cif)')
-            cif_path = str(cif_path[0]) if isinstance(cif_path, tuple) else str(cif_path)
-            key = path.basename(cif_path).rsplit('.')[0]
-            self._cif_file = key
-            self._cif_path = cif_path
-        else:
-            key = self._cif_file
-            cif_path = None
-        if key:
-            recoil = False
-            toggle_overplot_line(self, self._slice_plotter_presenter, key, recoil, checked, cif_file=cif_path)
 
     def _reset_intensity(self):
         options = self.plot_window.menu_intensity.actions()

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -14,43 +14,10 @@ from mslice.models.workspacemanager.workspace_provider import get_workspace_hand
 from mslice.plotting.plot_window.iplot import IPlot
 from mslice.plotting.plot_window.interactive_cut import InteractiveCut
 from mslice.plotting.plot_window.plot_options import SlicePlotOptions
+from mslice.plotting.plot_window.overplot_interface import _update_overplot_lines, _update_powder_lines,\
+    toggle_overplot_line
 from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
-
-
-def _update_overplot_lines(plotter_presenter, ws_name, lines):
-    for line in lines:
-        if line.isChecked():
-            plotter_presenter.add_overplot_line(ws_name, *lines[line])
-
-
-def _update_powder_lines(plot_handler, plotter_presenter):
-    """ Updates the powder overplots lines when intensity type changes """
-    lines = {plot_handler.plot_window.action_aluminium: ['Aluminium', False, ''],
-             plot_handler.plot_window.action_copper: ['Copper', False, ''],
-             plot_handler.plot_window.action_niobium: ['Niobium', False, ''],
-             plot_handler.plot_window.action_tantalum: ['Tantalum', False, ''],
-             plot_handler.plot_window.action_cif_file: [plot_handler._cif_file, False, plot_handler._cif_path]}
-    _update_overplot_lines(plotter_presenter, plot_handler.ws_name, lines)
-
-
-def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, cif_file=None):
-    last_active_figure_number = None
-    if plot_handler.manager._current_figs._active_figure is not None:
-        last_active_figure_number = plot_handler.manager._current_figs.get_active_figure().number
-    plot_handler.manager.report_as_current()
-
-    if checked:
-        plotter_presenter.add_overplot_line(plot_handler.ws_name, key, recoil, cif_file)
-    else:
-        plotter_presenter.hide_overplot_line(plot_handler.ws_name, key)
-
-    plot_handler.update_legend()
-    plot_handler._canvas.draw()
-
-    # Reset current active figure
-    if last_active_figure_number is not None:
-        plot_handler.manager._current_figs.set_figure_as_current(last_active_figure_number)
 
 
 class SlicePlot(IPlot):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -105,7 +105,7 @@ class CutPlotterPresenter(PresenterUtility):
             q_axis = cache.cut_axis
             e_axis = cache.integration_axis
         x, y = compute_powder_line(workspace_name, q_axis, key, cif_file=cif)
-        convert_energy_to_meV(y, e_axis.e_unit)
+        y = convert_energy_to_meV(y, e_axis.e_unit)
         self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
 
     def store_icut(self, icut):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -1,6 +1,7 @@
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.labels import generate_legend, is_momentum, is_twotheta
+from mslice.models.units import convert_energy_to_meV
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 import mslice.plotting.pyplot as plt
 from mslice.presenters.presenter_utility import PresenterUtility
@@ -104,11 +105,7 @@ class CutPlotterPresenter(PresenterUtility):
             q_axis = cache.cut_axis
             e_axis = cache.integration_axis
         x, y = compute_powder_line(workspace_name, q_axis, key, cif_file=cif)
-        if 'meV' not in e_axis.e_unit:
-            from mslice.models.units import EnergyUnits
-            import numpy as np
-            y = np.array(y) * EnergyUnits(e_axis.e_unit).factor_from_meV()
-
+        convert_energy_to_meV(y, e_axis.e_unit)
         self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
 
     def store_icut(self, icut):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -97,7 +97,7 @@ class CutPlotterPresenter(PresenterUtility):
         recoil = False
         cache = list(self._cut_cache_dict.values())[0][0]
         cache.rotated = not is_twotheta(cache.cut_axis.units) and not is_momentum(cache.cut_axis.units)
-        workspace_name = cache.workspace_name
+        workspace_name = workspace_name.split('(')[0][:-4]
         if cache.rotated:
             q_axis = cache.integration_axis
             e_axis = cache.cut_axis

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -1,9 +1,11 @@
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists
 from mslice.models.cut.cut_functions import compute_cut
-from mslice.models.labels import generate_legend
+from mslice.models.labels import generate_legend, is_momentum, is_twotheta
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 import mslice.plotting.pyplot as plt
 from mslice.presenters.presenter_utility import PresenterUtility
+from mslice.plotting.plot_window.overplot_interface import remove_line, plot_overplot_line
+from mslice.models.powder.powder_functions import compute_powder_line
 
 
 class CutPlotterPresenter(PresenterUtility):
@@ -12,6 +14,7 @@ class CutPlotterPresenter(PresenterUtility):
         self._main_presenter = None
         self._interactive_cut_cache = None
         self._cut_cache_dict = {}  # Dict of list of currently displayed cuts index by axes
+        self._overplot_cache = {}
 
     def run_cut(self, workspace, cut, plot_over=False, save_only=False):
         workspace = get_workspace_handle(workspace)
@@ -82,6 +85,31 @@ class CutPlotterPresenter(PresenterUtility):
         workspace = get_workspace_handle(workspace)
         self._plot_cut(workspace, cut, False, store, update_main=False)
         draw_interactive_cut(workspace)
+
+    def hide_overplot_line(self, workspace, key):
+        cache = self._overplot_cache
+        if key in cache:
+            line = cache.pop(key)
+            remove_line(line)
+
+    def add_overplot_line(self, workspace_name, key, recoil, cif=None):
+        recoil = False
+        cache = list(self._cut_cache_dict.values())[0][0]
+        cache.rotated = not is_twotheta(cache.cut_axis.units) and not is_momentum(cache.cut_axis.units)
+        workspace_name = cache.workspace_name
+        if cache.rotated:
+            q_axis = cache.integration_axis
+            e_axis = cache.cut_axis
+        else:
+            q_axis = cache.cut_axis
+            e_axis = cache.integration_axis
+        x, y = compute_powder_line(workspace_name, q_axis, key, cif_file=cif)
+        if 'meV' not in e_axis.e_unit:
+            from mslice.models.units import EnergyUnits
+            import numpy as np
+            y = np.array(y) * EnergyUnits(e_axis.e_unit).factor_from_meV()
+
+        self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
 
     def store_icut(self, icut):
         self._interactive_cut_cache = icut

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -1,7 +1,7 @@
 from matplotlib.colors import Normalize
 
-from mslice.models.slice.slice_functions import (compute_slice, sample_temperature, compute_recoil_line,
-                                                 compute_powder_line)
+from mslice.models.slice.slice_functions import compute_slice, sample_temperature, compute_recoil_line
+from mslice.models.powder.powder_functions import compute_powder_line
 from mslice.models.cmap import ALLOWED_CMAPS
 from mslice.models.slice.slice import Slice
 from mslice.models.labels import is_momentum, is_twotheta

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -98,7 +98,7 @@ class SlicePlotterPresenter(PresenterUtility):
             x, y = compute_recoil_line(workspace_name, cache.momentum_axis, key)
         else:
             x, y = compute_powder_line(workspace_name, cache.momentum_axis, key, cif_file=cif)
-        convert_energy_to_meV(y, cache.energy_axis.e_unit)
+        y = convert_energy_to_meV(y, cache.energy_axis.e_unit)
         cache.overplot_lines[key] = plot_overplot_line(x, y, key, recoil, cache)
 
     def validate_intensity(self, intensity_start, intensity_end):

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -5,9 +5,9 @@ from mslice.models.slice.slice_functions import (compute_slice, sample_temperatu
 from mslice.models.cmap import ALLOWED_CMAPS
 from mslice.models.slice.slice import Slice
 from mslice.models.labels import is_momentum, is_twotheta
-from mslice.views.slice_plotter import (set_colorbar_label, plot_cached_slice, remove_line,
-                                        plot_overplot_line, create_slice_figure)
+from mslice.views.slice_plotter import (set_colorbar_label, plot_cached_slice, create_slice_figure)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
+from mslice.plotting.plot_window.overplot_interface import plot_overplot_line, remove_line
 from mslice.presenters.presenter_utility import PresenterUtility
 
 

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -5,6 +5,7 @@ from mslice.models.powder.powder_functions import compute_powder_line
 from mslice.models.cmap import ALLOWED_CMAPS
 from mslice.models.slice.slice import Slice
 from mslice.models.labels import is_momentum, is_twotheta
+from mslice.models.units import convert_energy_to_meV
 from mslice.views.slice_plotter import (set_colorbar_label, plot_cached_slice, create_slice_figure)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.plotting.plot_window.overplot_interface import plot_overplot_line, remove_line
@@ -97,10 +98,7 @@ class SlicePlotterPresenter(PresenterUtility):
             x, y = compute_recoil_line(workspace_name, cache.momentum_axis, key)
         else:
             x, y = compute_powder_line(workspace_name, cache.momentum_axis, key, cif_file=cif)
-        if 'meV' not in cache.energy_axis.e_unit:
-            from mslice.models.units import EnergyUnits
-            import numpy as np
-            y = np.array(y) * EnergyUnits(cache.energy_axis.e_unit).factor_from_meV()
+        convert_energy_to_meV(y, cache.energy_axis.e_unit)
         cache.overplot_lines[key] = plot_overplot_line(x, y, key, recoil, cache)
 
     def validate_intensity(self, intensity_start, intensity_end):

--- a/mslice/tests/slice_functions_test.py
+++ b/mslice/tests/slice_functions_test.py
@@ -11,7 +11,8 @@ from mslice.models.axis import Axis
 from mslice.models.slice.slice_algorithm import Slice
 from mslice.models.slice.slice_functions import (compute_slice, compute_boltzmann_dist, compute_chi,
                                                  compute_chi_magnetic, compute_d2sigma, compute_symmetrised,
-                                                 compute_gdos, compute_powder_line, compute_recoil_line)
+                                                 compute_gdos, compute_recoil_line)
+from mslice.models.powder.powder_functions import compute_powder_line
 from mslice.util.mantid.algorithm_wrapper import wrap_algorithm
 from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace
 

--- a/mslice/tests/slice_functions_test.py
+++ b/mslice/tests/slice_functions_test.py
@@ -120,7 +120,7 @@ class SliceFunctionsTest(unittest.TestCase):
         self.assertAlmostEqual(line[10], 0.999578, 6)
         self.assertAlmostEqual(line[29], 5.276328, 6)
 
-    @patch('mslice.models.slice.slice_functions.get_workspace_handle')
+    @patch('mslice.models.powder.powder_functions.get_workspace_handle')
     def test_powder_line(self, ws_handle_mock):
         from mslice.models.axis import Axis
         ws_handle_mock.return_value.e_fixed = 20
@@ -132,7 +132,7 @@ class SliceFunctionsTest(unittest.TestCase):
         self.assertEqual(y[0], 1)
         self.assertEqual(y[1], -1)
 
-    @patch('mslice.models.slice.slice_functions.get_workspace_handle')
+    @patch('mslice.models.powder.powder_functions.get_workspace_handle')
     def test_powder_line_degrees(self, ws_handle_mock):
         from mslice.models.axis import Axis
         ws_handle_mock.return_value.e_fixed = 20

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -3,7 +3,7 @@ import unittest
 
 from matplotlib import colors
 from matplotlib.legend import Legend
-from mslice.plotting.plot_window.slice_plot import SlicePlot
+from mslice.plotting.plot_window.slice_plot import SlicePlot, toggle_overplot_line
 
 
 class SlicePlotTest(unittest.TestCase):
@@ -57,7 +57,8 @@ class SlicePlotTest(unittest.TestCase):
 
     def test_lines_redrawn_on_intensity_change(self):
         self.slice_plot.save_default_options()
-        self.slice_plot.toggle_overplot_line(self.slice_plot.plot_window.action_helium, 4, True, True)
+        toggle_overplot_line(self.slice_plot, self.slice_plot._slice_plotter_presenter,
+                             self.slice_plot.plot_window.action_helium, 4, True, True)
         colorbar_range = PropertyMock(return_value=(0, 10))
         type(self.slice_plot).colorbar_range = colorbar_range
         self.slice_plotter.show_dynamical_susceptibility.__name__ = 'foo'

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -3,7 +3,8 @@ import unittest
 
 from matplotlib import colors
 from matplotlib.legend import Legend
-from mslice.plotting.plot_window.slice_plot import SlicePlot, toggle_overplot_line
+from mslice.plotting.plot_window.slice_plot import SlicePlot
+from mslice.plotting.plot_window.overplot_interface import toggle_overplot_line
 
 
 class SlicePlotTest(unittest.TestCase):

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -36,6 +36,8 @@ def _show_plot(slice_cache, workspace):
     if cur_fig.canvas.manager.plot_handler.icut is not None:
         cur_fig.canvas.manager.plot_handler.icut.rect.ax = ax
 
+    cur_fig.canvas.manager.plot_handler._update_lines()
+
     cur_fig.canvas.draw_idle()
     cur_fig.show()
 

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -59,11 +59,14 @@ def remove_line(line):
 
 def plot_overplot_line(x, y, key, recoil, cache):
     color = OVERPLOT_COLORS[key] if key in OVERPLOT_COLORS else 'c'
-    if recoil:  # key is relative mass
-        label = get_recoil_label(key)
-    else:  # key is element name
-        label = key
-    if cache.rotated:
+    if recoil:
+        return overplot_line(x, y, color, get_recoil_label(key), cache.rotated)
+    else:
+        return overplot_line(x, y, color, key, cache.rotated)
+
+
+def overplot_line(x, y, color, label, rotated):
+    if rotated:
         return plt.gca().plot(y, x, color=color, label=label, alpha=.7,
                               picker=PICKER_TOL_PTS)[0]
     else:

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -1,8 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-from mslice.models.labels import recoil_labels
+from mslice.models.labels import get_recoil_label
 import mslice.plotting.pyplot as plt
-
 
 OVERPLOT_COLORS = {1: 'b', 2: 'g', 4: 'r', 'Aluminium': 'g', 'Copper': 'm', 'Niobium': 'y', 'Tantalum': 'b'}
 PICKER_TOL_PTS = 5
@@ -61,7 +60,7 @@ def remove_line(line):
 def plot_overplot_line(x, y, key, recoil, cache):
     color = OVERPLOT_COLORS[key] if key in OVERPLOT_COLORS else 'c'
     if recoil:  # key is relative mass
-        label = recoil_labels[key] if key in recoil_labels else 'Relative mass ' + str(key)
+        label = get_recoil_label(key)
     else:  # key is element name
         label = key
     if cache.rotated:

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -49,4 +49,3 @@ def _show_plot(slice_cache, workspace):
 
 def set_colorbar_label(label):
     plt.gcf().get_axes()[1].set_ylabel(label, rotation=270, labelpad=20)
-

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -31,12 +31,14 @@ def _show_plot(slice_cache, workspace):
     cb = plt.colorbar(image, ax=ax)
     cb.set_label('Intensity (arb. units)', labelpad=20, rotation=270, picker=PICKER_TOL_PTS)
 
+    plt_handler = cur_fig.canvas.manager.plot_handler
+
     # Because the axis is cleared, RectangleSelector needs to use the new axis
     # otherwise it can't be used after doing an intensity plot (as it clears the axes)
-    if cur_fig.canvas.manager.plot_handler.icut is not None:
-        cur_fig.canvas.manager.plot_handler.icut.rect.ax = ax
+    if plt_handler.icut is not None:
+        plt_handler.icut.rect.ax = ax
 
-    cur_fig.canvas.manager.plot_handler._update_lines()
+    plt_handler._update_lines()
 
     cur_fig.canvas.draw_idle()
     cur_fig.show()
@@ -44,8 +46,8 @@ def _show_plot(slice_cache, workspace):
     # This ensures that another slice plotted in the same window saves the plot options
     # as the plot window's showEvent is called only once. The equivalent command is left
     # in the showEvent for use by the CLI.
-    if cur_fig.canvas.manager.plot_handler.default_options is None:
-        cur_fig.canvas.manager.plot_handler.save_default_options()
+    if plt_handler.default_options is None:
+        plt_handler.save_default_options()
 
 
 def set_colorbar_label(label):

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -1,9 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
-from mslice.models.labels import get_recoil_label
 import mslice.plotting.pyplot as plt
 
-OVERPLOT_COLORS = {1: 'b', 2: 'g', 4: 'r', 'Aluminium': 'g', 'Copper': 'm', 'Niobium': 'y', 'Tantalum': 'b'}
 PICKER_TOL_PTS = 5
 
 
@@ -52,23 +50,3 @@ def _show_plot(slice_cache, workspace):
 def set_colorbar_label(label):
     plt.gcf().get_axes()[1].set_ylabel(label, rotation=270, labelpad=20)
 
-
-def remove_line(line):
-    plt.gca().lines.remove(line)
-
-
-def plot_overplot_line(x, y, key, recoil, cache):
-    color = OVERPLOT_COLORS[key] if key in OVERPLOT_COLORS else 'c'
-    if recoil:
-        return overplot_line(x, y, color, get_recoil_label(key), cache.rotated)
-    else:
-        return overplot_line(x, y, color, key, cache.rotated)
-
-
-def overplot_line(x, y, color, label, rotated):
-    if rotated:
-        return plt.gca().plot(y, x, color=color, label=label, alpha=.7,
-                              picker=PICKER_TOL_PTS)[0]
-    else:
-        return plt.gca().plot(x, y, color=color, label=label, alpha=.7,
-                              picker=PICKER_TOL_PTS)[0]


### PR DESCRIPTION
**Description of work**

Powder(Bragg) peaks are enabled on cut plots in addition to slice plots. 
Overplot interface is created taking material from powder peaks implementation for slice plots.

**To test:**

Create a slice plot
Make sure Information over-plots on slice plots work without any problems (The existing feature is not corrupted)

Create a cut plot
Then check that powder(Bragg) peaks (in Information) can be invoked on a cut plot

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #602 .
![PowderPeaks](https://user-images.githubusercontent.com/52707387/125275473-f7b3d980-e306-11eb-80d7-79df9dad6f36.jpg)
