### PR TITLE
fix colorbar crash #REF731

### DIFF
--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -205,6 +205,9 @@ class SlicePlot(IPlot):
         if logarithmic:
             if vmin <= float(0):
                 vmin = 0.001
+            if vmax <= float(0):
+                vmax = 0.001
+
             norm = colors.LogNorm(vmin, vmax)
         else:
             norm = colors.Normalize(vmin, vmax)


### PR DESCRIPTION
Description of work.

Fixed colorbar crash when changing scale to logarithmic with negative vmax value and/or negative/0 vmin value.

What was happening was if the min was 0 and the max negative, the values would be switched. The negative value of vmin would then be set to equal to 0.001, making it higher than the max. This causes an exception in matplotlib. Equally if both values were negative, the min would be set to equal 0.001, then not switched with the negative max as switching occurs first. 

**To test:**
-Load MAR21335_Ei60meV dataset
-In the Workspace Manager tab select the workspace MAR21335_Ei60meV
-Navigate to the slice tab, click Display
-Right click on colorbar axis
-Ensure the logarithmic box is checked
-Ensure min is set to 0.0
-Set Max to any negative value.
-Click Ok, observed expected behaviour and no crash.
-Repeat process with min and max both set to negative values.


<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #731
