### PR TITLE
Explicitly check out main branch

### DIFF
--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout MSlice
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: main
 
       - name: Check for changes since last build
         run: |


### PR DESCRIPTION
The github workflow for the nightly build of MSlice did have an empty GIT_DESCRIBE_TAG and therefore the created conda package with a version number of 0.0.0. Now the main branch gets checked out explicitly as this should provide the correct GIT_DESCRIBE_TAG.

**To test:**

Unfortunately this can only be tested by merging the fix into main and checking the nightly conda package one day later. The worst case would be a still incorrect version number.
