### PR TITLE
Updated workflow for automatic doc update

### DIFF
--- a/.github/workflows/onlinedocupdate.yml
+++ b/.github/workflows/onlinedocupdate.yml
@@ -2,23 +2,23 @@ name: MSlice online documentation update
 
 on:
   push:
-    paths:
-      - 'mslice\__init__.py'
+    branches:
+      - main
 
 jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Build and Commit
-      uses: sphinx-notes/pages@master
+      uses: sphinx-notes/pages@v1
       with:
         documentation_path: docs/source
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: gh-pages


### PR DESCRIPTION
Previously the online documentation for MSlice was only updated after a change in 'mslice\__init__.py' in main branch. 
This is now changed to every push to the main branch.

For some actions in this workflow there was no version number specified but 'master' used as a default. Now all actions have version numbers.

**To test:**

Once this PR is merged into main, the online documentation should have the version number 2.3.0 instead of the current 2.3.0.dev. Unfortunately this is not visible beforehand.
