### PR TITLE
Update to matplotlib 3.5

### DIFF
--- a/mslice/cli/plotfunctions.py
+++ b/mslice/cli/plotfunctions.py
@@ -66,7 +66,7 @@ def errorbar(axes, workspace, *args, **kwargs):
     axes.set_xlabel(get_display_name(cut_axis), picker=CUT_PICKER_TOL_PTS)
     axes.set_ylabel(CUT_INTENSITY_LABEL, picker=CUT_PICKER_TOL_PTS)
     if not plot_over:
-        cur_canvas.set_window_title(workspace.name)
+        cur_canvas.manager.set_window_title(workspace.name)
         cur_canvas.manager.update_grid()
     if not cur_canvas.manager.has_plot_handler():
         cur_canvas.manager.add_cut_plot(presenter, workspace.name)

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -1,5 +1,7 @@
+from distutils.version import LooseVersion
 from functools import partial
 
+from matplotlib import __version__ as mpl_version
 from matplotlib.collections import LineCollection
 from matplotlib.container import ErrorbarContainer
 from matplotlib.legend import Legend
@@ -398,7 +400,8 @@ class CutPlot(IPlot):
                     line.set_xdata(self._waterfall_cache[line][0] + ind * x)
                     line.set_ydata(self._waterfall_cache[line][1] + ind * y)
                 elif isinstance(line, LineCollection):
-                    line.set_offset_position('data')
+                    if LooseVersion(mpl_version) < LooseVersion('3.3'):
+                        line.set_offset_position('data') # set_offset_position is deprecated since 3.3
                     line.set_offsets((ind * x, ind * y))
 
     def on_newplot(self, ax):

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -12,7 +12,7 @@ def plot_cached_slice(slice_workspace, slice_cache):
 @plt.set_category(plt.CATEGORY_SLICE)
 def create_slice_figure(workspace_name, presenter):
     fig_canvas = plt.gcf().canvas
-    fig_canvas.set_window_title(workspace_name)
+    fig_canvas.manager.set_window_title(workspace_name)
     fig_canvas.manager.add_slice_plot(presenter, workspace_name)
     fig_canvas.manager.update_grid()
     plt.draw_all()


### PR DESCRIPTION
Added fixes for matplotlib functionality that is deprecated since 3.2.1 so that MSlice can be used with matplotlib 3.5 but still works with older versions as well (3.2.1 on Windows and 2.2.3 on Linux). 

**To test:**

1. Open MSlice
2. Load data, for instance MAR21335_Ei60meV.nxs from unit tests
3. Click Display on Slice tab and check that there are no error messages
4. Navigate to Cut tab
5. Enter '0' in the 'from' boxes as well as '1' in the 'to' boxes for x and y
6. Enter '0.2' in width
7. Click Plot and check that there is no error message and no warning apart from 'converting a masked element to nan.'
8. Click Waterfall and try different values for x and y offsets. There should be no warnings or error messages.

Fixes #720.
