### PR TITLE
Fix "Legends enabled in plot options and quick option despite being disabled on plot window"

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -212,11 +212,12 @@ class CutPlot(IPlot):
             all_line_options.append(line_options)
         return all_line_options
 
-    def set_all_line_options(self, line_data):
+    def set_all_line_options(self, line_data, update_legend):
         containers = self._canvas.figure.gca().containers
         for i in range(len(containers)):
             self.set_line_options_by_index(i, line_data[i])
-        self.update_legend(line_data)
+        if update_legend:
+            self.update_legend(line_data)
 
     def _single_line_has_error_bars(self, line_index):
         current_axis = self._canvas.figure.gca()

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -220,7 +220,7 @@ class CutPlotOptions(PlotOptionsDialog):
 
     def disable_show_legend(self):
         for line_widget in self._line_widgets:
-            line_widget.show_legend.setEnabled(self.chkShowLegends.isChecked())
+            line_widget.show_legend_line_specific.setEnabled(self.chkShowLegends.isChecked())
 
     @property
     def x_log(self):
@@ -340,21 +340,21 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
             self.show_line = QtWidgets.QCheckBox("Show Line")
             self.show_line.setChecked(line_options['shown'])
 
-            self.show_legend = QtWidgets.QCheckBox("Show Legend")
-            self.show_legend.setChecked(line_options['legend'])
+            self.show_legend_line_specific = QtWidgets.QCheckBox("Show Legend")
+            self.show_legend_line_specific.setChecked(line_options['legend'])
 
             if show_legends:
-                self.show_legend.setEnabled(line_options['shown'])
+                self.show_legend_line_specific.setEnabled(line_options['shown'])
             else:
-                self.show_legend.setEnabled(show_legends)
+                self.show_legend_line_specific.setEnabled(show_legends)
 
             row5.addWidget(self.show_line)
-            row4.addWidget(self.show_legend)
+            row4.addWidget(self.show_legend_line_specific)
 
             self.show_line.stateChanged.connect(lambda state: self.show_line_changed(state))
         else:
             self.show_line = None
-            self.show_legend = None
+            self.show_legend_line_specific = None
 
         # for quick options the color validator and the delete button is not used
         if self.color_validator is not None:
@@ -378,8 +378,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     def show_line_changed(self, state):
         #  automatically shows/hides legend if line is shown/hidden
-        self.show_legend.setEnabled(state)
-        self.show_legend.setChecked(state)
+        self.show_legend_line_specific.setEnabled(state)
+        self.show_legend_line_specific.setChecked(state)
 
         self.error_bar_checkbox.setEnabled(state)
         self.error_bar_checkbox.setChecked(state)
@@ -396,9 +396,9 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     @property
     def legend(self):
-        if self.show_legend is None:
+        if self.show_legend_line_specific is None:
             return None
-        return self.show_legend.checkState()
+        return self.show_legend_line_specific.checkState()
 
     @property
     def label(self):

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -182,10 +182,11 @@ class CutPlotOptions(PlotOptionsDialog):
         self.chkXLog.stateChanged.connect(self.xLogEdited)
         self.chkYLog.stateChanged.connect(self.yLogEdited)
         self.chkShowLegends.stateChanged.connect(self.showLegendsEdited)
+        self.showLegendsEdited.connect(self.disable_show_legend)
 
     def set_line_options(self, line_options):
         for i in range(len(line_options)):
-            line_widget = LegendAndLineOptionsSetter(line_options[i], self.color_validator)
+            line_widget = LegendAndLineOptionsSetter(line_options[i], self.color_validator, self.show_legends)
             line_widget.destroyed.connect(functools.partial(self.remove_line_widget, line_widget, i))
             self.verticalLayout_legend.addWidget(line_widget)
             self._line_widgets.append(line_widget)
@@ -216,6 +217,10 @@ class CutPlotOptions(PlotOptionsDialog):
     def remove_line_widget(self, selected, index):
         self._line_widgets.remove(selected)
         self.removed_line.emit(index)
+
+    def disable_show_legend(self):
+        for line_widget in self._line_widgets:
+            line_widget.show_legend.setEnabled(self.chkShowLegends.isChecked())
 
     @property
     def x_log(self):
@@ -257,7 +262,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
     inverse_styles = {v: k for k, v in iteritems(styles)}
     inverse_markers = {v: k for k, v in iteritems(markers)}
 
-    def __init__(self, line_options, color_validator):
+    def __init__(self, line_options, color_validator, show_legends=None):
         super(LegendAndLineOptionsSetter, self).__init__()
 
         self.legend_text_label = QtWidgets.QLabel("Plot")
@@ -338,7 +343,10 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
             self.show_legend = QtWidgets.QCheckBox("Show Legend")
             self.show_legend.setChecked(line_options['legend'])
 
