### PR TITLE
Clear figures first in generated scripts to avoid duplicated colour bars

### DIFF
--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -38,6 +38,7 @@ def add_plot_statements(script_lines, plot_handler, ax):
     add_header(script_lines, plot_handler)
 
     script_lines.append('fig = plt.gcf()\n')
+    script_lines.append('fig.clf()\n')
     script_lines.append('ax = fig.add_subplot(111, projection="mslice")\n')
 
     if plot_handler is not None:


### PR DESCRIPTION
Scripts generated from plots now clear figures first to avoid duplications when the original plot is still open while the script is run.

**To test:**

1. In the Workspace Manager tab select the workspace MAR21335_Ei60meV
2. Click Display in the Slice tab without changing the default values
3. Navigate to the File menu on the slice plot
4. Select Generate Script to Clipboard and paste the script into the Mantid editor
5. Do _not_ close the plot.
6. Run the script and check that the same slice plot is displayed. 
7. Now click the 'Keep' button in the plot window and run the script again. There should be a second identical window.
8. Close both windows.
9. Run the script again. The original plot should be visible again.

Fixes #659.
