### PR TITLE
Update cut algorithm names and added combo box on cut tab

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Flake8
         run: |
-          python setup.py flake8
+          python -m flake8
 
       - name: Nosetests
         run: |

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Flake8
         run: |
-          python setup.py flake8
+          python -m flake8
 
       - name: Nosetests
         run: |

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -261,8 +261,10 @@ class MainWindow(MainView, QMainWindow):
         for action in self._cut_algo_map.keys():
             if algo not in action:
                 self._cut_algo_map[action].setChecked(False)
+        self._presenter.set_cut_algorithm_default(self.get_cut_algorithm())
 
     def get_cut_algorithm(self):
         for action in self._cut_algo_map.keys():
             if self._cut_algo_map[action].isChecked():
+                print(action)
                 return action

--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -113,8 +113,8 @@ class MainWindow(MainView, QMainWindow):
         self.actionEUnitConvEnabled.triggered.connect(partial(self.set_energy_conversion, True))
         self.actionEUnitConvDisabled.triggered.connect(partial(self.set_energy_conversion, False))
         self._cut_algo_map = {'Rebin': self.actionCutAlgoRebin, 'Integration': self.actionCutAlgoIntegration}
-        self.actionCutAlgoRebin.triggered.connect(partial(self.set_cut_algorithm, 'Rebin'))
-        self.actionCutAlgoIntegration.triggered.connect(partial(self.set_cut_algorithm, 'Integration'))
+        self.actionCutAlgoRebin.triggered.connect(partial(self.set_cut_algorithm_default, 'Rebin'))
+        self.actionCutAlgoIntegration.triggered.connect(partial(self.set_cut_algorithm_default, 'Integration'))
 
     def setup_save(self):
         menu = QMenu()
@@ -254,17 +254,11 @@ class MainWindow(MainView, QMainWindow):
         else:
             self.actionEUnitConvEnabled.setChecked(not self.actionEUnitConvDisabled.isChecked())
 
-    def is_energy_conversion_allowed(self):
-        return self.actionEUnitConvEnabled.isChecked()
-
-    def set_cut_algorithm(self, algo):
+    def set_cut_algorithm_default(self, algo):
         for action in self._cut_algo_map.keys():
             if algo not in action:
                 self._cut_algo_map[action].setChecked(False)
-        self._presenter.set_cut_algorithm_default(self.get_cut_algorithm())
+        self._presenter.set_cut_algorithm_default(algo)
 
-    def get_cut_algorithm(self):
-        for action in self._cut_algo_map.keys():
-            if self._cut_algo_map[action].isChecked():
-                print(action)
-                return action
+    def is_energy_conversion_allowed(self):
+        return self.actionEUnitConvEnabled.isChecked()

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -470,7 +470,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Rebin</string>
+    <string>Rebin (Averages Counts)</string>
    </property>
   </action>
   <action name="actionCutAlgoIntegration">
@@ -478,7 +478,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Integration</string>
+    <string>Integration (Sum Counts)</string>
    </property>
   </action>
  </widget>

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -426,7 +426,7 @@
     </widget>
     <widget class="QMenu" name="menuCutAlgo">
      <property name="title">
-      <string>Cut algorithm</string>
+      <string>Cut algorithm default</string>
      </property>
      <addaction name="actionCutAlgoRebin"/>
      <addaction name="actionCutAlgoIntegration"/>

--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -202,7 +202,5 @@ class CutWidgetPresenter(PresenterUtility):
         self._cut_view.set_energy_units(en_default)
 
     def set_cut_algorithm_default(self, algo_default):
-        print("cut default")
-        print(algo_default)
         self._cut_view.set_cut_alg_default(algo_default)
         self._cut_view.set_cut_algorithm(algo_default)

--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -95,7 +95,7 @@ class CutWidgetPresenter(PresenterUtility):
 
         norm_to_one = bool(self._cut_view.get_intensity_is_norm_to_one())
         width = self._cut_view.get_integration_width()
