### PR TITLE
Changed default size for Bragg peaks on interactive plots

### DIFF
--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -107,7 +107,7 @@ class CutPlotterPresenter(PresenterUtility):
             scale_fac = np.nanmax(ws_handle.get_signal()) / 10
         except KeyError:
             # Workspace is interactively generated and is not in the workspace list
-            scale_fac = 1
+            scale_fac = 90
             workspace_name = workspace_name.split('(')[0][:-4]
         if cache.rotated:
             q_axis = cache.integration_axis


### PR DESCRIPTION
The lines for Bragg peaks were to small on interactive cuts due to a hardcoded scale factor. This scale factor was increased to a more suitable size.

**To test:**

Add a Bragg peak to an interactive cut and a normal cut plot. They should have similar sizes.

Fixes #735 
