### PR TITLE
Pyplot update

### DIFF
--- a/mslice/plotting/pyplot.py
+++ b/mslice/plotting/pyplot.py
@@ -3199,6 +3199,8 @@ def plot(*args, **kwargs):
     ax = gca()
     # Deprecated: allow callers to override the hold state
     # by passing hold=True|False
+    if not hasattr(ax, '_hold'):
+        return ax.plot(*args, **kwargs)
     washold = ax._hold
     hold = kwargs.pop('hold', None)
     if hold is not None:


### PR DESCRIPTION
MSlice has a version of `pyplot.py` from Matplotlib in order to provide a similar command line interface - this was copied almost verbatim from Matplotlib 1.5 and was updated to Matplotlib 2 several years ago. Since then Matplotlib 3 has been released which has removed the deprecated `hold` option and this now causes non-MSlice plotting to fail.

This change is just to check if the hold feature is present or not and if not to not crash due to an `AttributeError`. 

A more long lasting fix is to refactor the `pyplot.py` file to import from the underlying Matplotlib `pyplot` instead of copying its contents as described in issue #693

**To test:**

Run the script in issue #686 with a Matplotlib 3 installation and check that it does not error and a sine curve is plotted.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #686
