### PR TITLE
Added legends for recoil lines/bragg peaks on Slice Plots

### DIFF
--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -158,7 +158,7 @@ class PlotFigureManagerQT(QtCore.QObject):
             self.plot_handler.show_legends = True
             self.plot_handler.update_legend()
 
-        else: 
+        else:
             self.plot_handler.show_legends = False
             axes.legend_ = None
 

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -153,10 +153,15 @@ class PlotFigureManagerQT(QtCore.QObject):
 
     def _toggle_legend(self):
         axes = self.canvas.figure.gca()
-        if axes.legend_ is None:
+
+        if not self.plot_handler.show_legends:
+            self.plot_handler.show_legends = True
             self.plot_handler.update_legend()
-        else:
+
+        else: 
+            self.plot_handler.show_legends = False
             axes.legend_ = None
+
         self.canvas.draw()
 
     def plot_clicked(self, event):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -171,7 +171,7 @@ class SlicePlot(IPlot):
         axes = self._canvas.figure.gca()
 
         if self._legends_shown:
-            self.add_or_renew_legend(axes)
+            self._add_or_renew_legend(axes)
 
         if self._canvas.manager.plot_handler.icut is not None:
             self._canvas.manager.plot_handler.icut.rect.ax = axes

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -1,8 +1,10 @@
-from mock import MagicMock, patch, PropertyMock
+from mock import MagicMock, patch, PropertyMock, ANY
 import unittest
 
 from matplotlib import colors
 from matplotlib.legend import Legend
+from matplotlib.lines import Line2D
+
 from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.plotting.plot_window.overplot_interface import toggle_overplot_line
 
@@ -18,6 +20,8 @@ class SlicePlotTest(unittest.TestCase):
         self.axes = MagicMock()
         canvas.figure.gca = MagicMock(return_value=self.axes)
         self.slice_plot = SlicePlot(self.plot_figure, self.slice_plotter, "workspace")
+        self.line = [Line2D([], [])]
+        self.axes.get_legend_handles_labels = MagicMock(return_value=(self.line, ['some_label']))
 
     def test_that_is_changed_works_correctly(self):
         self.slice_plot.default_options = {}
@@ -101,6 +105,14 @@ class SlicePlotTest(unittest.TestCase):
 
         self.assertEqual(self.slice_plot._canvas.manager.plot_handler.icut.rect.ax, self.axes)
 
+    def test_update_legend_in_slice_plot(self):
+        with patch.object(self.axes, 'legend') as mock_add_legend,\
+                patch.object(self.axes, 'get_legend') as mock_get_legend:
+
+            mock_get_legend.return_value = MagicMock()
+
+            self.slice_plot.update_legend()
+            mock_add_legend.assert_called_with(self.line, ['some_label'], fontsize=ANY)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added ability to add/toggle legends on Slice Plots with regards to recoil lines/bragg peaks. Added unit test to confirm that legend is added when update_legend() is called.

**To test:**

<!-- Instructions for testing. -->
1) Open MSlice (Interfaces > Direct > MSlice)
2) Use file browser on data loading tab to load appropriate data (MAR21335_Ei60meV used)
3) Click display on slice sub-tab on Workspace Manager tab.
4) Add a [number of] recoil line /brag peaks to plot that is generated.
4) Observe legend appearing automatically and updating with each added feature, as legends are set to automatically show.
5) Toggle Legends off/on using the toolbar, observe legend being added/removed appropraitely.


<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #651.
