### PR TITLE
Changed Mantid into MSlice and added bug label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what you expected to happen.
 If applicable/possible, add screenshots to help explain your problem.
 
 **MSlice Version (please complete the following information):**
- - MSlice Version [e.g. 2.3.0]
+ - MSlice Version [e.g. 2.3.0, from `import mslice; print(mslice.__version__)`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---
@@ -23,8 +23,8 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable/possible, add screenshots to help explain your problem.
 
-**Mantid Version (please complete the following information):**
- - Mantid Version [e.g. 6.0.0]
+**MSlice Version (please complete the following information):**
+ - MSlice Version [e.g. 2.3.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - ipython
   - matplotlib
   - mock
-  - nose
   - numpy
   - numpy-base
   - pip
@@ -19,5 +18,6 @@ dependencies:
   - pip:
       - coverage
       - h5py
+      - nose
       - pre-commit
       - pyyaml


### PR DESCRIPTION
The bug template now asks for the MSlice version instead of the Mantid version. In addition, it automatically adds the 'bug' label.

**To test:**

Check the changes to the bug_report.md file.


Fixes #650.
