### PR TITLE
Fixed save to workspace button

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -105,6 +105,7 @@ rectangle by clicking outside the current rectangle and dragging. Once you have 
 ``Interactive Cut`` again to leave interactive mode. If you leave a slice in interactive cut mode and plot another
 slice, another window will open. Making a cut (see below) whilst the interactive mode is active will overplot on the
 same window as the interactive cut and this cut will be removed when the interactive mode rectangle is moved again.
+Only when you click ``Save Cut to Workspace`` an ``MD Histo`` type workspace is created.
 
 Plotting a Cut
 --------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -105,7 +105,7 @@ rectangle by clicking outside the current rectangle and dragging. Once you have 
 ``Interactive Cut`` again to leave interactive mode. If you leave a slice in interactive cut mode and plot another
 slice, another window will open. Making a cut (see below) whilst the interactive mode is active will overplot on the
 same window as the interactive cut and this cut will be removed when the interactive mode rectangle is moved again.
-Only when you click ``Save Cut to Workspace`` an ``MD Histo`` type workspace is created.
+Only when you click ``Save Cut to Workspace`` is an ``MD Histo`` type workspace created.
 
 Plotting a Cut
 --------------

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - ipython
   - matplotlib
   - mock
-  - nose
   - numpy
   - numpy-base
   - pip
@@ -19,5 +18,6 @@ dependencies:
   - pip:
       - coverage
       - h5py
+      - nose
       - pre-commit
       - pyyaml

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -250,7 +250,7 @@
                   </property>
                   <property name="maximumSize">
                    <size>
-                    <width>110</width>
+                    <width>130</width>
                     <height>16777215</height>
                    </size>
                   </property>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -75,7 +75,7 @@
                 <widget class="QPushButton" name="btnRename">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -101,7 +101,7 @@
                 <widget class="QPushButton" name="btnDelete">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -114,7 +114,7 @@
                 <widget class="QPushButton" name="btnAdd">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -127,7 +127,7 @@
                 <widget class="QPushButton" name="btnSave">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -140,7 +140,7 @@
                 <widget class="QPushButton" name="btnPlot">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -153,7 +153,7 @@
                 <widget class="QPushButton" name="btnMerge">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -166,7 +166,7 @@
                 <widget class="QPushButton" name="btnOverplot">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -179,7 +179,7 @@
                 <widget class="QPushButton" name="btnSubtract">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>
@@ -211,7 +211,7 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>25</height>
                   </size>
                  </property>
@@ -232,7 +232,7 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>110</width>
+                    <width>130</width>
                     <height>25</height>
                    </rect>
                   </property>
@@ -244,7 +244,7 @@
                   </property>
                   <property name="minimumSize">
                    <size>
-                    <width>110</width>
+                    <width>130</width>
                     <height>25</height>
                    </size>
                   </property>
@@ -264,7 +264,7 @@
                 <widget class="QFrame" name="composeFrame">
                  <property name="maximumSize">
                   <size>
-                   <width>110</width>
+                   <width>130</width>
                    <height>16777215</height>
                   </size>
                  </property>

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -1,6 +1,7 @@
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.labels import generate_legend, is_momentum, is_twotheta
+from mslice.models.workspacemanager.workspace_algorithms import export_workspace_to_ads
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 import mslice.plotting.pyplot as plt
 from mslice.presenters.presenter_utility import PresenterUtility
@@ -20,11 +21,11 @@ class CutPlotterPresenter(PresenterUtility):
     def run_cut(self, workspace, cut, plot_over=False, save_only=False):
         workspace = get_workspace_handle(workspace)
         cut.workspace_name = workspace.name
-
+        if save_only:
+            self.save_cut_to_workspace(workspace, cut)
+            return
         if cut.width is not None:
             self._plot_with_width(workspace, cut, plot_over)
-        elif save_only:
-            self.save_cut_to_workspace(workspace, cut)
         else:
             self._plot_cut(workspace, cut, plot_over)
 
@@ -67,8 +68,9 @@ class CutPlotterPresenter(PresenterUtility):
         return self._cut_cache_dict[ax] if ax in self._cut_cache_dict.keys() else None
 
     def save_cut_to_workspace(self, workspace, cut):
-        compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one, cut.algorithm)
+        cut_ws = compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one, cut.algorithm)
         self._main_presenter.update_displayed_workspaces()
+        export_workspace_to_ads(cut_ws)
 
     def plot_cut_from_selected_workspace(self, plot_over=False):
         selected_workspaces = self._main_presenter.get_selected_workspaces()

