### PR TITLE
Prevent exception when generating script from plot from script

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -514,4 +514,6 @@ class CutPlot(IPlot):
         self.plot_window.waterfall_y = value
 
     def is_changed(self, item):
+        if self.default_options is None:
+            return False
         return self.default_options[item] != getattr(self, item)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -498,4 +498,6 @@ class SlicePlot(IPlot):
         self.manager.y_grid = value
 
     def is_changed(self, item):
+        if self.default_options is None:
+            return False
         return self.default_options[item] != getattr(self, item)


### PR DESCRIPTION
When a plot is created by running a script generated from a plot the default options are not saved. This caused an exception when trying a to generate a new script from the plot. Now not existing default options are treated as unchanged options.

**To test:**

Follow instructions in original issue. Please note that this has been fixed both for slice and cut plots.

Fixes #652.
