### PR TITLE
Fix "Menu for Default Energy Unit empty"

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -105,7 +105,7 @@ class MainWindow(MainView, QMainWindow):
 
         self._en_default_actions = []
         for e_unit in EnergyUnits.get_all_units():
-            action = add_action(self.menuDefault_Energy_Units, self, e_unit, checkable=True)
+            action = add_action(self.menuDefault_Energy_Units, self, e_unit, checkable=True, visible=True)
             action.triggered.connect(partial(self.set_energy_default, action))
             self._en_default_actions.append(action)
         self._en_default_actions[0].setChecked(True)


### PR DESCRIPTION
**Description of work**
During last release, the `add_action` feature of `plot_window` was updated so that visibility is set to 'False' by default. The associated call to this function with regards to default energy units has been updated to set visibility to 'True'.

**To test:**

<!-- Instructions for testing. -->
1) Open MSlice
2) Click Options -> Default Energy Unit
3) Check Menu is populated

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #712
