### PR TITLE
Redraw Bragg peaks when axes flipped in interactive cut

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -17,7 +17,7 @@ from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.plotting.plot_window.plot_options import CutPlotOptions
 from mslice.plotting.plot_window.iplot import IPlot
 from mslice.plotting.plot_window.overplot_interface import toggle_overplot_line,\
-    cif_file_powder_line, _update_overplot_lines, _get_powder_lines
+    cif_file_powder_line
 from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
 
@@ -49,8 +49,6 @@ class CutPlot(IPlot):
         self._waterfall_cache = {}
         self._is_icut = False
         self._powder_lines = {}
-        self._cif_file = None
-        self._cif_path = None
 
     def save_default_options(self):
         self.default_options = {
@@ -315,6 +313,20 @@ class CutPlot(IPlot):
         self.plot_window.raise_()
         self._is_icut = is_icut
 
+    def is_icut(self):
+        return self._is_icut
+
+    def update_bragg_peaks(self):
+        if self.plot_window.action_aluminium.isChecked():
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Aluminium', False, cif=None)
+        if self.plot_window.action_copper.isChecked():
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Copper', False, cif=None)
+        if self.plot_window.action_niobium.isChecked():
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Niobium', False, cif=None)
+        if self.plot_window.action_tantalum.isChecked():
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Tantalum', False, cif=None)
+        self.update_legend()
+
     def save_icut(self):
         icut = self._cut_plotter_presenter.get_icut()
         return icut.save_cut()
@@ -322,15 +334,6 @@ class CutPlot(IPlot):
     def flip_icut(self):
         icut = self._cut_plotter_presenter.get_icut()
         icut.flip_axis()
-
-    def is_icut(self):
-        return self._is_icut
-
-    def save_powder_lines(self):
-        self._powder_lines = _get_powder_lines(self)
-
-    def restore_powder_lines(self):
-        _update_overplot_lines(self._cut_plotter_presenter, self.ws_name, self._powder_lines)
 
     def _get_line_index(self, line):
         """

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -17,7 +17,7 @@ from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.plotting.plot_window.plot_options import CutPlotOptions
 from mslice.plotting.plot_window.iplot import IPlot
 from mslice.plotting.plot_window.overplot_interface import toggle_overplot_line,\
-    cif_file_powder_line
+    cif_file_powder_line, _update_overplot_lines, _get_powder_lines
 from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
 
@@ -48,6 +48,9 @@ class CutPlot(IPlot):
         self.default_options = None
         self._waterfall_cache = {}
         self._is_icut = False
+        self._powder_lines = {}
+        self._cif_file = None
+        self._cif_path = None
 
     def save_default_options(self):
         self.default_options = {
@@ -319,6 +322,15 @@ class CutPlot(IPlot):
     def flip_icut(self):
         icut = self._cut_plotter_presenter.get_icut()
         icut.flip_axis()
+
+    def is_icut(self):
+        return self._is_icut
+
+    def save_powder_lines(self):
+        self._powder_lines = _get_powder_lines(self)
+
+    def restore_powder_lines(self):
+        _update_overplot_lines(self._cut_plotter_presenter, self.ws_name, self._powder_lines)
 
     def _get_line_index(self, line):
         """

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -411,11 +411,12 @@ class CutPlot(IPlot):
         num_lines = len(line_containers)
         self.plot_window.action_waterfall.setEnabled(num_lines > 1)
         self.plot_window.toggle_waterfall_edit()
-        self.plot_window.action_aluminium.setChecked(False)
-        self.plot_window.action_copper.setChecked(False)
-        self.plot_window.action_niobium.setChecked(False)
-        self.plot_window.action_tantalum.setChecked(False)
-        self.plot_window.action_cif_file.setChecked(False)
+        if not self._is_icut:
+            self.plot_window.action_aluminium.setChecked(False)
+            self.plot_window.action_copper.setChecked(False)
+            self.plot_window.action_niobium.setChecked(False)
+            self.plot_window.action_tantalum.setChecked(False)
+            self.plot_window.action_cif_file.setChecked(False)
         all_lines = [line for container in line_containers for line in container.get_children()]
         for cached_lines in list(self._waterfall_cache.keys()):
             if cached_lines not in all_lines:

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -16,20 +16,15 @@ def _update_overplot_lines(plotter_presenter, ws_name, lines):
             plotter_presenter.add_overplot_line(ws_name, *lines[line])
 
 
-def _get_powder_lines(plot_handler):
+def _update_powder_lines(plot_handler, plotter_presenter):
+    """ Updates the powder overplots lines when intensity type changes """
     lines = {plot_handler.plot_window.action_aluminium: ['Aluminium', False, ''],
              plot_handler.plot_window.action_copper: ['Copper', False, ''],
              plot_handler.plot_window.action_niobium: ['Niobium', False, ''],
              plot_handler.plot_window.action_tantalum: ['Tantalum', False, ''],
              plot_handler.plot_window.action_cif_file: [plot_handler._cif_file,
                                                         False, plot_handler._cif_path]}
-
-    return lines
-
-
-def _update_powder_lines(plot_handler, plotter_presenter):
-    """ Updates the powder overplot lines when intensity type changes """
-    _update_overplot_lines(plotter_presenter, plot_handler.ws_name, _get_powder_lines(plot_handler))
+    _update_overplot_lines(plotter_presenter, plot_handler.ws_name, lines)
 
 
 def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, cif_file=None):

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -16,15 +16,20 @@ def _update_overplot_lines(plotter_presenter, ws_name, lines):
             plotter_presenter.add_overplot_line(ws_name, *lines[line])
 
 
