### PR TITLE
Fix Crash when setting axes to log scale

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -163,12 +163,12 @@ class CutPlot(IPlot):
         if xy_config['x_log']:
             xmin = xy_config['x_range'][0]
             xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
-            min = get_min(xdata, absolute_minimum=0.)
-            self.x_axis_min = min
-            if LooseVersion(mpl_version) < LooseVersion('3.3'):
-                current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(min))))
-            else:
-                current_axis.set_xscale('symlog', linthresh=pow(10, np.floor(np.log10(min))))
+            self.x_axis_min = get_min(xdata, absolute_minimum=0.)
+            linthresh_val = pow(10, np.floor(np.log10(self.x_axis_min)))
+
+            kwargs = {'linthreshx': linthresh_val} if LooseVersion(mpl_version) < LooseVersion('3.3') \
+                else {'linthresh': linthresh_val}
+            current_axis.set_xscale('symlog', **kwargs)
 
             if xmin > 0:
                 xy_config['x_range'] = (xmin, xy_config['x_range'][1])
@@ -177,12 +177,12 @@ class CutPlot(IPlot):
         if xy_config['y_log']:
             ymin = xy_config['y_range'][0]
             ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
-            min = get_min(ydata, absolute_minimum=0.)
-            self.y_axis_min = min
-            if LooseVersion(mpl_version) < LooseVersion('3.3'):
-                current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(min))))
-            else:
-                current_axis.set_yscale('symlog', linthresh=pow(10, np.floor(np.log10(min))))
+            self.y_axis_min = get_min(ydata, absolute_minimum=0.)
+            linthresh_val = pow(10, np.floor(np.log10(self.y_axis_min)))
+
+            kwargs = {'linthreshy': linthresh_val} if LooseVersion(mpl_version) < LooseVersion('3.3') \
+                else {'linthresh': linthresh_val}
+            current_axis.set_yscale('symlog', **kwargs)
 
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -165,7 +165,11 @@ class CutPlot(IPlot):
             xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
             min = get_min(xdata, absolute_minimum=0.)
             self.x_axis_min = min
-            current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(min))))
+            if LooseVersion(mpl_version) < LooseVersion('3.3'):
+                current_axis.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10(min))))
+            else:
+                current_axis.set_xscale('symlog', linthresh=pow(10, np.floor(np.log10(min))))
+
             if xmin > 0:
                 xy_config['x_range'] = (xmin, xy_config['x_range'][1])
         else:
@@ -175,7 +179,11 @@ class CutPlot(IPlot):
             ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
             min = get_min(ydata, absolute_minimum=0.)
             self.y_axis_min = min
-            current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(min))))
+            if LooseVersion(mpl_version) < LooseVersion('3.3'):
+                current_axis.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10(min))))
+            else:
+                current_axis.set_yscale('symlog', linthresh=pow(10, np.floor(np.log10(min))))
+
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])
         else:

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -135,7 +135,7 @@ def add_cut_plot_statements(script_lines, plot_handler, ax):
                             f"linthresh{x_axis_str}=pow(10, np.floor(np.log10({plot_handler.x_axis_min}))))\n")
 
     if plot_handler.is_changed("y_log"):