-        algo = self._cut_view.get_cut_algorithm()
+        algo = ['Rebin', 'Integration'][self._cut_view.get_cut_algorithm()]
         return cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width, algo
 
     def _set_minimum_step(self, workspace, axis):

--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -95,7 +95,7 @@ class CutWidgetPresenter(PresenterUtility):
 
         norm_to_one = bool(self._cut_view.get_intensity_is_norm_to_one())
         width = self._cut_view.get_integration_width()
-        algo = self._main_presenter.get_cut_algorithm() if self._main_presenter is not None else 'Rebin'
+        algo = self._cut_view.get_cut_algorithm()
         return cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width, algo
 
     def _set_minimum_step(self, workspace, axis):
@@ -200,3 +200,9 @@ class CutWidgetPresenter(PresenterUtility):
         self._en_default = en_default
         self._cut_view.set_energy_units_default(en_default)
         self._cut_view.set_energy_units(en_default)
+
+    def set_cut_algorithm_default(self, algo_default):
+        print("cut default")
+        print(algo_default)
+        self._cut_view.set_cut_alg_default(algo_default)
+        self._cut_view.set_cut_algorithm(algo_default)

--- a/mslice/presenters/interfaces/main_presenter.py
+++ b/mslice/presenters/interfaces/main_presenter.py
@@ -50,6 +50,10 @@ class MainPresenterInterface(object):
         pass
 
     @abc.abstractmethod
+    def subscribe_to_cut_algo_default_monitor(self, client):
+        pass
+
+    @abc.abstractmethod
     def is_energy_conversion_allowed(self):
         pass
 

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -72,8 +72,7 @@ class MainPresenter(MainPresenterInterface):
             listener.set_energy_default(en_default)
 
     def subscribe_to_cut_algo_default_monitor(self, client):
-        print("client")
-        if isinstance(getattr(client, "set_cut_algo_default", None), collections.Callable):
+        if isinstance(getattr(client, "set_cut_algorithm_default", None), collections.Callable):
             self._cut_algo_default_listener.append(client)
 
     def set_cut_algorithm_default(self, algo_default):

--- a/mslice/presenters/main_presenter.py
+++ b/mslice/presenters/main_presenter.py
@@ -9,6 +9,7 @@ class MainPresenter(MainPresenterInterface):
         self._mainView = main_view
         self._selected_workspace_listener = []
         self._energy_default_listener = []
+        self._cut_algo_default_listener = []
         for presenter in subpresenters:
             presenter.register_master(self)
 
@@ -69,6 +70,15 @@ class MainPresenter(MainPresenterInterface):
     def set_energy_default(self, en_default):
         for listener in self._energy_default_listener:
             listener.set_energy_default(en_default)
+
+    def subscribe_to_cut_algo_default_monitor(self, client):
+        print("client")
+        if isinstance(getattr(client, "set_cut_algo_default", None), collections.Callable):
+            self._cut_algo_default_listener.append(client)
+
+    def set_cut_algorithm_default(self, algo_default):
+        for listener in self._cut_algo_default_listener:
+            listener.set_cut_algorithm_default(algo_default)
 
     def is_energy_conversion_allowed(self):
         return self._mainView.is_energy_conversion_allowed()

--- a/mslice/presenters/presenter_utility.py
+++ b/mslice/presenters/presenter_utility.py
@@ -8,6 +8,7 @@ class PresenterUtility(object):
         self._main_presenter = main_presenter
         self._main_presenter.subscribe_to_workspace_selection_monitor(self)
         self._main_presenter.subscribe_to_energy_default_monitor(self)
+        self._main_presenter.subscribe_to_cut_algo_default_monitor(self)
 
     def _to_float(self, x):
         return None if x == "" else float(x)

--- a/mslice/tests/cut_widget_presenter_test.py
+++ b/mslice/tests/cut_widget_presenter_test.py
@@ -113,7 +113,7 @@ class CutWidgetPresenterTest(unittest.TestCase):
         axis, processed_axis = tuple(args[0:2])
         integration_start, integration_end, width = tuple(args[2:5])
         intensity_start, intensity_end, is_norm = tuple(args[5:8])
