### PR TITLE
Minor bug fixes for GitHub workflows

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -27,8 +27,8 @@ jobs:
         run: |
           sudo apt-add-repository ppa:mantid/mantid -y && sudo apt-get update -qq
           sudo apt-get install gdebi -y
-          export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/master/releases/nightly.txt | grep ubuntu)
-          wget http://downloads.sourceforge.net/project/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
+          export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/main/releases/nightly.txt | grep ubuntu)
+          wget http://downloads.sourceforge.net/project/files/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
           sudo gdebi --option=APT::Get::force-yes=1,APT::Get::Assume-Yes=1 -n /tmp/mtn.deb
           echo "PYTHONPATH=/opt/mantidnightly/bin:/opt/mantidnightly/lib" >> $GITHUB_ENV
           echo "HDF5_DISABLE_VERSION_CHECK=1" >> $GITHUB_ENV

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-add-repository ppa:mantid/mantid -y && sudo apt-get update -qq
           sudo apt-get install gdebi -y
           export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/main/releases/nightly.txt | grep ubuntu)
-          wget http://downloads.sourceforge.net/project/files/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
+          wget https://sourceforge.net/projects/mantid/files/Nightly/$mantiddeb -O /tmp/mtn.deb
           sudo gdebi --option=APT::Get::force-yes=1,APT::Get::Assume-Yes=1 -n /tmp/mtn.deb
           echo "PYTHONPATH=/opt/mantidnightly/bin:/opt/mantidnightly/lib" >> $GITHUB_ENV
           echo "HDF5_DISABLE_VERSION_CHECK=1" >> $GITHUB_ENV

--- a/.github/workflows/onlinedocupdate.yml
+++ b/.github/workflows/onlinedocupdate.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Build and Commit
-      uses: sphinx-notes/pages@v1
+      uses: sphinx-notes/pages@1.0
       with:
         documentation_path: docs/source
     - name: Push changes

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -27,8 +27,8 @@ jobs:
         run: |
           sudo apt-add-repository ppa:mantid/mantid -y && sudo apt-get update -qq
           sudo apt-get install gdebi -y
-          export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/master/releases/nightly.txt | grep ubuntu)
-          wget http://downloads.sourceforge.net/project/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
+          export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/main/releases/nightly.txt | grep ubuntu)
+          wget http://downloads.sourceforge.net/project/files/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
           sudo gdebi --option=APT::Get::force-yes=1,APT::Get::Assume-Yes=1 -n /tmp/mtn.deb
           echo "PYTHONPATH=/opt/mantidnightly/bin:/opt/mantidnightly/lib" >> $GITHUB_ENV
           echo "HDF5_DISABLE_VERSION_CHECK=1" >> $GITHUB_ENV

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-add-repository ppa:mantid/mantid -y && sudo apt-get update -qq
           sudo apt-get install gdebi -y
           export mantiddeb=$(curl -sL https://github.com/mantidproject/download.mantidproject.org/raw/main/releases/nightly.txt | grep ubuntu)
-          wget http://downloads.sourceforge.net/project/files/mantid/Nightly/$mantiddeb -O /tmp/mtn.deb
+          wget https://sourceforge.net/projects/mantid/files/Nightly/$mantiddeb -O /tmp/mtn.deb
           sudo gdebi --option=APT::Get::force-yes=1,APT::Get::Assume-Yes=1 -n /tmp/mtn.deb
           echo "PYTHONPATH=/opt/mantidnightly/bin:/opt/mantidnightly/lib" >> $GITHUB_ENV
           echo "HDF5_DISABLE_VERSION_CHECK=1" >> $GITHUB_ENV


### PR DESCRIPTION
This PR fixes four issues in the MSlice GitHub workflows:

1. Use https instead of http for sourceforge.net
2. The path to the Mantid nightly builds on sourceforge.net is slightly different now
3. The path to the file with information on the Mantid nightly release on GitHub has changed: main instead of master
4. The version number of sphinx-notes/pages is 1.0 and not v1

Issue 1. - 3. are the reason why the workflows for nightly builds of MSlice as well as for any push to a branch that is not workflow_fix_file_path fail at the moment.

**To Test**
For 1.-3. check in the Action tab whether the workflow for the push to workflow_fix_file_path was running successfully. 