### PR TITLE
Removed delete line button for quick options dialog

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -243,7 +243,10 @@ class CutPlot(IPlot):
         main_line.set_linestyle(line_options['style'])
         main_line.set_marker(line_options['marker'])
 
-        self._legends_visible[line_index] = bool(line_options['legend'])
+        try:
+            self._legends_visible[line_index] = bool(line_options['legend'])
+        except IndexError:
+            self._legends_visible.append(bool(line_options['legend']))
 
         self.toggle_errorbar(line_index, line_options)
 

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -348,12 +348,12 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
             self.show_line = None
             self.show_legend = None
 
+        # for quick options the color validator and the delete button is not used
         if self.color_validator is not None:
             self.line_color.currentIndexChanged.connect(lambda selected: self.color_valid(selected))
-
-        self.delete_button = QtWidgets.QPushButton("Delete Line", self)
-        row5.addWidget(self.delete_button)
-        self.delete_button.clicked.connect(self.deleteLater)
+            self.delete_button = QtWidgets.QPushButton("Delete Line", self)
+            row5.addWidget(self.delete_button)
+            self.delete_button.clicked.connect(self.deleteLater)
 
         separator = QtWidgets.QFrame()
         separator.setFrameShape(QtWidgets.QFrame.HLine)


### PR DESCRIPTION
Removed the Delete Line button from the edit line dialog.

**To test:**

1. In the Workspace Manager tab select the workspace MAR21335_Ei60meV
2. Navigate to the Cut tab
3. In the row labelled along, set the from value to 0 and the to value to 10
4. In the row labelled over, set the from value to -5 and the to value to 5
5. Click Plot. A new window with a cut plot should open.
6. Double click on the line. A line editor should open.
7. Check that there is no Delete Line button

Fixes #674.
