### PR TITLE
Moved some imports to top

### DIFF
--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -1,3 +1,5 @@
+import copy
+
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.base import WorkspaceBase as Workspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
@@ -135,7 +137,6 @@ def _get_workspace_type(workspace):
 def _rescale_energy_cut_plot(presenter, cuts, new_e_unit):
     """Given a CutPlotterPresenter and a set of cached cuts,
     rescales the workspaces to a different energy-unit and replot"""
-    import copy
     cuts_copy = copy.deepcopy(cuts)  # Because run_cut will overwrite the cuts cache for plot_over=True
     for id, cut in enumerate(cuts_copy):
         cut.cut_axis.e_unit = new_e_unit

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -7,6 +7,7 @@ Uses mantid algorithms to perform workspace operations
 from __future__ import (absolute_import, division, print_function)
 
 import os.path
+from os.path import splitext
 
 import numpy as np
 from scipy import constants
@@ -19,10 +20,12 @@ from mslice.models.axis import Axis
 
 from mslice.util.mantid.algorithm_wrapper import add_to_ads
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_name, delete_workspace
-from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus, ConvertUnits
+from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus, ConvertUnits, Rebose
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace
+
+from .file_io import save_ascii, save_matlab, save_nexus
 
 # -----------------------------------------------------------------------------
 # Classes and functions
@@ -212,7 +215,6 @@ def subtract(workspaces, background_ws, ssf):
 
 
 def rebose_single(ws, from_temp, to_temp):
-    from mslice.util.mantid.mantid_algorithms import Rebose
     ws = get_workspace_handle(ws)
     results = Rebose(InputWorkspace=ws, CurrentTemperature=from_temp, TargetTemperature=to_temp,
                      OutputWorkspace=ws.name+'_bosed')