-        workspace, integrated_axis = tuple(args[8:10])
+        workspace, integrated_axis, cut_algorithm = tuple(args[8:11])
         if isinstance(workspace, string_types):
             workspace = [workspace]
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=workspace)
@@ -129,6 +129,7 @@ class CutWidgetPresenterTest(unittest.TestCase):
         self.view.get_intensity_is_norm_to_one = mock.Mock(return_value=is_norm)
         self.view.get_integration_width = mock.Mock(return_value=width)
         self.view.get_energy_units = mock.Mock(return_value=axis.e_unit)
+        self.view.get_cut_algorithm = mock.Mock(return_value=cut_algorithm)
 
     def test_cut_no_workspaces_selected_fail(self):
         cut_widget_presenter = CutWidgetPresenter(self.view)
@@ -164,7 +165,6 @@ class CutWidgetPresenterTest(unittest.TestCase):
         fields1['cut_parameters'] = ['0', '10', '0.05']
         fields1['integration_range'] = ['-1', '1']
         fields1['integration_width'] = '2'
-        fields1['smoothing'] = ''
         fields1['normtounity'] = False
         self.view.get_input_fields = mock.Mock(return_value=fields1)
         self.view.get_cut_axis = mock.Mock(return_value='DeltaE')
@@ -180,7 +180,6 @@ class CutWidgetPresenterTest(unittest.TestCase):
         fields2['cut_parameters'] = ['-5', '5', '0.1']
         fields2['integration_range'] = ['2', '3']
         fields2['integration_width'] = '1'
-        fields2['smoothing'] = ''
         fields2['normtounity'] = True
         self.view.get_input_fields = mock.Mock(return_value=fields2)
         self.view.get_cut_axis = mock.Mock(return_value='|Q|')
@@ -226,8 +225,10 @@ class CutWidgetPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
+        cut_algorithm = 'Rebin'
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
-                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis,
+                         cut_algorithm)
         self.view.get_cut_axis_step = mock.Mock(return_value="")
         self.view.get_minimum_step = mock.Mock(return_value=1)
 
@@ -252,9 +253,11 @@ class CutWidgetPresenterTest(unittest.TestCase):
         is_norm = True
         selected_workspaces = ["ws1", "ws2"]
         integrated_axis = 'integrated axis'
