### PR TITLE
Add ability to change slice plot font sizes using quick options

### DIFF
--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -325,12 +325,28 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.canvas.figure.gca().set_xlim(value)
 
     @property
+    def x_range_font_size(self):
+        return self.canvas.figure.gca().xaxis.get_ticklabels()[0].get_size()
+
+    @x_range_font_size.setter
+    def x_range_font_size(self, font_size):
+        self.canvas.figure.gca().tick_params(axis='x', labelsize=font_size)
+
+    @property
     def y_range(self):
         return self.figure.gca().get_ylim()
 
     @y_range.setter
     def y_range(self, value):
         self.figure.gca().set_ylim(value)
+
+    @property
+    def y_range_font_size(self):
+        return self.canvas.figure.gca().yaxis.get_ticklabels()[0].get_size()
+
+    @y_range_font_size.setter
+    def y_range_font_size(self, font_size):
+        self.canvas.figure.gca().tick_params(axis='y', labelsize=font_size)
 
     @property
     def x_grid(self):

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -24,7 +24,7 @@ class QuickOptions(QtWidgets.QDialog):
 
 class QuickAxisOptions(QuickOptions):
 
-    def __init__(self, target, existing_values, grid, log, redraw_signal):
+    def __init__(self, target, existing_values, fontsize, grid, log, redraw_signal):
         super(QuickAxisOptions, self).__init__()
         self.setWindowTitle("Edit " + target)
         self.log = log
@@ -34,26 +34,35 @@ class QuickAxisOptions(QuickOptions):
         self.max_label = QtWidgets.QLabel("Max:")
         self.max = QtWidgets.QLineEdit()
         self.max.setText(str(existing_values[1]))
+        self.font_size_label = QtWidgets.QLabel("Font Size:")
+        self.font_size = QtWidgets.QDoubleSpinBox()
+        self.decimals = 1
+        self.font_size.setValue(fontsize)
+
         row1 = QtWidgets.QHBoxLayout()
         row2 = QtWidgets.QHBoxLayout()
+        row3 = QtWidgets.QHBoxLayout()
         row1.addWidget(self.min_label)
         row1.addWidget(self.min)
         row2.addWidget(self.max_label)
         row2.addWidget(self.max)
+        row3.addWidget(self.font_size_label)
+        row3.addWidget(self.font_size)
         self.layout.addLayout(row1)
         self.layout.addLayout(row2)
+        self.layout.addLayout(row3)
         if grid is not None:
             self.grid = QtWidgets.QCheckBox("Grid", self)
             self.grid.setChecked(grid)
-            row3 = QtWidgets.QHBoxLayout()
-            row3.addWidget(self.grid)
-            self.layout.addLayout(row3)
+            row4 = QtWidgets.QHBoxLayout()
+            row4.addWidget(self.grid)
+            self.layout.addLayout(row4)
         if log is not None:
             self.log_scale = QtWidgets.QCheckBox("Logarithmic", self)
             self.log_scale.setChecked(self.log)
-            row4 = QtWidgets.QHBoxLayout()
-            row4.addWidget(self.log_scale)
-            self.layout.addLayout(row4)
+            row5 = QtWidgets.QHBoxLayout()
+            row5.addWidget(self.log_scale)
+            self.layout.addLayout(row5)
         self.layout.addLayout(self.button_row)
         self.layout.addWidget(self.keep_open)
         self.ok_button.clicked.disconnect()
@@ -87,19 +96,40 @@ class QuickLabelOptions(QuickOptions):
     ok_clicked = Signal()
     cancel_clicked = Signal()
 
-    def __init__(self, label):
+    def __init__(self, label, redraw_signal):
         super(QuickLabelOptions, self).__init__()
         self.setWindowTitle("Edit " + label.get_text())
         self.line_edit = QtWidgets.QLineEdit()
         self.line_edit.setText(label.get_text())
+        self.font_size_label = QtWidgets.QLabel("Font Size:")
+        self.font_size = QtWidgets.QDoubleSpinBox()
+        self.font_size.setValue(label.get_size())
+
+        row1 = QtWidgets.QHBoxLayout()
+        row1.addWidget(self.font_size_label)
+        row1.addWidget(self.font_size)
+
         self.layout.addWidget(self.line_edit)
+        self.layout.addLayout(row1)
         self.layout.addLayout(self.button_row)
         self.line_edit.show()
+
+        self.redraw_signal = redraw_signal
+        self.ok_button.disconnect()
+        self.ok_button.clicked.connect(self._ok_clicked)
 
     @property
     def label(self):
         return self.line_edit.text()
 
+    @property
+    def label_font_size(self):
+        return self.font_size.value()
+
+    def _ok_clicked(self):
+        self.ok_clicked.emit()
+        self.redraw_signal.emit()
+        self.accept()
 
 class QuickLineOptions(QuickOptions):
 

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -24,7 +24,7 @@ class QuickOptions(QtWidgets.QDialog):
 
 class QuickAxisOptions(QuickOptions):
 
-    def __init__(self, target, existing_values, fontsize, grid, log, redraw_signal):
+    def __init__(self, target, existing_values, font_size, grid, log, redraw_signal):
         super(QuickAxisOptions, self).__init__()
         self.setWindowTitle("Edit " + target)
         self.log = log
@@ -37,7 +37,7 @@ class QuickAxisOptions(QuickOptions):
         self.font_size_label = QtWidgets.QLabel("Font Size:")
         self.font_size = QtWidgets.QDoubleSpinBox()
         self.decimals = 1
-        self.font_size.setValue(fontsize)
+        self.font_size.setValue(font_size)
 
         row1 = QtWidgets.QHBoxLayout()
         row2 = QtWidgets.QHBoxLayout()

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -5,6 +5,7 @@ from qtpy.QtCore import Qt
 
 import matplotlib.colors as colors
 from matplotlib.legend import Legend
