### PR TITLE
Save default options for cut plot

### DIFF
--- a/mslice/views/cut_plotter.py
+++ b/mslice/views/cut_plotter.py
@@ -47,6 +47,9 @@ def plot_cut_impl(workspace, intensity_range=None, plot_over=False, legend=None,
     else:
         cur_fig.canvas.manager.plot_handler.ws_list = [workspace.name]
 
+    if cur_fig.canvas.manager.plot_handler.default_options is None:
+        cur_fig.canvas.manager.plot_handler.save_default_options()
+
     return ax.lines
 
 


### PR DESCRIPTION
Without saving the default options for cut plots scripts cannot be generated successfully.

**To test:**

Create cut plot. On the plot window, click File->Generate Script to Clipboard

Fixes #[628](https://github.com/mantidproject/mslice/issues/628).
