### PR TITLE
Use conda packages with mantid nightly label for unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install mantid mantidqt
+          conda install -c mantid/label/nightly mantid mantidqt
 
       - name: Flake8
         run: |

--- a/.github/workflows/unit_tests_nighly.yml
+++ b/.github/workflows/unit_tests_nighly.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install mantid mantidqt
+          conda install -c mantid/label/nightly mantid mantidqt
 
       - name: Flake8
         run: |


### PR DESCRIPTION
For unit tests the aim is to test MSlice with the nightly versions of the Mantid conda packages and not with the released Mantid conda packages so that any problems caused by recent changes in these packages can be detected.

It is not necessary to install mantid and mantidqt with the mantid/label/nightly label as this is set in the environment file. However, once there are both main and nightly versions available for mantid and mantidqt this modification ensures that the nightly version and not the main version is used.

**To Test**

Check that unit tests were successful.
