### PR TITLE
Improve clipboard usage for scripts

### DIFF
--- a/mslice/scripting/__init__.py
+++ b/mslice/scripting/__init__.py
@@ -1,4 +1,4 @@
-from qtpy import QtWidgets
+from qtpy import QtGui, QtWidgets
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.scripting.helperfunctions import add_plot_statements
 from mslice.app.presenters import get_cut_plotter_presenter
@@ -20,7 +20,8 @@ def generate_script(ws_name, filename=None, plot_handler=None, window=None, clip
     script_lines = preprocess_lines(ws_name, plot_handler, ax)
     script_lines = add_plot_statements(script_lines, plot_handler, ax)
     if clipboard:
-        QtWidgets.QApplication.clipboard().setText(''.join(script_lines))
+        cb = QtGui.QGuiApplication.clipboard()
+        cb.setText(''.join(script_lines), mode=cb.Clipboard)
     else:
         with open(filename, 'w') as generated_script:
             generated_script.writelines(script_lines)


### PR DESCRIPTION
Pasting generated scripts did not work on Linux. One part of the problem is that Ctrl +v does sometimes not work as expected on Linux. By using QtGui.QGuiApplication with clipboard mode instead of QtWidgets.QApplication it is at least possible to ensure that both shift insert as well as right clicking and selecting 'Paste' can be used.

**To test:**

1. Open MSlice
2. Load data
3. Plot a slice
4. On the plot select "generate script to clipboard"
5. Paste script to script editor either with shift insert or with a right click and 'Paste'

Fixes #[630](https://github.com/mantidproject/mslice/issues/630).