--- a/mslice/tests/cut_plotter_presenter_test.py
+++ b/mslice/tests/cut_plotter_presenter_test.py
@@ -53,7 +53,8 @@ class CutPlotterPresenterTest(unittest.TestCase):
     @mock.patch('mslice.presenters.cut_plotter_presenter.get_workspace_handle')
     @mock.patch('mslice.presenters.cut_plotter_presenter.compute_cut')
     @mock.patch('mslice.presenters.cut_plotter_presenter.plot_cut_impl')
-    def test_save_to_workspace_success(self, plot_cut_impl_mock, compute_cut_mock, get_ws_handle_mock):
+    @mock.patch('mslice.presenters.cut_plotter_presenter.export_workspace_to_ads')
+    def test_save_to_workspace_success(self, export_workspace_to_ads, plot_cut_impl_mock, compute_cut_mock, get_ws_handle_mock):
         mock_ws = mock.MagicMock()
         mock_ws.name = 'workspace'
         get_ws_handle_mock.return_value = mock_ws
@@ -61,6 +62,7 @@ class CutPlotterPresenterTest(unittest.TestCase):
 
         self.cut_plotter_presenter.run_cut('workspace', cut_cache, save_only=True)
         self.assertEqual(1, compute_cut_mock.call_count)
+        self.assertEqual(1, export_workspace_to_ads.call_count)
         self.assertEqual(0, plot_cut_impl_mock.call_count)
 
     @mock.patch('mslice.presenters.cut_plotter_presenter.get_workspace_handle')

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -9,6 +9,7 @@ from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget
 from mslice.util.qt import load_ui
 from mslice.util.qt.validator_helper import double_validator_without_separator
+from mslice.util.mantid import in_mantid
 
 from mslice.presenters.cut_widget_presenter import CutWidgetPresenter
 
@@ -32,7 +33,7 @@ class CutWidget(CutView, QWidget):
         self._command_lookup = {
             self.btnCutPlot: Command.Plot,
             self.btnCutPlotOver: Command.PlotOver,
-            self.btnCutSaveToWorkspace: Command.SaveToWorkspace
+            self.btnCutSaveToWorkbench: Command.SaveToWorkspace
         }
         for button in self._command_lookup.keys():
             button.clicked.connect(self._btn_clicked)
@@ -263,11 +264,14 @@ class CutWidget(CutView, QWidget):
         self.lneCutIntensityEnd.setEnabled(True)
         self.rdoCutNormToOne.setEnabled(True)
 
-        self.btnCutSaveToWorkspace.setEnabled(False)
+        self.btnCutSaveToWorkbench.setEnabled(False)
         self.btnCutPlot.setEnabled(False)
         self.btnCutPlotOver.setEnabled(False)
 
-        self.btnCutSaveToWorkspace.setEnabled(True)
+        if in_mantid():
+            self.btnCutSaveToWorkbench.setEnabled(True)
+        else:
+            self.btnCutSaveToWorkbench.hide()
         self.btnCutPlot.setEnabled(True)
         self.btnCutPlotOver.setEnabled(True)
 
@@ -286,7 +290,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutIntensityEnd.setEnabled(False)
         self.rdoCutNormToOne.setEnabled(False)
 
-        self.btnCutSaveToWorkspace.setEnabled(False)
+        self.btnCutSaveToWorkbench.setEnabled(False)
         self.btnCutPlot.setEnabled(False)
         self.btnCutPlotOver.setEnabled(False)
 

--- a/mslice/widgets/cut/cut.ui
+++ b/mslice/widgets/cut/cut.ui
@@ -173,12 +173,12 @@
       </widget>
      </item>
      <item row="4" column="3" colspan="3">
-      <widget class="QPushButton" name="btnCutSaveToWorkspace">
+      <widget class="QPushButton" name="btnCutSaveToWorkbench">
        <property name="enabled">
         <bool>true</bool>
        </property>
        <property name="text">
-        <string>Save to Workspace</string>
+        <string>Save to Workbench</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
The `Save to Workspace` button on the cut tab is now called `Save to Workbench` and does save the corresponding MD Histo workspace to the ADS. In addition, the `Save to Workbench` button on the MD Histo tab was resized so that the button text is fully visible. The documentation was updated with details on the  `Save to Workbench` buttons and the `Save Cut to Workspace` button.

**To test:**

Check spelling and grammar of the documentation changes. Try out the  `Save to Workbench` button for a cut.

Fixes #673.
