### PR TITLE
Remove unnecessary draw event which causes axes options not to open

### DIFF
--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -168,7 +168,6 @@ class SlicePlot(IPlot):
                     quick_options('y_range', self, redraw_signal=self.plot_window.redraw)
                 elif x > bounds['colorbar_range']:
                     quick_options('colorbar_range', self, self.colorbar_log, redraw_signal=self.plot_window.redraw)
-            self._canvas.draw()
 
     def object_clicked(self, target):
         if isinstance(target, Legend):


### PR DESCRIPTION
**Description of work**
This PR removes a draw event which I believe is not needed. Removing this draw event will also fix the bug seen in the attached issue.

**To test:**
Follow the instructions in the attached issue:

Fixes #736
