### PR TITLE
Changed default tab to load tab

### DIFF
--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -31,7 +31,7 @@
         <enum>QTabWidget::Rounded</enum>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>0</number>
        </property>
        <property name="iconSize">
         <size>


### PR DESCRIPTION
Changed the default tab from plot to load.

**To test:**

Open MSlice and make sure that the load tab is opened and not the plot tab.

Fixes #[629](https://github.com/mantidproject/mslice/issues/629).
