### PR TITLE
Fix rectangle visibility bug #REF730

### DIFF
--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -100,8 +100,10 @@ class InteractiveCut(object):
     def clear(self):
         self._cut_plotter_presenter.set_is_icut(False)
         self.rect.set_active(False)
+        self.rect.set_visible(False)
         for event in self.connect_event:
             self._canvas.mpl_disconnect(event)
+
         self._canvas.draw()
 
     def flip_axis(self):


### PR DESCRIPTION
Description of work.

In previous versions of matplotlib, the `set_active(False)` function causes the drawn rectangle to not be included on the axis (Its not immediately obvious my why this happens). In more recent versions of matplotlib, this is not the case, so I've set the visibility to false directly.

**To test:**
1. Open a data set in the MSlice interface of Mantid.
2. Display a slice plot.
3. Click on 'Interactive Cuts'
4. Select region by selecting a rectangular region on the slice plot.
5. Close the newly opened cut window.
6. Observe the selected region removal.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #730.