+        cut_algorithm = 'Rebin'
         integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
         self._create_cut(axis, integration_axis, integration_start, integration_end, width,
-                         intensity_start, intensity_end, is_norm, selected_workspaces, integrated_axis)
+                         intensity_start, intensity_end, is_norm, selected_workspaces, integrated_axis,
+                         cut_algorithm)
         cut_widget_presenter.notify(Command.Plot)
         call_list = [
             call(selected_workspaces[0], mock.ANY, save_only=False, plot_over=False),
@@ -279,9 +282,10 @@ class CutWidgetPresenterTest(unittest.TestCase):
         intensity_start, intensity_end, is_norm, workspace = (11, 30, True, 'ws1')
         axis = Axis("units", "0", "100", "1")
         integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
+        cut_algorithm = 'Integration'
         self._create_cut(axis, integration_axis, integration_start, integration_end, width,
-                         intensity_start, intensity_end, is_norm, workspace, integrated_axis)
-        self.main_presenter.get_cut_algorithm = mock.Mock(return_value='Integration')
+                         intensity_start, intensity_end, is_norm, workspace, integrated_axis,
+                         cut_algorithm)
         cut_widget_presenter.notify(Command.Plot)
         self.view.display_error.assert_not_called()
         mock_cut_obj.assert_called_once_with(axis, integration_axis, intensity_start, intensity_end,

--- a/mslice/tests/cut_widget_presenter_test.py
+++ b/mslice/tests/cut_widget_presenter_test.py
@@ -225,7 +225,7 @@ class CutWidgetPresenterTest(unittest.TestCase):
         is_norm = True
         workspace = "workspace"
         integrated_axis = 'integrated axis'
-        cut_algorithm = 'Rebin'
+        cut_algorithm = 0
         self._create_cut(axis, processed_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis,
                          cut_algorithm)
@@ -253,7 +253,7 @@ class CutWidgetPresenterTest(unittest.TestCase):
         is_norm = True
         selected_workspaces = ["ws1", "ws2"]
         integrated_axis = 'integrated axis'
-        cut_algorithm = 'Rebin'
+        cut_algorithm = 0
         integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
         self._create_cut(axis, integration_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, selected_workspaces, integrated_axis,
@@ -282,7 +282,7 @@ class CutWidgetPresenterTest(unittest.TestCase):
         intensity_start, intensity_end, is_norm, workspace = (11, 30, True, 'ws1')
         axis = Axis("units", "0", "100", "1")
         integration_axis = Axis('integrated axis', integration_start, integration_end, 0)
-        cut_algorithm = 'Integration'
+        cut_algorithm = 1
         self._create_cut(axis, integration_axis, integration_start, integration_end, width,
                          intensity_start, intensity_end, is_norm, workspace, integrated_axis,
                          cut_algorithm)

--- a/mslice/tests/main_presenter_test.py
+++ b/mslice/tests/main_presenter_test.py
@@ -83,3 +83,21 @@ class MainPresenterTests(unittest.TestCase):
         main_presenter = MainPresenter(self.mainview)
         main_presenter.is_energy_conversion_allowed()
         self.mainview.is_energy_conversion_allowed.assert_called()
+
+    def test_set_cut_algorithm_default(self):
+        main_presenter = MainPresenter(self.mainview)
+        clients = [[mock.Mock(), True], [mock.Mock(), False], [mock.Mock(), True]]
+        for client, enable in clients:
+            if not enable:
+                client.set_cut_algorithm_default = mock.NonCallableMagicMock()
+            main_presenter.subscribe_to_cut_algo_default_monitor(client)
+
+        for client, enable in clients:
+            client.set_energy_default.assert_not_called()
+
+        main_presenter.set_cut_algorithm_default('Rebin')
+        for client, enable in clients:
+            if enable:
+                client.set_cut_algorithm_default.assert_called_once()
+            else:
+                client.set_cut_algorithm_default.assert_not_called()

--- a/mslice/views/interfaces/cut_view.py
+++ b/mslice/views/interfaces/cut_view.py
@@ -38,9 +38,6 @@ class CutView:
     def get_intensity_is_norm_to_one(self):
         pass
 
-    def get_smoothing(self):
-        pass
-
     def get_presenter(self):
         pass
 
@@ -60,6 +57,12 @@ class CutView:
         pass
 
     def set_energy_units(self, unit):
+        pass
+
+    def get_cut_algorithm(self):
+        pass
+
+    def set_cut_algorithm(self, algo):
         pass
 
     def set_energy_units_default(self, unit):

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -26,6 +26,7 @@ from .command import Command
 class CutWidget(CutView, QWidget):
     error_occurred = Signal('QString')
     busy = Signal(bool)
+    _name_to_index = {'Rebin':0, 'Integration':1}
 
     def __init__(self, parent=None, *args, **kwargs):
         QWidget.__init__(self, parent, *args, **kwargs)
@@ -45,7 +46,10 @@ class CutWidget(CutView, QWidget):
         self.set_validators()
         self._en = EnergyUnits('meV')
         self._en_default = 'meV'
+        self._cut_alg_default = 'Rebin'
+        self.set_cut_algorithm('Rebin')
         self.cmbCutEUnits.currentIndexChanged.connect(self._changed_unit)
+        self.cmbCutAlg.currentIndexChanged.connect(self.cut_algorithm_changed)
 
     def _btn_clicked(self):
         sender = self.sender()
@@ -89,6 +93,9 @@ class CutWidget(CutView, QWidget):
 
     def display_error(self, error_string):
         self.error_occurred.emit(error_string)
+
+    def cut_algorithm_changed(self, _changed_index):
+        self.get_input_fields()
 
     def axis_changed(self, _changed_index):
         self._presenter.notify(Command.AxisChanged)
@@ -143,9 +150,6 @@ class CutWidget(CutView, QWidget):
     def get_intensity_is_norm_to_one(self):
         return self.rdoCutNormToOne.isChecked()
 
-    def get_smoothing(self):
-        return str(self.lneCutSmoothing.text())
-
     def get_energy_units(self):
         return self.cmbCutEUnits.currentText()
 
@@ -154,6 +158,15 @@ class CutWidget(CutView, QWidget):
 
     def set_energy_units_default(self, unit):
         self._en_default = unit
+
+    def set_cut_alg_default(self, algo_default):
+        self._cut_alg_default = algo_default
+
+    def get_cut_algorithm(self):
+        return self.cmbCutAlg.currentIndex()
+
+    def set_cut_algorithm(self, algo):
+        self.cmbCutAlg.setCurrentIndex(self._name_to_index[algo])
 
     def set_cut_axis(self, axis_name):
         index = [ind for ind in range(self.cmbCutAxis.count()) if str(self.cmbCutAxis.itemText(ind)) == axis_name]
@@ -208,8 +221,8 @@ class CutWidget(CutView, QWidget):
         self.populate_cut_params("", "", "")
         self.populate_integration_params("", "")
         self.lneCutIntegrationWidth.setText("")
-        self.lneCutSmoothing.setText("")
         self.rdoCutNormToOne.setChecked(0)
+        self.cmbCutAlg.setCurrentIndex(self._name_to_index[self._cut_alg_default])
         self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(self._en_default))
 
     def is_fields_cleared(self):
@@ -217,20 +230,20 @@ class CutWidget(CutView, QWidget):
         cleared_fields = {'cut_parameters': ['', '', ''],
                           'integration_range': ['', ''],
                           'integration_width': '',
-                          'smoothing': '',
-                          'normtounity': False}
+                          'normtounity': False,
+                          'cut_algorithm_index': ''}
         for k in cleared_fields:
             if current_fields[k] != cleared_fields[k]:
                 return False
         return True
 
     def populate_input_fields(self, saved_input):