+from matplotlib.text import Text
 
 from mslice.models.colors import to_hex
 from mslice.models.units import get_sample_temperature_from_string
@@ -172,6 +173,9 @@ class SlicePlot(IPlot):
     def object_clicked(self, target):
         if isinstance(target, Legend):
             return
+        elif isinstance(target, Text):
+            quick_options(target, self, redraw_signal=self.plot_window.redraw)
+
         else:
             quick_options(target, self)
             self.update_legend()
@@ -444,6 +448,14 @@ class SlicePlot(IPlot):
         self.change_axis_scale(value, self.colorbar_log)
 
     @property
+    def colorbar_range_font_size(self):
+        return self._canvas.figure.get_axes()[1].get_yticklabels()[0].get_size()
+
+    @colorbar_range_font_size.setter
+    def colorbar_range_font_size(self, value):
+        self._canvas.figure.get_axes()[1].tick_params(axis='y', which='both', labelsize=value)
+
+    @property
     def colorbar_log(self):
         return isinstance(self._canvas.figure.gca().collections[0].norm, colors.LogNorm)
 
@@ -493,12 +505,28 @@ class SlicePlot(IPlot):
         self.manager.x_range = value
 
     @property
+    def x_range_font_size(self):
+        return self.manager.x_range_font_size
+
+    @x_range_font_size.setter
+    def x_range_font_size(self, font_size):
+        self.manager.x_range_font_size = font_size
+
+    @property
     def y_range(self):
         return self.manager.y_range
 
     @y_range.setter
     def y_range(self, value):
         self.manager.y_range = value
+
+    @property
+    def y_range_font_size(self):
+        return self.manager.y_range_font_size
+
+    @y_range_font_size.setter
+    def y_range_font_size(self, font_size):
+        self.manager.y_range_font_size = font_size
 
     @property
     def x_grid(self):

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -7,24 +7,24 @@ from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLab
 def quick_options(target, model, has_logarithmic=None, redraw_signal=None):
     """Find which quick_options to use based on type of target"""
     if isinstance(target, text.Text):
-        quick_label_options(target)
+        quick_label_options(target, redraw_signal)
     elif isinstance(target, string_types):
         return quick_axis_options(target, model, has_logarithmic, redraw_signal)
     else:
         quick_line_options(target, model)
 
 
-def quick_label_options(target):
-    view = QuickLabelOptions(target)
-    _run_quick_options(view, _set_label, target)
-
+def quick_label_options(target, redraw_signal):
+    view = QuickLabelOptions(target, redraw_signal)
+    view.ok_clicked.connect(lambda: _set_label_options(view, target))
+    view.show()
 
 def quick_axis_options(target, model, has_logarithmic=None, redraw_signal=None):
     if target[:1] == 'x' or target[:1] == 'y':
         grid = getattr(model, target[:-5] + 'grid')
     else:
         grid = None
-    view = QuickAxisOptions(target, getattr(model, target), grid, has_logarithmic, redraw_signal)
+    view = QuickAxisOptions(target, getattr(model, target), getattr(model, target + '_font_size'), grid, has_logarithmic, redraw_signal)
     view.ok_clicked.connect(lambda: _set_axis_options(view, target, model, has_logarithmic, grid))
     view.show()
     return view
@@ -44,11 +44,17 @@ def _run_quick_options(view, update_model_function, *args):
 def _set_axis_options(view, target, model, has_logarithmic, grid):
     range = (float(view.range_min), float(view.range_max))
     setattr(model, target, range)
+
     if has_logarithmic is not None:
         setattr(model, target[:-5] + 'log', view.log_scale.isChecked())
     if grid is not None:
         setattr(model, target[:-5] + 'grid', view.grid_state)
 
+    setattr(model, target + "_font_size", view.font_size.value())
+
+def _set_label_options(view, target):
+    _set_label(view,target)
+    _set_font_size(view, target)
 
 def check_latex(value):
     if '$' in value:
@@ -67,6 +73,9 @@ def _set_label(view, target):
     else:
         QuickError('Invalid LaTeX in label string')
 
+def _set_font_size(view, target):
+    size = view.label_font_size
+    target.set_size(size)
 
 def _set_line_options(view, model, line):
     line_options = {}

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -14,10 +14,12 @@ def quick_options(target, model, has_logarithmic=None, redraw_signal=None):
         quick_line_options(target, model)
 
 
-def quick_label_options(target, redraw_signal):
+def quick_label_options(target, redraw_signal=None):
     view = QuickLabelOptions(target, redraw_signal)
     view.ok_clicked.connect(lambda: _set_label_options(view, target))
     view.show()
+    return view
+
 
 def quick_axis_options(target, model, has_logarithmic=None, redraw_signal=None):
     if target[:1] == 'x' or target[:1] == 'y':


### PR DESCRIPTION
Allows the user to change font sizes on slice plots using the quick options (right click). I have no added this functionality to the settings menu as it could crowd the menu, but could do if it is desired.

quick label options now trigger via a qt signal as per quick axis options. Relevant unit tests have been updated to reflect this.

<!-- Instructions for testing. -->
1) Open MSlice (Interfaces > Direct > MSlice)
2) Use file browser on data loading tab to load appropriate data (MAR21335_Ei60meV used)
3) Click display on slice sub-tab on Workspace Manager tab.
4) Right click on the following features, and change the font size using the spinbox. Following the change on font size, right click on the feature again and check the spinbox contains the correct value.
> - Plot Title
> - Axis Labels
> - Axis Tick Labels
> - Colorbar Labels
> - Colorbar Tick labels

Resolves #530.
