### PR TITLE
Fix for errors caused by small interactive cuts

### DIFF
--- a/mslice/cli/__init__.py
+++ b/mslice/cli/__init__.py
@@ -4,7 +4,7 @@ import mslice.util.mantid.init_mantid # noqa: F401
 from mslice.plotting.pyplot import *  # noqa: F401
 from matplotlib.axes import Axes
 from matplotlib.projections import register_projection
-from mslice.cli.helperfunctions import is_slice, is_cut
+from mslice.cli.helperfunctions import is_slice, is_cut, is_hs_workspace
 from ._mslice_commands import *  # noqa: F401
 from mslice.app import is_gui
 from mslice.cli.helperfunctions import (_check_workspace_name, _check_workspace_type, _get_overplot_key,
@@ -27,13 +27,7 @@ class MSliceAxes(Axes):
         from mslice.cli.plotfunctions import errorbar
         if is_cut(*args):
             return errorbar(self, *args, **kwargs)
-        else:
-            if 'intensity_range' in kwargs:
-                kwargs.pop('intensity_range', None)
-            if 'plot_over' in kwargs:
-                kwargs.pop('plot_over', None)
-            if 'en_conversion' in kwargs:
-                kwargs.pop('en_conversion', None)
+        if not is_hs_workspace(*args):
             return Axes.errorbar(self, *args, **kwargs)
 
     def pcolormesh(self, *args, **kwargs):

--- a/mslice/cli/__init__.py
+++ b/mslice/cli/__init__.py
@@ -28,6 +28,12 @@ class MSliceAxes(Axes):
         if is_cut(*args):
             return errorbar(self, *args, **kwargs)
         else:
+            if 'intensity_range' in kwargs:
+                kwargs.pop('intensity_range', None)
+            if 'plot_over' in kwargs:
+                kwargs.pop('plot_over', None)
+            if 'en_conversion' in kwargs:
+                kwargs.pop('en_conversion', None)
             return Axes.errorbar(self, *args, **kwargs)
 
     def pcolormesh(self, *args, **kwargs):

--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -149,7 +149,7 @@ def is_slice(*args):
 
 def is_cut(*args):
     """
-    Checks if args[0] is a HistogramWorkspace
+    Checks if args[0] is a HistogramWorkspace and if the bin number matches
     """
     if isinstance(args[0], HistogramWorkspace) and \
             sum([args[0].raw_ws.getDimension(i).getNBins() != 1 for i in range(args[0]._raw_ws.getNumDims())]) == 1:
@@ -157,6 +157,14 @@ def is_cut(*args):
     else:
         return False
 
+def is_hs_workspace(*args):
+    """
+    Checks if args[0] is a HistogramWorkspace
+    """
+    if isinstance(args[0], HistogramWorkspace):
+        return True
+    else:
+        return False
 
 def append_visible_handle(visible_handles, handles, idx: int):
     handle = handles[idx]

--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -161,10 +161,7 @@ def is_hs_workspace(*args):
     """
     Checks if args[0] is a HistogramWorkspace
     """
-    if isinstance(args[0], HistogramWorkspace):
-        return True
-    else:
-        return False
+    return isinstance(args[0], HistogramWorkspace)
 
 def append_visible_handle(visible_handles, handles, idx: int):
     handle = handles[idx]

--- a/mslice/workspace/helperfunctions.py
+++ b/mslice/workspace/helperfunctions.py
@@ -1,6 +1,9 @@
 import pickle
 import codecs
 
+from mantid.simpleapi import DeleteWorkspace
+
+
 def _attribute_from_string(ws, comstr):
     if comstr:
         try:
@@ -75,6 +78,16 @@ def attribute_to_log(attrdict, raw_ws, append=False):
                     attrdict[k] = v
         runinfo.addProperty('MSlice', str(codecs.encode(pickle.dumps(attrdict), 'base64').decode()), True)
 
+def delete_workspace(workspace, ws):
+    try:
+        if hasattr(workspace, str(ws)) and ws is not None and ws.name().endswith('_HIDDEN'):
+            DeleteWorkspace(ws)
+            ws = None
+    except RuntimeError:
+        # On exit the workspace can get deleted before __del__ is called
+        # where you receive a RuntimeError: Variable invalidated, data has been deleted.
+        # error
+        pass
 
 class WrapWorkspaceAttribute(object):
 

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -2,10 +2,9 @@ from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .histo_mixin import HistoMixin
 from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
-from .helperfunctions import attribute_from_log, attribute_to_log
+from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace
 
 from mantid.api import IMDHistoWorkspace
-from mantid.simpleapi import DeleteWorkspace
 
 
 class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
@@ -54,12 +53,4 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        try:
-            if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
-                DeleteWorkspace(self._raw_ws)
-                self._raw_ws = None
-        except RuntimeError:
-            # On exit the workspace can get deleted before __del__ is called
-            # where you receive a RuntimeError: Variable invalidated, data has been deleted.
-            # error
-            pass
+        delete_workspace(self, self._raw_ws)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -3,11 +3,9 @@ from .base import WorkspaceBase
 from .histogram_workspace import HistogramWorkspace
 from .pixel_mixin import PixelMixin
 from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
-from .helperfunctions import attribute_from_log, attribute_to_log
+from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace
 
 from mantid.api import IMDEventWorkspace
-from mantid.simpleapi import DeleteWorkspace
-
 
 
 class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
@@ -53,21 +51,5 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        try:
-            if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
-                DeleteWorkspace(self._raw_ws)
-                self._raw_ws = None
-        except RuntimeError:
-            # On exit the workspace can get deleted before __del__ is called
-            # where you receive a RuntimeError: Variable invalidated, data has been deleted.
-            # error
-            pass
-        try:
-            if hasattr(self, '_histo_ws') and self._histo_ws is not None and self._histo_ws.name().endswith('_HIDDEN'):
-                DeleteWorkspace(self._histo_ws)
-                self._histo_ws = None
-        except RuntimeError:
-            # On exit the workspace can get deleted before __del__ is called
-            # where you receive a RuntimeError: Variable invalidated, data has been deleted.
-            # error
-            pass
+        delete_workspace(self, self._raw_ws)
+        delete_workspace(self, self._histo_ws)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -53,9 +53,21 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
-            DeleteWorkspace(self._raw_ws)
-            self._raw_ws = None
-        if hasattr(self, '_histo_ws') and self._histo_ws is not None and self._histo_ws.name().endswith('_HIDDEN'):
-            DeleteWorkspace(self._histo_ws)
-            self._histo_ws = None
+        try:
+            if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
+                DeleteWorkspace(self._raw_ws)
+                self._raw_ws = None
+        except RuntimeError:
+            # On exit the workspace can get deleted before __del__ is called
+            # where you receive a RuntimeError: Variable invalidated, data has been deleted.
+            # error
+            pass
+        try:
+            if hasattr(self, '_histo_ws') and self._histo_ws is not None and self._histo_ws.name().endswith('_HIDDEN'):
+                DeleteWorkspace(self._histo_ws)
+                self._histo_ws = None
+        except RuntimeError:
+            # On exit the workspace can get deleted before __del__ is called
+            # where you receive a RuntimeError: Variable invalidated, data has been deleted.
+            # error
+            pass

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -47,6 +47,12 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
-            DeleteWorkspace(self._raw_ws)
-            self._raw_ws = None
+        try:
+            if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
+                DeleteWorkspace(self._raw_ws)
+                self._raw_ws = None
+        except RuntimeError:
+            # On exit the workspace can get deleted before __del__ is called
+            # where you receive a RuntimeError: Variable invalidated, data has been deleted.
+            # error
+            pass

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -1,10 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
-from .helperfunctions import attribute_from_log, attribute_to_log
+from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace
 
 from mantid.api import MatrixWorkspace
-from mantid.simpleapi import DeleteWorkspace
 
 
 class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
@@ -47,12 +46,4 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
         attribute_from_log(None, self.raw_ws)
 
     def __del__(self):
-        try:
-            if hasattr(self, '_raw_ws') and self._raw_ws is not None and self._raw_ws.name().endswith('_HIDDEN'):
-                DeleteWorkspace(self._raw_ws)
-                self._raw_ws = None
-        except RuntimeError:
-            # On exit the workspace can get deleted before __del__ is called
-            # where you receive a RuntimeError: Variable invalidated, data has been deleted.
-            # error
-            pass
+        delete_workspace(self, self._raw_ws)


### PR DESCRIPTION
In the MSlice matplotlib projection the matplotlib errorbar method should only be used when args[0] is not a HistogramWorkspace as otherwise parameters are either unknown or unsuitable (issue https://github.com/mantidproject/mslice/issues/626).

Another error occurred when trying to delete the same workspace twice. This problem was also described in https://github.com/mantidproject/mslice/issues/544. The solution is to handle the exception this causes.

**To test:**

Follow the instructions in https://github.com/mantidproject/mslice/issues/626 and https://github.com/mantidproject/mslice/issues/544. The described errors should not appear anymore.

Fixes #[626](https://github.com/mantidproject/mslice/issues/626) and #[544](https://github.com/mantidproject/mslice/issues/544).