-        self.cmbCutEUnits.blockSignals(True)
         self.populate_cut_params(*saved_input['cut_parameters'])
         self.populate_integration_params(*saved_input['integration_range'])
         self.lneCutIntegrationWidth.setText(saved_input['integration_width'])
-        self.lneCutSmoothing.setText(saved_input['smoothing'])
         self.rdoCutNormToOne.setChecked(saved_input['normtounity'])
+        self.cmbCutAlg.setCurrentIndex(saved_input['cut_algorithm_index'])
+        self.cmbCutEUnits.blockSignals(True)
         self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(saved_input['energy_unit']))
         self._en = EnergyUnits(saved_input['energy_unit'])
         self.cmbCutEUnits.blockSignals(False)
@@ -243,8 +256,8 @@ class CutWidget(CutView, QWidget):
         saved_input['cut_parameters'] = list(cut_params)
         saved_input['integration_range'] = list(int_params)[:2]
         saved_input['integration_width'] = list(int_params)[2]
-        saved_input['smoothing'] = self.get_smoothing()
         saved_input['normtounity'] = self.get_intensity_is_norm_to_one()
+        saved_input['cut_algorithm_index'] = self.get_cut_algorithm()
         saved_input['energy_unit'] = self.get_energy_units()
         return saved_input
 
@@ -254,6 +267,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutStep.setEnabled(True)
         self.cmbCutAxis.setEnabled(True)
         self.cmbCutEUnits.setEnabled(True)
+        self.cmbCutAlg.setEnabled(True)
 
         self.lneCutIntegrationStart.setEnabled(True)
         self.lneCutIntegrationEnd.setEnabled(True)
@@ -280,6 +294,7 @@ class CutWidget(CutView, QWidget):
         self.lneCutStep.setEnabled(False)
         self.cmbCutAxis.setEnabled(False)
         self.cmbCutEUnits.setEnabled(False)
