### PR TITLE
Fix error bar offset bug #REF738

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -391,18 +391,24 @@ class CutPlot(IPlot):
             self._apply_offset(0., 0.)
         self._canvas.draw()
 
+    def _cache_line(self, line):
+        if isinstance(line, Line2D):
+            self._waterfall_cache[line] = [line.get_xdata(), line.get_ydata()]
+        elif isinstance(line, LineCollection):
+            self._waterfall_cache[line] = [np.copy(path.vertices) for path in line._paths]
+
     def _apply_offset(self, x, y):
         for ind, line_containers in enumerate(self._canvas.figure.gca().containers):
             for line in line_containers.get_children():
+                line not in self._waterfall_cache and self._cache_line(line)
                 if isinstance(line, Line2D):
-                    if line not in self._waterfall_cache:
-                        self._waterfall_cache[line] = [line.get_xdata(), line.get_ydata()]
                     line.set_xdata(self._waterfall_cache[line][0] + ind * x)
                     line.set_ydata(self._waterfall_cache[line][1] + ind * y)
                 elif isinstance(line, LineCollection):
-                    if LooseVersion(mpl_version) < LooseVersion('3.3'):
-                        line.set_offset_position('data') # set_offset_position is deprecated since 3.3
-                    line.set_offsets((ind * x, ind * y))
+                    for index, path in enumerate(line._paths):
+                        if not np.isnan(path.vertices).any():
+                            path.vertices = np.add(self._waterfall_cache[line][index], \
+                                            np.array([[ind * x, ind * y], [ind * x, ind * y]]))
 
     def on_newplot(self, ax):
         # This callback should be activated by a call to errorbar

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -1,7 +1,5 @@
-from distutils.version import LooseVersion
 from functools import partial
 
-from matplotlib import __version__ as mpl_version
 from matplotlib.collections import LineCollection
 from matplotlib.container import ErrorbarContainer
 from matplotlib.legend import Legend
@@ -16,7 +14,7 @@ from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.plotting.plot_window.plot_options import CutPlotOptions
 from mslice.plotting.plot_window.iplot import IPlot
-from mslice.plotting.plot_window.overplot_interface import toggle_overplot_line,\
+from mslice.plotting.plot_window.overplot_interface import toggle_overplot_line, \
     cif_file_powder_line
 from mslice.scripting import generate_script
 from mslice.util.compat import legend_set_draggable
@@ -407,8 +405,8 @@ class CutPlot(IPlot):
                 elif isinstance(line, LineCollection):
                     for index, path in enumerate(line._paths):
                         if not np.isnan(path.vertices).any():
-                            path.vertices = np.add(self._waterfall_cache[line][index], \
-                                            np.array([[ind * x, ind * y], [ind * x, ind * y]]))
+                            path.vertices = np.add(self._waterfall_cache[line][index],
+                                                   np.array([[ind * x, ind * y], [ind * x, ind * y]]))
 
     def on_newplot(self, ax):
         # This callback should be activated by a call to errorbar


### PR DESCRIPTION
Description of work.

In previous versions of mslice, the offset feature of waterfall graphs was applied to error bars using the `set_offsets` function of `LineCollection`, with the `_offset_position` property set to `data`. 

In matplotlib >3.3, the ability to change the `_offset_position` was deprecated. A subsequent change to MSlice removed code that previously did this.

In this state, the `set_offsets` function sets by _pixel_ rather than by datapoints meaning that offsets were applied incorrectly. The ability to set by data has effectively been removed. Converting between data and pixels is not a viable solution due to zoom functionality.

In this fix we access the protected member function of `LineCollection`, `_paths` to manually apply the offsets.

**To test:**
NOTE: These tests must be completed using a build with matplotlib version < 3,3 and another >= 3.3.

-In the Workspace Manager tab select the workspace MAR21335_Ei60meV
-Navigate to the Cut tab
-In the row labelled along, set the from value to 0 and the to value to 10
-In the row labelled over, set the from value to -5 and the to value to 5
-Click Plot. A new window with a cut plot should open.
-Again on the cut tab. click overplot.
-On the cut plot with two overplotted lines, click the waterfall button on the toolbar.
-Apply a variety of offsets to x and y, observing correct behaviour of the lines and errorbars.



Fixes #738.