-        script_lines.append(f"ax.set_xscale('symlog', "
+        script_lines.append(f"ax.set_yscale('symlog', "
                             f"linthresh{y_axis_str}=pow(10, np.floor(np.log10({plot_handler.y_axis_min}))))\n")
 
 def add_cut_lines(script_lines, plot_handler, ax):

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -123,12 +123,8 @@ def add_cut_plot_statements(script_lines, plot_handler, ax):
     add_cut_lines(script_lines, plot_handler, ax)
     add_plot_options(script_lines, plot_handler)
 
-    if LooseVersion(mpl_version) < LooseVersion('3.3'):
-        x_axis_str = "x"
-        y_axis_str = "y"
-    else:
-        x_axis_str = ""
-        y_axis_str = ""
+    x_axis_str = "x" if LooseVersion(mpl_version) < LooseVersion('3.3') else ""
+    y_axis_str = "y" if LooseVersion(mpl_version) < LooseVersion('3.3') else ""
 
     if plot_handler.is_changed("x_log"):
         script_lines.append(f"ax.set_xscale('symlog', "

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -123,21 +123,17 @@ def add_cut_plot_statements(script_lines, plot_handler, ax):
     add_cut_lines(script_lines, plot_handler, ax)
     add_plot_options(script_lines, plot_handler)
 
+    if LooseVersion(mpl_version) < LooseVersion('3.3'):
+        x_axis_str = "x"
+        y_axis_str = "y"
+
     if plot_handler.is_changed("x_log"):
-        if LooseVersion(mpl_version) < LooseVersion('3.3'):
-            script_lines.append("ax.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10({}))))\n".format(
-                plot_handler.x_axis_min))
-        else:
-            script_lines.append("ax.set_xscale('symlog', linthresh=pow(10, np.floor(np.log10({}))))\n".format(
-                plot_handler.x_axis_min))
+        script_lines.append(f"ax.set_xscale('symlog', "
+                            f"linthresh{x_axis_str}=pow(10, np.floor(np.log10({plot_handler.x_axis_min}))))\n")
 
     if plot_handler.is_changed("y_log"):
-        if LooseVersion(mpl_version) < LooseVersion('3.3'):
-            script_lines.append("ax.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10({}))))\n".format(
-                plot_handler.y_axis_min))
-        else:
-            script_lines.append("ax.set_yscale('symlog', linthresh=pow(10, np.floor(np.log10({}))))\n".format(
-                plot_handler.y_axis_min))
+        script_lines.append(f"ax.set_xscale('symlog', "
+                            f"linthresh{y_axis_str}=pow(10, np.floor(np.log10({plot_handler.y_axis_min}))))\n")
 
 def add_cut_lines(script_lines, plot_handler, ax):
     cuts = plot_handler._cut_plotter_presenter._cut_cache_dict[ax]

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -126,6 +126,9 @@ def add_cut_plot_statements(script_lines, plot_handler, ax):
     if LooseVersion(mpl_version) < LooseVersion('3.3'):
         x_axis_str = "x"
         y_axis_str = "y"
+    else:
+        x_axis_str = ""
+        y_axis_str = ""
 
     if plot_handler.is_changed("x_log"):
         script_lines.append(f"ax.set_xscale('symlog', "

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -123,14 +123,13 @@ def add_cut_plot_statements(script_lines, plot_handler, ax):
     add_cut_lines(script_lines, plot_handler, ax)
     add_plot_options(script_lines, plot_handler)
 
-    x_axis_str = "x" if LooseVersion(mpl_version) < LooseVersion('3.3') else ""
-    y_axis_str = "y" if LooseVersion(mpl_version) < LooseVersion('3.3') else ""
-
     if plot_handler.is_changed("x_log"):
+        x_axis_str = "x" if LooseVersion(mpl_version) < LooseVersion('3.3') else ""
         script_lines.append(f"ax.set_xscale('symlog', "
                             f"linthresh{x_axis_str}=pow(10, np.floor(np.log10({plot_handler.x_axis_min}))))\n")
 
     if plot_handler.is_changed("y_log"):
+        y_axis_str = "y" if LooseVersion(mpl_version) < LooseVersion('3.3') else ""
         script_lines.append(f"ax.set_yscale('symlog', "
                             f"linthresh{y_axis_str}=pow(10, np.floor(np.log10({plot_handler.y_axis_min}))))\n")
 

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from distutils.version import LooseVersion
 from mslice.cli.helperfunctions import _function_to_intensity
 from mslice.models.labels import get_recoil_key
+from matplotlib import __version__ as mpl_version
 
 COMMON_PACKAGES = ["import mslice.cli as mc", "import mslice.plotting.pyplot as plt\n\n"]
 MPL_COLORS_IMPORT = ["\nimport matplotlib.colors as colors\n"]
@@ -122,13 +124,20 @@ def add_cut_plot_statements(script_lines, plot_handler, ax):
     add_plot_options(script_lines, plot_handler)
 
     if plot_handler.is_changed("x_log"):
-        script_lines.append("ax.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10({}))))\n".format(
-            plot_handler.x_axis_min))
+        if LooseVersion(mpl_version) < LooseVersion('3.3'):
+            script_lines.append("ax.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.x_axis_min))
+        else:
+            script_lines.append("ax.set_xscale('symlog', linthresh=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.x_axis_min))
 
     if plot_handler.is_changed("y_log"):
-        script_lines.append("ax.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10({}))))\n".format(
-            plot_handler.y_axis_min))
-
+        if LooseVersion(mpl_version) < LooseVersion('3.3'):
+            script_lines.append("ax.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.y_axis_min))
+        else:
+            script_lines.append("ax.set_yscale('symlog', linthresh=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.y_axis_min))
 
 def add_cut_lines(script_lines, plot_handler, ax):
     cuts = plot_handler._cut_plotter_presenter._cut_cache_dict[ax]

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -1,8 +1,10 @@
 from mock import MagicMock, patch, ANY
+from distutils.version import LooseVersion
 import numpy as np
 import unittest
 
 from matplotlib.lines import Line2D
+from matplotlib import __version__ as mpl_version
 from mslice.plotting.plot_window.cut_plot import CutPlot, get_min
 
 
@@ -57,8 +59,14 @@ class CutPlotTest(unittest.TestCase):
         xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
 
         self.cut_plot.change_axis_scale(xy_config)
-        self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
-        self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
+
+        if LooseVersion(mpl_version) < LooseVersion('3.3'):
+            self.axes.set_xscale.assert_called_once_with('symlog', linthreshx=10.0)
+            self.axes.set_yscale.assert_called_once_with('symlog', linthreshy=1.0)
+        else:
+            self.axes.set_xscale.assert_called_once_with('symlog', linthresh=10.0)
+            self.axes.set_yscale.assert_called_once_with('symlog', linthresh=1.0)
+
         self.assertEqual(self.cut_plot.x_range, (0, 20))
         self.assertEqual(self.cut_plot.y_range, (1, 7))
 

--- a/mslice/tests/scripting_helperfunctions_test.py
+++ b/mslice/tests/scripting_helperfunctions_test.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest import mock
+from distutils.version import LooseVersion
 from mslice.scripting.helperfunctions import header, add_header, add_plot_statements, add_slice_plot_statements, \
     COMMON_PACKAGES, MPL_COLORS_IMPORT, NUMPY_IMPORT, add_overplot_statements, add_cut_plot_statements, add_cut_lines, \
     add_cut_lines_with_width, add_plot_options, hide_lines
@@ -8,6 +9,7 @@ from mslice.plotting.plot_window.slice_plot import SlicePlot
 from mslice.cli.helperfunctions import _function_to_intensity
 from matplotlib.lines import Line2D
 import matplotlib.pyplot as plt
+from matplotlib import __version__ as mpl_version
 import numpy as np
 from mslice.models.cut.cut import Cut
 from mslice.models.axis import Axis
@@ -211,11 +213,16 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
         add_cut_lines.assert_called_once_with(script_lines, plot_handler, ax)
         add_plot_options.assert_called_once_with(script_lines, plot_handler)
 
-        self.assertIn("ax.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10({}))))\n".format(
-            plot_handler.x_axis_min), script_lines)
-
-        self.assertIn("ax.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10({}))))\n".format(
-            plot_handler.y_axis_min), script_lines)
+        if LooseVersion(mpl_version) < LooseVersion('3.3'):
+            self.assertIn("ax.set_xscale('symlog', linthreshx=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.x_axis_min), script_lines)
+            self.assertIn("ax.set_yscale('symlog', linthreshy=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.y_axis_min), script_lines)
+        else:
+            self.assertIn("ax.set_xscale('symlog', linthresh=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.x_axis_min), script_lines)
+            self.assertIn("ax.set_yscale('symlog', linthresh=pow(10, np.floor(np.log10({}))))\n".format(
+                plot_handler.y_axis_min), script_lines)
 
     @mock.patch('mslice.scripting.helperfunctions.add_cut_lines_with_width')
     @mock.patch('mslice.cli._mslice_commands.GlobalFigureManager')


### PR DESCRIPTION
#REF731

Description of work.

This fixes the crash that occurs when setting axes to log scale.

This was caused my a deprecation of the `linthreshx/y` kwarg in matplotlib 3.3.

Note that issue #731 refers to two other bugs when using the plot options and when setting the color bar to log scale with a negative min value:
    - For the bug when using plot options, I cannot replicate this exactly. I get the same error message as when changing via the    
      quick options (which this PR fixes). I have tried to replicate this using the mantid nightly build, a local mslice build using an 
      older version of matplotlib, and a conda build of mslice using an updated version of matplotlib
    - The colorscale bug occurs only when setting the max value as a negative when using a log scale. This is a seperate issue, so 
      will be addressed as such.

**To test:**
NOTE: These tests must be completed using a build with matplotlib version < 3,3 and another >= 3.3.

-In the Workspace Manager tab select the workspace MAR21335_Ei60meV
-Navigate to the Cut tab
-In the row labelled along, set the from value to 0 and the to value to 10
-In the row labelled over, set the from value to -5 and the to value to 5
-Click Plot. A new window with a cut plot should open.

-Right click on y axis to open quick options.
-Check the Logarithmic checkbox. 
-Press ok, observed no crash and correct behaviour.
-Repeat for x axis.

-Open Plot Options using the cog symbol on the toolbar.
-For X Axis, check the Logarithmic checkbox.
-Press ok, observed no crash and correct behaviour.
-Repeat for Y axis.

-Check effected unit tests pass.

<!-- Instructions for testing. -->

Partially Fixes 731, will reference and close this issue when in a subsequent PR.