-            self.show_legend.setEnabled(line_options['shown'])
+            if show_legends:
+                self.show_legend.setEnabled(line_options['shown'])
+            else:
+                self.show_legend.setEnabled(show_legends)
 
             row5.addWidget(self.show_line)
             row4.addWidget(self.show_legend)

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -262,7 +262,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
     inverse_styles = {v: k for k, v in iteritems(styles)}
     inverse_markers = {v: k for k, v in iteritems(markers)}
 
-    def __init__(self, line_options, color_validator, show_legends=None):
+    def __init__(self, line_options, color_validator, show_legends):
         super(LegendAndLineOptionsSetter, self).__init__()
 
         self.legend_text_label = QtWidgets.QLabel("Plot")

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -136,10 +136,10 @@ class QuickLineOptions(QuickOptions):
     ok_clicked = Signal()
     cancel_clicked = Signal()
 
-    def __init__(self, line_options):
+    def __init__(self, line_options, show_legends):
         super(QuickLineOptions, self).__init__()
         self.setWindowTitle("Edit line")
-        self.line_widget = LegendAndLineOptionsSetter(line_options, None)
+        self.line_widget = LegendAndLineOptionsSetter(line_options, None, show_legends)
         self.layout.addWidget(self.line_widget)
         self.layout.addLayout(self.button_row)
 

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -12,7 +12,6 @@ class PlotOptionsPresenter(object):
 
         self.set_properties()  # propagate dialog with existing data
 
-
         self._view.titleEdited.connect(partial(self._value_modified, 'title'))
         self._view.xLabelEdited.connect(partial(self._value_modified, 'x_label'))
         self._view.yLabelEdited.connect(partial(self._value_modified, 'y_label'))
@@ -20,7 +19,6 @@ class PlotOptionsPresenter(object):
         self._view.yRangeEdited.connect(partial(self._xy_config_modified, 'y_range'))
         self._view.xGridEdited.connect(partial(self._value_modified, 'x_grid'))
         self._view.yGridEdited.connect(partial(self._value_modified, 'y_grid'))
-
 
     def _value_modified(self, value_name):
         self._modified_values[value_name] = getattr(self._view, value_name)

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -12,6 +12,7 @@ class PlotOptionsPresenter(object):
 
         self.set_properties()  # propagate dialog with existing data
 
+
         self._view.titleEdited.connect(partial(self._value_modified, 'title'))
         self._view.xLabelEdited.connect(partial(self._value_modified, 'x_label'))
         self._view.yLabelEdited.connect(partial(self._value_modified, 'y_label'))
@@ -19,6 +20,7 @@ class PlotOptionsPresenter(object):
         self._view.yRangeEdited.connect(partial(self._xy_config_modified, 'y_range'))
         self._view.xGridEdited.connect(partial(self._value_modified, 'x_grid'))
         self._view.yGridEdited.connect(partial(self._value_modified, 'y_grid'))
+
 
     def _value_modified(self, value_name):
         self._modified_values[value_name] = getattr(self._view, value_name)
@@ -90,9 +92,20 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         self._model.remove_line_by_index(index)
 
     def get_new_config(self):
+        current_show_legends = getattr(self._model, 'show_legends')
+        new_show_legends = current_show_legends
+
         if self._xy_config['modified']:
             self._model.change_axis_scale(self._xy_config)
         for key, value in list(self._modified_values.items()):
-            setattr(self._model, key, value)
+            if key is 'show_legends':
+                new_show_legends = value
+            else:
+                setattr(self._model, key, value)
+
         line_options = self._view.get_line_options()
-        self._model.set_all_line_options(line_options)
+
+        if new_show_legends is not current_show_legends:
+            self._model.manager.window.action_toggle_legends.trigger()
+
+        self._model.set_all_line_options(line_options, new_show_legends)

--- a/mslice/presenters/plot_options_presenter.py
+++ b/mslice/presenters/plot_options_presenter.py
@@ -96,7 +96,7 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         if self._xy_config['modified']:
             self._model.change_axis_scale(self._xy_config)
         for key, value in list(self._modified_values.items()):
-            if key is 'show_legends':
+            if key == 'show_legends':
                 new_show_legends = value
             else:
                 setattr(self._model, key, value)

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -33,7 +33,7 @@ def quick_axis_options(target, model, has_logarithmic=None, redraw_signal=None):
 
 
 def quick_line_options(target, model):
-    view = QuickLineOptions(model.get_line_options(target))
+    view = QuickLineOptions(model.get_line_options(target), model.show_legends)
     _run_quick_options(view, _set_line_options, model, target)
 
 

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -1,5 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
-from mock import MagicMock, PropertyMock, Mock
+from mock import MagicMock, PropertyMock, Mock, ANY
 import unittest
 from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter, SlicePlotOptionsPresenter
 
@@ -207,7 +207,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.presenter.get_new_config()
 
         self.view.get_line_options.assert_called_once_with()
