### PR TITLE
Fix for empty window in generated script

### DIFF
--- a/mslice/cli/plotfunctions.py
+++ b/mslice/cli/plotfunctions.py
@@ -71,7 +71,7 @@ def errorbar(axes, workspace, *args, **kwargs):
     if not cur_canvas.manager.has_plot_handler():
         cur_canvas.manager.add_cut_plot(presenter, workspace.name)
     cur_fig.canvas.draw()
-    axes.pchanged()  # This call is to let the waterfall callback know to update
+    cur_canvas.manager.update_axes(axes)
 
     cut = Cut(cut_axis, int_axis, intensity_min, intensity_max, workspace.norm_to_one, width='',
               algorithm=workspace.algorithm)

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -72,7 +72,6 @@ class CutPlot(IPlot):
         plot_window.action_waterfall.triggered.connect(self.toggle_waterfall)
         plot_window.waterfall_x_edt.editingFinished.connect(self.toggle_waterfall)
         plot_window.waterfall_y_edt.editingFinished.connect(self.toggle_waterfall)
-        self.mpl_axes_changed = self._canvas.figure.gca().add_callback(self.on_newplot)
         plot_window.action_aluminium.triggered.connect(
             partial(toggle_overplot_line, self, self._cut_plotter_presenter, 'Aluminium', False))
         plot_window.action_copper.triggered.connect(
@@ -88,7 +87,6 @@ class CutPlot(IPlot):
         plot_window.action_save_cut.triggered.disconnect()
         plot_window.action_flip_axis.triggered.disconnect()
         plot_window.action_gen_script.triggered.disconnect()
-        self._canvas.figure.gca().remove_callack(self.mpl_axes_changed)
         plot_window.action_aluminium.triggered.disconnect()
         plot_window.action_copper.triggered.disconnect()
         plot_window.action_niobium.triggered.disconnect()

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -68,6 +68,7 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.window.show()
         self.window.activateWindow()
         self.window.raise_()
+        self.canvas.draw()
 
     def window_closing(self):
         if self.plot_handler is not None:
@@ -267,6 +268,10 @@ class PlotFigureManagerQT(QtCore.QObject):
             self.canvas.figure.gca().grid(True, axis='x')
         if self._ygrid:
             self.canvas.figure.gca().grid(True, axis='y')
+
+    def update_axes(self, ax):
+        if self.plot_handler is not None:
+            self.plot_handler.on_newplot(ax)
 
     def move_window(self, x, y):
         center = QtWidgets.QDesktopWidget().screenGeometry().center()

--- a/mslice/tests/cli_mslice_projection_test.py
+++ b/mslice/tests/cli_mslice_projection_test.py
@@ -72,7 +72,6 @@ class CLIProjectionTest(unittest.TestCase):
 
         return_value = errorbar(ax, cut)
         self.assertEqual(ax.lines, return_value)
-        ax.pchanged.assert_called()
 
     def test_that_plot_slice_mslice_projection_works_correctly(self):
         slice = mc.Slice(self.workspace)


### PR DESCRIPTION
This bug fix has to elements. The plot figure manager was updated to draw the canvas in the show method to ensure that the figure is visible. This bug was originally discovered for slice plots but occurred for both slice and cut plots.
The second element is removing the matplotlib pchanged call that activated the callback on_newplot for cut plots as this caused crashes. Now on_newplot is called directly for cut plots.

**To test:**

1. In the Workspace Manager tab of the MSlice interface load a data set (MAR21335_Ei60meV) and select the workspace 
2. Click Display in the Slice tab without changing the default values
3. Navigate to the File menu on the slice plot
4. Select Generate Script to Clipboard and paste the script into the Mantid editor.
5. Close the window with the slice plot
6. Run the script
7. The original slice plot should be displayed

Please repeat the above steps for the Cut tab and ensure that the original cut plot is displayed (and no crash occurs)

Fixes #639.

_A release note will be added for Mantid when this bug fix is made available for Mantid._