@@ -240,7 +242,6 @@ def save_workspaces(workspaces, path, save_name, extension, slice_nonpsd=False):
     :param extension: file extension (such as .txt)
     :param slice_nonpsd: whether the selection is in non_psd mode
     """
-    from .file_io import save_ascii, save_matlab, save_nexus
     if extension == '.nxs':
         save_method = save_nexus
     elif extension == '.txt':
@@ -253,7 +254,6 @@ def save_workspaces(workspaces, path, save_name, extension, slice_nonpsd=False):
         if len(workspaces) == 1:
             save_names = [save_name]
         else:
-            from os.path import splitext
             name, _ = splitext(save_name)
             save_names = ['{}_{:03d}{}'.format(name, idx+1, extension) for idx in range(len(workspaces))]
     else:

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -1,7 +1,10 @@
 from functools import partial
 
+from matplotlib.collections import LineCollection
 from matplotlib.container import ErrorbarContainer
 from matplotlib.legend import Legend
+from matplotlib.lines import Line2D
+
 import warnings
 import numpy as np
 
@@ -373,8 +376,6 @@ class CutPlot(IPlot):
         self._canvas.draw()
 
     def _apply_offset(self, x, y):
-        from matplotlib.lines import Line2D
-        from matplotlib.collections import LineCollection
         for ind, line_containers in enumerate(self._canvas.figure.gca().containers):
             for line in line_containers.get_children():
                 if isinstance(line, Line2D):
@@ -388,7 +389,6 @@ class CutPlot(IPlot):
 
     def on_newplot(self, ax):
         # This callback should be activated by a call to errorbar
-        from matplotlib.lines import Line2D
         new_line = False
         line_containers = self._canvas.figure.gca().containers
         num_lines = len(line_containers)

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -7,6 +7,7 @@ from mslice.models.units import EnergyUnits
 from mslice.models.workspacemanager.workspace_algorithms import (get_limits)
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.presenters.cut_plotter_presenter import CutPlotterPresenter
+from mslice.plotting.pyplot import GlobalFigureManager
 
 
 class InteractiveCut(object):
@@ -56,7 +57,6 @@ class InteractiveCut(object):
             self._cut_plotter_presenter.set_is_icut(True)
             if self._is_initial_cut_plotter_presenter:
                 # First time we've plotted a 1D cut - get the true CutPlotterPresenter
-                from mslice.plotting.pyplot import GlobalFigureManager
                 self._cut_plotter_presenter = GlobalFigureManager.get_active_figure().plot_handler._cut_plotter_presenter
                 self._is_initial_cut_plotter_presenter = False
                 GlobalFigureManager.disable_make_current()

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -1,6 +1,6 @@
 import os.path
 import weakref
-
+import io
 import six
 from qtpy.QtCore import Qt
 from qtpy import QtCore, QtGui, QtWidgets, QtPrintSupport
@@ -245,7 +245,6 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.canvas.figure.savefig(path, dpi=resolution)
 
     def _get_figure_image_data(self, resolution=300):
-        import io
         buf = io.BytesIO()
         self.canvas.figure.savefig(buf, dpi=resolution)
         return buf

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -16,6 +16,7 @@ from mslice.plotting.plot_window.interactive_cut import InteractiveCut
 from mslice.plotting.plot_window.plot_options import SlicePlotOptions
 from mslice.plotting.plot_window.overplot_interface import _update_overplot_lines, _update_powder_lines,\
     toggle_overplot_line, cif_file_powder_line
+from mslice.plotting.pyplot import GlobalFigureManager
 from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
 
@@ -395,7 +396,6 @@ class SlicePlot(IPlot):
         if self.icut is not None:
             self.icut.clear()
             self.icut = None
-            from mslice.plotting.pyplot import GlobalFigureManager
             GlobalFigureManager.enable_make_current()
         else:
             self.icut = InteractiveCut(self, self._canvas, self.ws_name)

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.labels import generate_legend, is_momentum, is_twotheta
@@ -95,10 +97,8 @@ class CutPlotterPresenter(PresenterUtility):
 
     def add_overplot_line(self, workspace_name, key, recoil, cif=None):
         recoil = False
-        from mslice.plotting.pyplot import gca
-        cache = self._cut_cache_dict[gca()][0]
+        cache = self._cut_cache_dict[plt.gca()][0]
         cache.rotated = not is_twotheta(cache.cut_axis.units) and not is_momentum(cache.cut_axis.units)
-        import numpy as np
         try:
             ws_handle = get_workspace_handle(workspace_name)
             workspace_name = ws_handle.parent

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -1,5 +1,6 @@
 from six import string_types
 from matplotlib import text
+from matplotlib.mathtext import MathTextParser
 from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLabelOptions, QuickLineOptions, QuickError
 
 
@@ -51,7 +52,6 @@ def _set_axis_options(view, target, model, has_logarithmic, grid):
 
 def check_latex(value):
     if '$' in value:
-        from matplotlib.mathtext import MathTextParser
         parser = MathTextParser('ps')
         try:
             parser.parse(value)

--- a/mslice/presenters/slice_widget_presenter.py
+++ b/mslice/presenters/slice_widget_presenter.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 from .busy import show_busy
+import traceback
 from mslice.models.alg_workspace_ops import get_available_axes, get_axis_range
 from mslice.models.axis import Axis
 from mslice.models.units import EnergyUnits
@@ -66,7 +67,6 @@ class SliceWidgetPresenter(PresenterUtility, SlicePlotterPresenterInterface):
         try:
             self._slice_plotter_presenter.plot_slice(*args)
         except RuntimeError as e:
-            import traceback
             traceback.print_exc(e)
             self._slice_view.error(e.args[0])
         except ValueError as e:

--- a/mslice/quickview/workspace_manager_quickview.py
+++ b/mslice/quickview/workspace_manager_quickview.py
@@ -1,4 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
+from command import Command as c
 from quickview.QuickView import QuickView
 from WorkspaceManagerPresenter import WorkspaceManagerPresenter
 from workspacemanager.WorkspaceView import WorkspaceView
@@ -17,6 +18,5 @@ class WorkspaceManagerQuickView(QuickView,WorkspaceView):
 
 
 if __name__ == '__main__':
-    from command import Command as c
     m = WorkspaceManagerQuickView(c)
     m.app.exec_()

--- a/mslice/tests/cli_mslice_projection_test.py
+++ b/mslice/tests/cli_mslice_projection_test.py
@@ -6,6 +6,7 @@ from mantid.simpleapi import (AddSampleLog, CreateSampleWorkspace)
 import mslice.cli._mslice_commands as mc
 from mslice.workspace import wrap_workspace
 import mslice.plotting.pyplot as plt
+from mslice.plotting.plot_window.cut_plot import CutPlot
 from mslice.cli.plotfunctions import pcolormesh, errorbar
 from mslice.cli.helperfunctions import _get_overplot_key
 
@@ -139,7 +140,6 @@ class CLIProjectionTest(unittest.TestCase):
         self.assertEqual(plot_handler.manager._xgrid, b)
 
     def test_that_waterfall_command_works(self):
-        from mslice.plotting.plot_window.cut_plot import CutPlot
         active_figure = mock.MagicMock()
         active_figure.plot_handler = mock.MagicMock(spec=CutPlot)
 

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -1,6 +1,9 @@
 import unittest
 import mock
 import numpy as np
+
+from matplotlib.axes import Axes
+
 from mantid.simpleapi import (AddSampleLog, CreateSampleWorkspace, CreateMDHistoWorkspace, CreateSimulationWorkspace,
                               ConvertToMD)
 from mslice.cli._mslice_commands import (Load, MakeProjection, Slice, Cut, PlotCut, PlotSlice, KeepFigure, MakeCurrent,
@@ -224,7 +227,6 @@ class CommandLineTest(unittest.TestCase):
         is_gui.return_value = True
         workspace = self.create_workspace('test_plot_cut_non_psd_cli')
         cut = Cut(workspace)
-        from matplotlib.axes import Axes
         ax = mock.Mock(spec=Axes)
         ax.get_ylim.return_value = (0., 1.)
         ax.lines = mock.Mock

--- a/mslice/tests/pixel_workspace_test.py
+++ b/mslice/tests/pixel_workspace_test.py
@@ -4,6 +4,7 @@ import unittest
 
 from mantid.simpleapi import CreateSimulationWorkspace, ConvertToMD, AddSampleLog
 
+from mslice.workspace.helperfunctions import attribute_to_log
 from mslice.workspace.pixel_workspace import PixelWorkspace
 
 
@@ -78,7 +79,6 @@ class PixelWorkspaceTest(unittest.TestCase):
         self.assertAlmostEqual(35, result[3][52], 8)
 
     def test_attribute_propagation(self):
-        from mslice.workspace.helperfunctions import attribute_to_log
         self.attr = {'axes':[1, object]}
         attribute_to_log(self.attr, self.workspace.raw_ws)
         new_workspace = PixelWorkspace(self.workspace.raw_ws, 'new')

--- a/mslice/tests/slice_functions_test.py
+++ b/mslice/tests/slice_functions_test.py
@@ -122,7 +122,6 @@ class SliceFunctionsTest(unittest.TestCase):
 
     @patch('mslice.models.powder.powder_functions.get_workspace_handle')
     def test_powder_line(self, ws_handle_mock):
-        from mslice.models.axis import Axis
         ws_handle_mock.return_value.e_fixed = 20
         x, y = compute_powder_line('ws_name', Axis('|Q|', 0.1, 9.1, 0.1), 'Copper')
         self.assertEqual(len(x), len(y))
@@ -134,7 +133,6 @@ class SliceFunctionsTest(unittest.TestCase):
 
     @patch('mslice.models.powder.powder_functions.get_workspace_handle')
     def test_powder_line_degrees(self, ws_handle_mock):
-        from mslice.models.axis import Axis
         ws_handle_mock.return_value.e_fixed = 20
         x, y = compute_powder_line('ws_name', Axis('Degrees', 3, 93, 1), 'Copper')
         self.assertEqual(len(x), len(y))

--- a/mslice/tests/slice_plotter_presenter_test.py
+++ b/mslice/tests/slice_plotter_presenter_test.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 import mock
 import unittest
+import numpy as np
 
 from mslice.models.axis import Axis
 from mslice.models.cmap import DEFAULT_CMAP
@@ -75,7 +76,6 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         slice_presenter.add_overplot_line('workspace', recoil_key, True)
         compute_recoil_mock.assert_called_once()
         cache_mock.overplot_lines.__setitem__.assert_called_with(recoil_key, 'plot')
-        import numpy as np
         plot_line_mock.assert_called_with([1], np.array([2]) * 8.065544, recoil_key, True, cache_mock)
         slice_presenter.add_overplot_line('workspace', powder_key, False)
         compute_powder_mock.assert_called_once()

--- a/mslice/tests/workspace_test.py
+++ b/mslice/tests/workspace_test.py
@@ -4,6 +4,7 @@ import unittest
 import numpy as np
 from mantid.simpleapi import CreateWorkspace
 
+from mslice.workspace.helperfunctions import attribute_to_log
 from mslice.workspace.workspace import Workspace
 
 
@@ -52,7 +53,6 @@ class BaseWorkspaceTest(unittest.TestCase):
         self.assertTrue((result == expected_values).all())
 
     def set_attribute(self):
-        from mslice.workspace.helperfunctions import attribute_to_log
         self.attr = {'axes':[1, object]}
         attribute_to_log(self.attr, self.workspace.raw_ws)
 


### PR DESCRIPTION
To clean up the code a bit some of the imports were moved to the top of their respective files. Unfortunately it is not possible to move all imports in this way as it causes problems with circular dependencies.

**To test:**

Check that tests are still passing.

Fixes #645.