-        self.model.set_all_line_options.assert_called_once_with(line_data2, Mock.ANY)
+        self.model.set_all_line_options.assert_called_once_with(line_data2, ANY)
 
     def test_remove_line(self):
         self.remove_line_by_index = Mock()

--- a/mslice/tests/plot_options_presenter_test.py
+++ b/mslice/tests/plot_options_presenter_test.py
@@ -207,7 +207,7 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         self.presenter.get_new_config()
 
         self.view.get_line_options.assert_called_once_with()
-        self.model.set_all_line_options.assert_called_once_with(line_data2)
+        self.model.set_all_line_options.assert_called_once_with(line_data2, Mock.ANY)
 
     def test_remove_line(self):
         self.remove_line_by_index = Mock()

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -37,7 +37,7 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, self.model)
         label_options_mock.assert_called_once_with(target, None)
 
-    @patch.object(QuickLineOptions, '__init__', lambda x, y: None)
+    @patch.object(QuickLineOptions, '__init__', lambda x, y, z: None)
     @patch.object(QuickLineOptions, 'exec_', lambda x: None)
     @patch('mslice.presenters.quick_options_presenter.quick_line_options')
     def test_line(self, line_options_mock):
@@ -45,7 +45,7 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, self.model)
         line_options_mock.assert_called_once_with(target, self.model)
 
-    @patch.object(QuickLineOptions, '__init__', lambda x, y: None)
+    @patch.object(QuickLineOptions, '__init__', lambda x, y, z: None)
     @patch.object(QuickLineOptions, 'exec_', lambda x: None)
     @patch('mslice.presenters.quick_options_presenter.quick_axis_options')
     def test_axis(self, axis_options_mock):
@@ -53,8 +53,9 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, self.model)
         axis_options_mock.assert_called_once_with(target, self.model, None, None)
 
+    @patch('mslice.plotting.plot_window.cut_plot.CutPlot.show_legends', new_callable=PropertyMock(return_value=True))
     @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
-    def test_line_slice(self, qlo_mock):
+    def test_line_slice(self, qlo_mock, show_legends):
         plot_figure = MagicMock()
         window = MagicMock()
         plot_figure.window = window
@@ -63,19 +64,21 @@ class QuickOptionsTest(unittest.TestCase):
         slice_plotter = MagicMock()
         model = SlicePlot(plot_figure, slice_plotter, 'workspace')
         qlo_mock, target = setup_line_values(qlo_mock)
+
         quick_options(target, model)
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
             {'shown': None, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
-             'marker': 'o', 'legend': None, 'error_bar': None})
+             'marker': 'o', 'legend': None, 'error_bar': None}, True)
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
                              {'shown': None, 'color': '#0000ff', 'label': u'label2',
                               'style': '--', 'width': '5', 'marker': '.', 'legend': None,
                               'error_bar': None})
 
+    @patch('mslice.plotting.plot_window.cut_plot.CutPlot.show_legends', new_callable=PropertyMock(return_value=True))
     @patch('mslice.presenters.quick_options_presenter.QuickLineOptions')
-    def test_line_cut(self, qlo_mock):
+    def test_line_cut(self, qlo_mock, show_legends):
         plot_figure = MagicMock()
         window = MagicMock()
         plot_figure.window = window
@@ -95,7 +98,7 @@ class QuickOptionsTest(unittest.TestCase):
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
             {'shown': True, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
-             'marker': 'o', 'legend': True, 'error_bar': False})
+             'marker': 'o', 'legend': True, 'error_bar': False}, True)
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
                              {'shown': True, 'color': '#0000ff', 'label': u'label2',


### PR DESCRIPTION
**Description of work:**

This fixes various issues with the "show legends" checkbox on the plot options window, and related line specific "show legend" checkboxes.

**To test:**
- In the Workspace Manager tab select the workspace MAR21335_Ei60meV
- Navigate to the Cut tab
- In the row labelled along, set the from value to 0 and the to value to 10
- In the row labelled over, set the from value to -5 and the to value to 5
- Click Plot. A new window with a cut plot should open.

Ensure:
-"Legends" toggle button on plot window aligns with "Show Legends" checkbox at the top of the "Legend and Line Options page. Check that toggling button off/on effects the checkbox, and vice versa.
- When show legends is unchecked, any line specific "show legend" checkboxes are disabled. When checked, the line specific "show legend" checkboxes are enabled.
- Check that the both "show legends" checkbox and line specific "show legends" checkboxes function as expected ("show legends" removes whole legend, individual "show legend" removes individual lines from legend.
- Check that functionality works as expected with multiple lines.
- Double click on the line. A line editor should open. Ensure the check box for 'Show Legend' is selected on this option window, and that is aligns with the individual "show legend" checkboxes on the options menu.

Fixes #681
