### PR TITLE
Reset Bragg peaks and recoil lines for new display of slice

### DIFF
--- a/mslice/cli/plotfunctions.py
+++ b/mslice/cli/plotfunctions.py
@@ -103,13 +103,16 @@ def pcolormesh(axes, workspace, *args, **kwargs):
     intensity = kwargs.pop('intensity', None)
     temperature = kwargs.pop('temperature', None)
 
+    plot_handler = GlobalFigureManager.get_active_figure().plot_handler
+    plot_handler.on_newplot()
+
     if temperature is not None:
         get_slice_plotter_presenter().set_sample_temperature(workspace.name[2:], temperature)
 
     if intensity is not None and intensity != 's(q,e)':
         workspace = getattr(slice_cache, _intensity_to_workspace[intensity])
         plot_window = GlobalFigureManager.get_active_figure().window
-        plot_handler = GlobalFigureManager.get_active_figure().plot_handler
+
         intensity_action = getattr(plot_window, _intensity_to_action[intensity])
         plot_handler.set_intensity(intensity_action)
         intensity_action.setChecked(True)
@@ -128,6 +131,7 @@ def pcolormesh(axes, workspace, *args, **kwargs):
 
     if not workspace.is_PSD and not slice_cache.rotated:
         workspace = Transpose(OutputWorkspace=workspace.name, InputWorkspace=workspace, store=False)
+
     axesfunctions.pcolormesh(axes, workspace.raw_ws, *args, **kwargs)
     axes.set_title(workspace.name[2:], picker=SLICE_PICKER_TOL_PTS)
     x_axis = slice_cache.energy_axis if slice_cache.rotated else slice_cache.momentum_axis

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -425,6 +425,18 @@ class SlicePlot(IPlot):
     def update_workspaces(self):
         self._slice_plotter_presenter.update_displayed_workspaces()
 
+    def on_newplot(self):
+        # This callback should be activated by a call to pcolormesh
+        self.plot_window.action_hydrogen.setChecked(False)
+        self.plot_window.action_deuterium.setChecked(False)
+        self.plot_window.action_helium.setChecked(False)
+        self.plot_window.action_arbitrary_nuclei.setChecked(False)
+        self.plot_window.action_aluminium.setChecked(False)
+        self.plot_window.action_copper.setChecked(False)
+        self.plot_window.action_niobium.setChecked(False)
+        self.plot_window.action_tantalum.setChecked(False)
+        self.plot_window.action_cif_file.setChecked(False)
+
     def generate_script(self, clipboard=False):
         try:
             generate_script(self.ws_name, None, self, self.plot_window, clipboard)


### PR DESCRIPTION
Clicking on Display in the slice tab is overwriting the currently displayed slice plot in case 'Keep' is not enabled. This means that Bragg peaks and recoil lines on the displayed slice plot have to be de-selected when the new slice is plotted. 

**To test:**

Plot a slice in MSlice via the slice tab and select a Bragg peak and a recoil line. Change the step size on the slice tab and click on Display. The slice plot should change according to the step size change and the Bragg peak and recoil line should disappear. Check that no Bragg peaks or recoil lines are selected in the corresponding menus.


Fixes #739.
