### PR TITLE
Fix crash when reloading the same data after a rename

### DIFF
--- a/mslice/workspace/helperfunctions.py
+++ b/mslice/workspace/helperfunctions.py
@@ -92,7 +92,8 @@ def delete_workspace(workspace, ws):
 
 def rename_workspace(old_name: str, new_name: str) -> None:
     """Rename a workspace stored in the ADS."""
-    RenameWorkspace(InputWorkspace=old_name, OutputWorkspace=new_name)
+    if new_name != old_name:
+        RenameWorkspace(InputWorkspace=old_name, OutputWorkspace=new_name)
 
 
 class WrapWorkspaceAttribute(object):

--- a/mslice/workspace/helperfunctions.py
+++ b/mslice/workspace/helperfunctions.py
@@ -1,7 +1,7 @@
 import pickle
 import codecs
 
-from mantid.simpleapi import DeleteWorkspace
+from mantid.simpleapi import DeleteWorkspace, RenameWorkspace
 
 
 def _attribute_from_string(ws, comstr):
@@ -88,6 +88,12 @@ def delete_workspace(workspace, ws):
         # where you receive a RuntimeError: Variable invalidated, data has been deleted.
         # error
         pass
+
+
+def rename_workspace(old_name: str, new_name: str) -> None:
+    """Rename a workspace stored in the ADS."""
+    RenameWorkspace(InputWorkspace=old_name, OutputWorkspace=new_name)
+
 
 class WrapWorkspaceAttribute(object):
 

--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .histo_mixin import HistoMixin
 from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
-from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace
+from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace, rename_workspace
 
 from mantid.api import IMDHistoWorkspace
 
@@ -15,7 +15,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
             self._raw_ws = mantid_ws
         else:
             raise TypeError('HistogramWorkspace expected IMDHistoWorkspace, got %s' % mantid_ws.__class__.__name__)
-        self.name = name
+        self._name = name
         self._cut_params = {}
         self.is_PSD = None
         self.axes = []
@@ -23,6 +23,13 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
         self.parent = None
         self.algorithm = []
         attribute_from_log(self, mantid_ws)
+
+    @WorkspaceMixin.name.setter
+    def name(self, new_name: str):
+        raw_name = str(self.raw_ws)
+        rename_workspace(raw_name, raw_name.replace(self.name, new_name))
+
+        self._name = new_name
 
     def rewrap(self, ws):
         new_ws = HistogramWorkspace(ws, self.name)

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -3,7 +3,7 @@ from .base import WorkspaceBase
 from .histogram_workspace import HistogramWorkspace
 from .pixel_mixin import PixelMixin
 from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
-from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace
+from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace, rename_workspace
 
 from mantid.api import IMDEventWorkspace
 
@@ -17,11 +17,12 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
             self._raw_ws = mantid_ws
             self._histo_ws = None
         elif isinstance(mantid_ws, HistogramWorkspace):
+            self._raw_ws = None
             self._histo_ws = mantid_ws
         else:
             raise TypeError("PixelWorkspace expected IMDEventWorkspace or HistogramWorkspace, got %s"
                             % mantid_ws.__class__.__name__)
-        self.name = name
+        self._name = name
         self._cut_params = {}
         self.limits = {}
         self.is_PSD = None
@@ -30,6 +31,17 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
         self.axes = []
         if isinstance(mantid_ws, IMDEventWorkspace):
             attribute_from_log(self, mantid_ws)
+
+    @WorkspaceMixin.name.setter
+    def name(self, new_name: str):
+        if self.raw_ws is not None:
+            raw_name = str(self.raw_ws)
+            rename_workspace(raw_name, raw_name.replace(self.name, new_name))
+        elif self._histo_ws is not None:
+            histo_name = str(self._histo_ws)
+            rename_workspace(histo_name, histo_name.replace(self.name, new_name))
+
+        self._name = new_name
 
     def rewrap(self, ws):
         new_ws = PixelWorkspace(ws, self.name)

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 from .base import WorkspaceBase
 from .workspace_mixin import WorkspaceOperatorMixin, WorkspaceMixin
-from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace
+from .helperfunctions import attribute_from_log, attribute_to_log, delete_workspace, rename_workspace
 
 from mantid.api import MatrixWorkspace
 
@@ -14,7 +14,7 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
             self._raw_ws = mantid_ws
         else:
             raise TypeError('Workspace expected matrixWorkspace, got %s' % mantid_ws.__class__.__name__)
-        self.name = name
+        self._name = name
         self._cut_params = {}
         self.ef_defined = None
         self.limits = {}
@@ -23,6 +23,13 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase):
         self.e_fixed = None
         self.axes = []
         attribute_from_log(self, mantid_ws)
+
+    @WorkspaceMixin.name.setter
+    def name(self, new_name: str):
+        raw_name = str(self.raw_ws)
+        rename_workspace(raw_name, raw_name.replace(self.name, new_name))
+
+        self._name = new_name
 
     def rewrap(self, mantid_ws):
         new_ws = Workspace(mantid_ws, self.name)

--- a/mslice/workspace/workspace_mixin.py
+++ b/mslice/workspace/workspace_mixin.py
@@ -4,6 +4,7 @@ import numpy as np
 from mantid.simpleapi import CloneWorkspace, PowerMD
 from mslice.util.numpy_helper import apply_with_corrected_shape
 
+
 # Other operators are defined when MSlice is imported in _workspace_ops.attach_binary_operators()
 class WorkspaceOperatorMixin(object):
     def __neg__(self):
@@ -12,6 +13,7 @@ class WorkspaceOperatorMixin(object):
     def __pow__(self, exponent):
         return self.rewrap(PowerMD(InputWorkspace=self._raw_ws, OutputWorkspace="_",
                                    Exponent=exponent, StoreInADS=False))
+
 
 class WorkspaceMixin(object):
 
@@ -70,6 +72,10 @@ class WorkspaceMixin(object):
 
     def is_axis_saved(self, axis):
         return True if axis in self._cut_params else False
+
+    @property
+    def name(self):
+        return self._name
 
     @property
     def raw_ws(self):


### PR DESCRIPTION
**Description of work:**
This PR ensures the hidden raw and histogram workspace gets renamed when the associated data is renamed in the workspace
manager. Without this, the raw data associated with a renamed dataset is overridden and invalidated if the original file is loaded back into MSlice.

**To test:**
- Load dataset
- Rename dataset using workspace manager tab
- Load same dataset again
- Click to switch between workspaces on the workspace selector

It would also be good to do this test for MatrixWorkspaces, HistogramWorkspaces, and Pixel Workspaces to make sure each case is working.

Fixes #753