-def _update_powder_lines(plot_handler, plotter_presenter):
-    """ Updates the powder overplots lines when intensity type changes """
+def _get_powder_lines(plot_handler):
     lines = {plot_handler.plot_window.action_aluminium: ['Aluminium', False, ''],
              plot_handler.plot_window.action_copper: ['Copper', False, ''],
              plot_handler.plot_window.action_niobium: ['Niobium', False, ''],
              plot_handler.plot_window.action_tantalum: ['Tantalum', False, ''],
              plot_handler.plot_window.action_cif_file: [plot_handler._cif_file,
                                                         False, plot_handler._cif_path]}
-    _update_overplot_lines(plotter_presenter, plot_handler.ws_name, lines)
+
+    return lines
+
+
+def _update_powder_lines(plot_handler, plotter_presenter):
+    """ Updates the powder overplot lines when intensity type changes """
+    _update_overplot_lines(plotter_presenter, plot_handler.ws_name, _get_powder_lines(plot_handler))
 
 
 def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, cif_file=None):

--- a/mslice/views/cut_plotter.py
+++ b/mslice/views/cut_plotter.py
@@ -36,11 +36,7 @@ def plot_cut_impl(workspace, intensity_range=None, plot_over=False, legend=None,
     else:
         ax = axes[0]
         if not plot_over:
-            if cur_fig.canvas.manager.plot_handler.is_icut():
-                cur_fig.canvas.manager.plot_handler.save_powder_lines()
             ax.cla()
-            if cur_fig.canvas.manager.plot_handler.is_icut():
-                cur_fig.canvas.manager.plot_handler.restore_powder_lines()
 
     legend = workspace.name if legend is None else legend
     ax.errorbar(workspace, 'o-', label=legend, picker=PICKER_TOL_PTS,
@@ -53,6 +49,9 @@ def plot_cut_impl(workspace, intensity_range=None, plot_over=False, legend=None,
 
     if cur_fig.canvas.manager.plot_handler.default_options is None:
         cur_fig.canvas.manager.plot_handler.save_default_options()
+
+    if cur_fig.canvas.manager.plot_handler.is_icut():
+        cur_fig.canvas.manager.plot_handler.update_bragg_peaks()
 
     return ax.lines
 

--- a/mslice/views/cut_plotter.py
+++ b/mslice/views/cut_plotter.py
@@ -36,7 +36,11 @@ def plot_cut_impl(workspace, intensity_range=None, plot_over=False, legend=None,
     else:
         ax = axes[0]
         if not plot_over:
+            if cur_fig.canvas.manager.plot_handler.is_icut():
+                cur_fig.canvas.manager.plot_handler.save_powder_lines()
             ax.cla()
+            if cur_fig.canvas.manager.plot_handler.is_icut():
+                cur_fig.canvas.manager.plot_handler.restore_powder_lines()
 
     legend = workspace.name if legend is None else legend
     ax.errorbar(workspace, 'o-', label=legend, picker=PICKER_TOL_PTS,


### PR DESCRIPTION
For interactive cuts the enabled Bragg peaks now remain checked when flipping the axes and are redrawn on the new plot.

**To test:**

Add a Bragg peak to an interactive cut and flip the axes a couple of times. The Bragg peak should remain enabled and the corresponding lines be adapted to the current plot.

Fixes #740 