+        self.cmbCutAlg.setEnabled(False)
 
         self.lneCutIntegrationStart.setEnabled(False)
         self.lneCutIntegrationEnd.setEnabled(False)

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -238,12 +238,12 @@ class CutWidget(CutView, QWidget):
         return True
 
     def populate_input_fields(self, saved_input):
+        self.cmbCutEUnits.blockSignals(True)
         self.populate_cut_params(*saved_input['cut_parameters'])
         self.populate_integration_params(*saved_input['integration_range'])
         self.lneCutIntegrationWidth.setText(saved_input['integration_width'])
         self.rdoCutNormToOne.setChecked(saved_input['normtounity'])
         self.cmbCutAlg.setCurrentIndex(saved_input['cut_algorithm_index'])
-        self.cmbCutEUnits.blockSignals(True)
         self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(saved_input['energy_unit']))
         self._en = EnergyUnits(saved_input['energy_unit'])
         self.cmbCutEUnits.blockSignals(False)

--- a/mslice/widgets/cut/cut.ui
+++ b/mslice/widgets/cut/cut.ui
@@ -124,23 +124,13 @@
      <item row="2" column="5">
       <widget class="QLineEdit" name="lneCutIntensityEnd"/>
      </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="label_5">
-       <property name="visible">
-        <bool>false</bool>
+     <item row="3" column="2" colspan="2">
+      <widget class="QPushButton" name="btnCutSaveToWorkbench">
+       <property name="enabled">
+        <bool>true</bool>
        </property>
        <property name="text">
-        <string>Smoothing</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2" colspan="2">
-      <widget class="QLineEdit" name="lneCutSmoothing">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="visible">
-        <bool>false</bool>
+        <string>Save to Workbench</string>
        </property>
       </widget>
      </item>
@@ -172,14 +162,25 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="3" colspan="3">
-      <widget class="QPushButton" name="btnCutSaveToWorkbench">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
+     <item row="4" column="1">
+      <widget class="QLabel" name="labCutAlg">
        <property name="text">
-        <string>Save to Workbench</string>
+        <string>Cut Algorithm</string>
        </property>
+      </widget>
+     </item>
+     <item row="4" column="2" colspan="2">
+      <widget class="QComboBox" name="cmbCutAlg">
+       <item>
+        <property name="text">
+         <string>Rebin (Averages Counts)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Integration (Sum Counts)</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="4" column="6" colspan="2">

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -103,7 +103,7 @@ def {name}():
 '''
 
 
-def boilerplate_gen():
+def boilerplate_gen():# noqa: C901
     """Generator of lines for the automated part of pyplot."""
 
     # these methods are all simple wrappers of Axes methods by the same
@@ -208,8 +208,8 @@ def boilerplate_gen():
                 return '=mlab.' + value.__name__
             if value.__name__ == 'mean':
                 return '=np.' + value.__name__
-            raise ValueError(('default value %s unknown to boilerplate.' +
-                             'formatvalue') % value)
+            raise ValueError(('default value %s unknown to boilerplate.'
+                             + 'formatvalue') % value)
         return '=' + repr(value)
 
     text_wrapper = textwrap.TextWrapper(break_long_words=False)
@@ -243,7 +243,7 @@ def boilerplate_gen():
                 def_edited = []
                 for val in defaults:
                     if six.PY2:
-                        if isinstance(val, unicode):
+                        if isinstance(val, str):
                             val = val.encode('ascii', 'ignore')
                     def_edited.append(val)
                 defaults = tuple(def_edited)


### PR DESCRIPTION
The cut algorithm names were misleading and easily overlooked as only available as a global setting in the main menu.
The displayed names are now updated and the cut tab has a combo box to select the cut algorithm individually (using the previously unused slot for the Smooth input ). The logic behind this is the same as for the energy units. The global setting changes the current workspace and every new workspace, previous workspaces remember their setting.

**To test:**

Check both global and local cut algorithm settings.

The documentation is not yet updated to reflect this and will be updated as part of #689.

Fixes #687.
