### PR TITLE
Add latex installation in doc build action

### DIFF
--- a/.github/workflows/onlinedocupdate.yml
+++ b/.github/workflows/onlinedocupdate.yml
@@ -13,6 +13,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Update dependencies
+      run: |
+        sudo apt-get install texlive-latex-base texlive-latex-recommended \
+            texlive-fonts-recommended texlive-latex-extra dvipng
     - name: Build and Commit
       uses: sphinx-notes/pages@1.0
       with:


### PR DESCRIPTION
Adds installation of `texlive` so that equations in the documentation (particularly [here](https://mantidproject.github.io/mslice/slicing.html#converting-intensity-information-in-displayed-data)) work.

**To test:**

Make sure all CI tasks run and equations are displayed correctly in the online docs.

----

No issues.