### PR TITLE
Replaced error message for empty cut axes

### DIFF
--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -53,7 +53,10 @@ class CutWidgetPresenter(PresenterUtility):
             self._parse_step()
             params = self._parse_input()
         except ValueError as e:
-            self._cut_view.display_error(str(e))
+            if "''" in str(e):
+                self._cut_view.display_error("Cut axes cannot be empty!")
+            else:
+                self._cut_view.display_error(str(e))
             return
         for workspace in selected_workspaces:
             try:


### PR DESCRIPTION
Replaced the error message displayed when attempting to plot a cut without specifying cut axes.

**To test:**

Open a data set in MSlice and navigate to the Cut tab. Without entering any values, click on Plot and check the error message displayed on the bottom of the MSlice window.

Fixes #734 
