### PR TITLE
Aborting CIF File Load during brad peak plot now unchecks CIF on the list menu

### DIFF
--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -52,6 +52,11 @@ def cif_file_powder_line(plot_handler, plotter_presenter, checked):
                                                  'Open CIF file', '/home',
                                                  'Files (*.cif)')
         cif_path = str(cif_path[0]) if isinstance(cif_path, tuple) else str(cif_path)
+
+        if not cif_path:
+            plot_handler.plot_window.uncheck_action_by_text(plot_handler.plot_window.menu_bragg_peaks, "CIF file")
+            return
+
         key = path.basename(cif_path).rsplit('.')[0]
         plot_handler._cif_file = key
         plot_handler._cif_path = cif_path

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -211,6 +211,11 @@ class PlotWindow(QtWidgets.QMainWindow):
         except AttributeError:
             pass
 
+    def uncheck_action_by_text(self, holder, item_text):
+        for action in holder.actions():
+            if action.iconText() == item_text and action.isCheckable() and action.isChecked():
+                action.setChecked(False)
+
     @property
     def waterfall(self):
         return (self.action_waterfall.isChecked()


### PR DESCRIPTION
Description of work.

Aborting CIF File Load during brad peak plot now unchecks CIF on the list menu.
A function has been added to the 'plot_window' called 'uncheck_action_by_text'. This function takes the action icon text and the menu (sub menu in this case, bragg peaks), and unchecks any item found with the relevant text if that action is checkable and currently checked.

<!-- Instructions for testing. -->

1) Open MSlice (Interfaces > Direct > MSlice)
2) Use file browser on data loading tab to load appropriate data (MAR21335_Ei60meV used)
3) Click display on slice sub-tab on Workspace Manager tab.
4) On the toolbar, click Information > Bragg peaks > CIF File.
5) Close the file browser using either of the 'cancel' or 'x' buttons
6) On the toolbar, click Information > Bragg peaks
7) Observe that "CIF File" is unchecked

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #640 .
