### PR TITLE
Fixed bug that prevented script generation for cut plots

### DIFF
--- a/mslice/cli/__init__.py
+++ b/mslice/cli/__init__.py
@@ -7,7 +7,6 @@ from matplotlib.projections import register_projection
 from mslice.cli.helperfunctions import is_slice, is_cut, is_hs_workspace
 from ._mslice_commands import *  # noqa: F401
 from mslice.app import is_gui
-from mslice.app.presenters import get_cut_plotter_presenter, get_slice_plotter_presenter
 from mslice.cli.helperfunctions import (_check_workspace_name, _check_workspace_type, _get_workspace_type, _get_overplot_key,
                                         _update_overplot_checklist, _update_legend)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
@@ -39,6 +38,7 @@ class MSliceAxes(Axes):
             return Axes.pcolormesh(self, *args, **kwargs)
 
     def recoil(self, workspace, element=None, rmm=None):
+        from mslice.app.presenters import get_slice_plotter_presenter
         _check_workspace_name(workspace)
         workspace = get_workspace_handle(workspace)
         _check_workspace_type(workspace, HistogramWorkspace)
@@ -55,6 +55,7 @@ class MSliceAxes(Axes):
         _update_legend()
 
     def bragg(self, workspace, element=None, cif=None):
+        from mslice.app.presenters import get_cut_plotter_presenter, get_slice_plotter_presenter
         _check_workspace_name(workspace)
         workspace = get_workspace_handle(workspace)
 

--- a/mslice/cli/__init__.py
+++ b/mslice/cli/__init__.py
@@ -7,7 +7,8 @@ from matplotlib.projections import register_projection
 from mslice.cli.helperfunctions import is_slice, is_cut, is_hs_workspace
 from ._mslice_commands import *  # noqa: F401
 from mslice.app import is_gui
-from mslice.cli.helperfunctions import (_check_workspace_name, _check_workspace_type, _get_overplot_key,
+from mslice.app.presenters import get_cut_plotter_presenter, get_slice_plotter_presenter
+from mslice.cli.helperfunctions import (_check_workspace_name, _check_workspace_type, _get_workspace_type, _get_overplot_key,
                                         _update_overplot_checklist, _update_legend)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.plotting.globalfiguremanager import GlobalFigureManager
@@ -38,7 +39,6 @@ class MSliceAxes(Axes):
             return Axes.pcolormesh(self, *args, **kwargs)
 
     def recoil(self, workspace, element=None, rmm=None):
-        from mslice.app.presenters import get_slice_plotter_presenter
         _check_workspace_name(workspace)
         workspace = get_workspace_handle(workspace)
         _check_workspace_type(workspace, HistogramWorkspace)
@@ -55,14 +55,17 @@ class MSliceAxes(Axes):
         _update_legend()
 
     def bragg(self, workspace, element=None, cif=None):
-        from mslice.app.presenters import get_slice_plotter_presenter
         _check_workspace_name(workspace)
         workspace = get_workspace_handle(workspace)
-        _check_workspace_type(workspace, HistogramWorkspace)
 
         key = _get_overplot_key(element, rmm=None)
 
-        get_slice_plotter_presenter().add_overplot_line(workspace.name, key, recoil=False, cif=cif)
+        ws_type = _get_workspace_type(workspace)
+        if ws_type == 'HistogramWorkspace':
+            get_cut_plotter_presenter().add_overplot_line(workspace.name, key, recoil=True, cif=None)
+        elif ws_type == 'MatrixWorkspace':
+            get_slice_plotter_presenter().add_overplot_line(workspace.name, key, recoil=False, cif=cif)
+
         _update_overplot_checklist(key)
         _update_legend()
 

--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -125,6 +125,12 @@ def _check_workspace_type(workspace, correct_type):
         if not isinstance(workspace, MatrixWorkspace):
             raise RuntimeError("Incorrect workspace type.")
 
+def _get_workspace_type(workspace):
+    """Determine workspace type"""
+    if isinstance(workspace, MatrixWorkspace):
+        return "MatrixWorkspace"
+    if isinstance(workspace, HistogramWorkspace):
+        return "HistogramWorkspace"
 
 def _rescale_energy_cut_plot(presenter, cuts, new_e_unit):
     """Given a CutPlotterPresenter and a set of cached cuts,

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -46,6 +46,7 @@ def add_plot_statements(script_lines, plot_handler, ax):
             add_overplot_statements(script_lines, plot_handler)
         elif isinstance(plot_handler, CutPlot):
             add_cut_plot_statements(script_lines, plot_handler, ax)
+            add_overplot_statements(script_lines, plot_handler)
 
         script_lines.append("mc.Show()\n")
 

--- a/mslice/tests/cli_helper_functions_test.py
+++ b/mslice/tests/cli_helper_functions_test.py
@@ -143,6 +143,16 @@ class CLIHelperFunctionsTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             _check_workspace_type(psd_workspace, MatrixWorkspace)
 
+    def test_that_get_workspace_type_works_as_expected(self):
+        workspace = self.create_workspace("test_workspace")
+        workspace_histo = self.create_histo_workspace('histogram_workspace')
+
+        return_value = _get_workspace_type(workspace)
+        self.assertEqual(return_value, "MatrixWorkspace")
+
+        return_value = _get_workspace_type(workspace_histo)
+        self.assertEqual(return_value, "HistogramWorkspace")
+
     def test_that_is_slice_works_as_expected(self):
         workspace = self.create_workspace('workspace')
         slice_ws = Slice(workspace)

--- a/mslice/tests/cli_helper_functions_test.py
+++ b/mslice/tests/cli_helper_functions_test.py
@@ -5,7 +5,7 @@ from mantid.simpleapi import (AddSampleLog, CreateSampleWorkspace, CreateMDHisto
 from unittest import mock
 from mslice.workspace import wrap_workspace
 from mslice.cli.helperfunctions import _string_to_axis, _string_to_integration_axis, _process_axis,\
-    _check_workspace_name, _check_workspace_type, is_slice, is_cut, _get_overplot_key, _update_overplot_checklist, \
+    _check_workspace_name, _check_workspace_type, _get_workspace_type, is_slice, is_cut, _get_overplot_key, _update_overplot_checklist, \
     _update_legend
 from mslice.cli._mslice_commands import Cut, Slice
 from mslice.models.axis import Axis

--- a/mslice/tests/scripting_helperfunctions_test.py
+++ b/mslice/tests/scripting_helperfunctions_test.py
@@ -62,7 +62,8 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
 
     @mock.patch('mslice.scripting.helperfunctions.add_header')
     @mock.patch('mslice.scripting.helperfunctions.add_cut_plot_statements')
-    def test_that_add_plot_statements_works_as_expected_for_cuts(self, add_cut, add_header):
+    @mock.patch('mslice.scripting.helperfunctions.add_overplot_statements')
+    def test_that_add_plot_statements_works_as_expected_for_cuts(self, add_overplot, add_cut, add_header):
         plot_handler = mock.MagicMock(spec=CutPlot)
         script_lines = []
 
@@ -73,6 +74,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
 
         add_header.assert_called_once_with(script_lines, plot_handler)
         add_cut.assert_called_once_with(script_lines, plot_handler, ax)
+        add_overplot.assert_called_once_with(script_lines, plot_handler)
 
         self.assertIn("mc.Show()\n", script_lines)
         self.assertIn('fig = plt.gcf()\n', script_lines)


### PR DESCRIPTION
Added functionality to store information on Bragg peaks for cut plots during script generation. Also, added functionality to reproduce cut plot by running the script.

For testing follow instructions in issue.

Fixes #648.
