### PR TITLE
Fix print button import error

### DIFF
--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -3,7 +3,7 @@ import weakref
 
 import six
 from qtpy.QtCore import Qt
-from qtpy import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets, QtPrintSupport
 from mslice.util.qt.qapp import (QAppThreadCall, create_qapp_if_required,
                                  force_method_calls_to_qapp_thread)
 from mslice.models.workspacemanager.file_io import get_save_directory
@@ -171,10 +171,10 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.plot_handler.plot_options()
 
     def print_plot(self):
-        printer = QtWidgets.QPrinter()
+        printer = QtPrintSupport.QPrinter()
         printer.setResolution(300)
-        printer.setOrientation(QtWidgets.QPrinter.Landscape)
-        print_dialog = QtWidgets.QPrintDialog(printer)
+        printer.setOrientation(QtPrintSupport.QPrinter.Landscape)
+        print_dialog = QtPrintSupport.QPrintDialog(printer)
         if print_dialog.exec_():
             pixmap_image = QtWidgets.QWidget.grab(self.canvas)
             page_size = printer.pageRect()


### PR DESCRIPTION
A quick fix to the imports for `QPrinter` and `QPrintDialog` because the module had changed from `QtWidgets` in QtPy4 when the code was originally written to `QtPrintSupport` in `qtpy` which we're using now.

**To test:**

Plot a cut, and click on the printer icon - it should show up a dialog. 
Print to a pdf - a file should be generated.
Previously it gave an `AttributeError`.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #657
