### PR TITLE
Fixed bug in processing of input workspaces

### DIFF
--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -12,10 +12,9 @@ from mslice.workspace.workspace import Workspace as MsliceWorkspace2D
 
 
 def _parse_ws_names(args, kwargs):
-    input_workspace = None
-    if 'InputWorkspace' in kwargs:
-        input_workspace = kwargs['InputWorkspace']
-        kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(kwargs['InputWorkspace'])
+    input_workspace = kwargs.get('InputWorkspace', None)
+    if input_workspace:
+        kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(input_workspace)
     elif len(args) > 0:
         if isinstance(args[0], MsliceWorkspace) or isinstance(args[0], string_types):
             input_workspace = get_workspace_handle(args[0])

--- a/mslice/util/mantid/algorithm_wrapper.py
+++ b/mslice/util/mantid/algorithm_wrapper.py
@@ -13,9 +13,8 @@ from mslice.workspace.workspace import Workspace as MsliceWorkspace2D
 
 def _parse_ws_names(args, kwargs):
     input_workspace = None
-
     if 'InputWorkspace' in kwargs:
-        input_workspace = get_workspace_handle(kwargs['InputWorkspace'])
+        input_workspace = kwargs['InputWorkspace']
         kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(kwargs['InputWorkspace'])
     elif len(args) > 0:
         if isinstance(args[0], MsliceWorkspace) or isinstance(args[0], string_types):
@@ -43,7 +42,6 @@ def _alg_has_outputws(wrapped_alg):
 
 def wrap_algorithm(algorithm):
     def alg_wrapper(*args, **kwargs):
-
         input_workspace, output_name, args, kwargs = _parse_ws_names(args, kwargs)
 
         args = tuple([_name_or_wrapper_to_workspace(arg) if isinstance(arg, MsliceWorkspace) else arg for arg in args])


### PR DESCRIPTION
The fix for the bug https://github.com/mantidproject/mslice/issues/531 included returning workspace handles for all input workspaces that are provided by the workspace name. This caused problems when using the Scale button on Mslice. By being more selective when to return a workspace handle the original fix still works and the Scale button is usable again as well.

**To test:**

1. In the Workspace Manager tab select the workspace MAR21335_Ei60meV
2. Click on the Scale button
3. Click ok on the pop up window. Check that no exception is thrown.

Also quickly check if https://github.com/mantidproject/mslice/issues/531 is still fixed. 

Fixes #649.
