### PR TITLE
Added error message when attempting to load by file path

### DIFF
--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -5,7 +5,7 @@ import os
 from functools import partial
 
 from qtpy.QtWidgets import QWidget, QFileSystemModel, QAbstractItemView, QMessageBox
-from qtpy.QtCore import Signal, QDir, Qt
+from qtpy.QtCore import Signal, QDir, Qt, QFileInfo
 
 from mslice.presenters.data_loader_presenter import DataLoaderPresenter
 from mslice.util.qt import load_ui
@@ -60,6 +60,10 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self._update_from_path()
 
     def refresh(self):
+        file_info = QFileInfo(self.txtpath.text())
+        if file_info.isFile():
+            self._display_error("Loading by file path is not supported")
+            return
         path_entered = QDir(self.txtpath.text())
         if path_entered.exists():
             self.directory = path_entered


### PR DESCRIPTION
MSlice does not allow to load a file by entering the file path and name into the file path box on top of the data loader tab. In order to differentiate this case from entering an invalid file path a new error message was added: "Loading by file path is not supported"

**To test:**

Enter the full path to a file with the filename into the box on top of the data loader tab, e.g. C:\data\MAR21335_Ei60meV.nxs and hit enter

Fixes #671.
