### PR TITLE
Add "sum" option to PSD Cut

### DIFF
--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -173,6 +173,12 @@ class CommandLineTest(unittest.TestCase):
         self.assertEqual(128, signal[0])
         self.assertEqual(192, signal[29])
         self.assertEqual(429, signal[15])
+        result = Cut(workspace, Algorithm='Integration')
+        signal = result.get_signal()
+        self.assertEqual(type(result), HistogramWorkspace)
+        self.assertAlmostEqual(64, signal[0], 2)
+        self.assertAlmostEqual(192, signal[29], 2)
+        self.assertAlmostEqual(1287, signal[15], 2)
 
     @mock.patch('mslice.app.presenters.get_slice_plotter_presenter')
     def test_slice_fail_workspace_type(self, get_spp):

--- a/mslice/workspace/histo_mixin.py
+++ b/mslice/workspace/histo_mixin.py
@@ -8,7 +8,7 @@ class HistoMixin(object):
 
     def get_signal(self):
         """Gets data values (Y axis) from the workspace as a numpy array."""
-        return self._raw_ws.getSignalArray().copy()
+        return np.squeeze(self._raw_ws.getSignalArray().copy())
 
     def get_error(self):
         """Gets error values (E) from the workspace as a numpy array."""
@@ -17,7 +17,7 @@ class HistoMixin(object):
     def get_variance(self, copy=True):
         """Gets variance (error^2) from the workspace as a numpy array."""
         variance = self._raw_ws.getErrorSquaredArray()
-        return variance.copy() if copy else variance
+        return np.squeeze(variance.copy() if copy else variance)
 
     def set_signal(self, signal):
         self._raw_ws.setSignalArray(signal)


### PR DESCRIPTION
This PR adds the option to run the `Cut` algorithm with an "Integration" (summed counts) method.

**To test:**

The test file (125MB) is on the `\\Olympic\Babylon` shared drive accessible in ISIS.

Run the following script:

```python
import mslice.cli as mc
import mslice.plotting.pyplot as plt

LET73024_1to1_3_70 = mc.Load(Filename=r'\\Olympic\Babylon5\Public\duc\Ross nxspe files\LET73024_1to1_3.70.nxs', OutputWorkspace='LET73024_1to1_3.70')
ws_LET73024_1to1_3_70_QE = mc.MakeProjection(InputWorkspace=LET73024_1to1_3_70, Axis1='|Q|', Axis2='DeltaE')

fig = plt.gcf()
fig.clf()
ax = fig.add_subplot(111, projection="mslice")

algo = 'Integration'
for intrng in [0.5, 1, 2]:
    cut = mc.Cut(ws_LET73024_1to1_3_70_QE, CutAxis="|Q|,0.0,2.0,0.01166", IntegrationAxis=f"DeltaE,-{intrng},{intrng},0.0", NormToOne=False, Algorithm=algo)
    ax.errorbar(cut, label=f"LET73024_1to1_3.70_QE -{intrng}<E<{intrng}", intensity_range=(0,1000))

ax.set_title('')
ax.set_ylabel(r'Signal/#Events')
ax.set_ylim(bottom=0.0, top=1000.0)
ax.set_xlim(left=0.017441860465116282, right=2.063953488372093)
mc.Show()
```

Without this PR the plots look the same regardless of the value of `algo` (either `Rebin` or `Integration`). With this PR the plot should look like:

![int_psd_correct](https://user-images.githubusercontent.com/14106963/152014435-45fb0259-9371-46ba-a681-a6a9e5b8c966.png)

with the lines approximately at the same values.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #695.
