### PR TITLE
Replace conda nose with pip nose

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - ipython
   - matplotlib
   - mock
-  - nose
   - numpy
   - numpy-base
   - pip
@@ -19,5 +18,6 @@ dependencies:
   - pip:
       - coverage
       - h5py
+      - nose
       - pre-commit
       - pyyaml


### PR DESCRIPTION
For some reason nose did not get installed properly anymore for GitHub workflows. By using pip instead of conda for installing nose this problem is fixed.
