### PR TITLE
Colour scheme is now consistent within MSlice

### DIFF
--- a/mslice/models/colors.py
+++ b/mslice/models/colors.py
@@ -19,6 +19,7 @@ the string cyan
 from __future__ import (absolute_import, division)
 
 from matplotlib import rcParams
+
 from six import iteritems
 try:
     from matplotlib.colors import to_hex
@@ -35,9 +36,9 @@ except ImportError:
     def mpl_named_colors():
         return cnames
 
-_BASIC_COLORS_PRETTY_NAME = {'b': 'blue', 'g': 'green', 'r': 'red', 'c': 'cyan', 'm': 'magenta', 'y': 'yellow',
-                             'k': 'black', 'w': 'white'}
-_BASIC_COLORS_HEX_MAPPING = dict((k, to_hex(k)) for k, _ in iteritems(_BASIC_COLORS_PRETTY_NAME))
+_BASIC_COLORS_HEX_MAPPING = {'blue': '#1f77b4', 'orange': '#ff7f0e', 'green': '#2ca02c', 'red': '#d62728',
+                             'purple': '#9467bd', 'brown': '#8c564b', 'pink': '#e377c2', 'gray': '#7f7f7f',
+                             'olive': '#bcbd22', 'cyan': '#17becf'}
 
 
 def pretty_name(name):
@@ -71,17 +72,17 @@ def named_cycle_colors():
 
 def name_to_color(name):
     """
-    Translate between a our string names and the mpl color
+    Translate between our string names and the mpl color
     representation
     :param name: One of our known string names
     :return: The string identifier we have chosen
     :raises: ValueError if the color is not known
     """
     try:
-        return mpl_named_colors()[name]
+        return _BASIC_COLORS_HEX_MAPPING[name]
     except KeyError:
         try:
-            return _BASIC_COLORS_HEX_MAPPING[name]
+            return mpl_named_colors()[name]
         except KeyError:
             raise ValueError("Color name {} unknown".format(name))
 
@@ -95,12 +96,12 @@ def color_to_name(color):
     :raises: ValueError if the color is not known
     """
     color_as_hex = to_hex(color)
-    for name, value in iteritems(mpl_named_colors()):
-        if color_as_hex == to_hex(value):
-            return pretty_name(name)
+    for name, hexvalue in iteritems(_BASIC_COLORS_HEX_MAPPING):
+        if color_as_hex == hexvalue:
+            return name
     else:
-        for name, hexvalue in iteritems(_BASIC_COLORS_HEX_MAPPING):
-            if color_as_hex == hexvalue:
-                return name
+        for name, value in iteritems(mpl_named_colors()):
+            if color_as_hex == to_hex(value):
+                return pretty_name(name)
         else:
             raise ValueError("matplotlib color {} unknown".format(color))

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -11,7 +11,7 @@ from matplotlib.text import Text
 import warnings
 import numpy as np
 
-from mslice.models.colors import to_hex
+from mslice.models.colors import to_hex, name_to_color
 from mslice.presenters.plot_options_presenter import CutPlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options, check_latex
 from mslice.plotting.plot_window.plot_options import CutPlotOptions
@@ -208,7 +208,7 @@ class CutPlot(IPlot):
             line.set_label(line_options['label'])
             line.set_linestyle(line_options['style'])
             line.set_marker(line_options['marker'])
-            line.set_color(line_options['color'])
+            line.set_color(name_to_color(line_options['color']))
             line.set_linewidth(line_options['width'])
 
     def get_all_line_options(self):
@@ -267,7 +267,7 @@ class CutPlot(IPlot):
         self.toggle_errorbar(line_index, line_options)
 
         for child in container.get_children():
-            child.set_color(line_options['color'])
+            child.set_color(name_to_color(line_options['color']))
             child.set_linewidth(line_options['width'])
             child.set_visible(line_options['shown'])
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -7,7 +7,7 @@ import matplotlib.colors as colors
 from matplotlib.legend import Legend
 from matplotlib.text import Text
 
-from mslice.models.colors import to_hex
+from mslice.models.colors import to_hex, name_to_color
 from mslice.models.units import get_sample_temperature_from_string
 from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options, check_latex
@@ -233,7 +233,7 @@ class SlicePlot(IPlot):
         line.set_label(line_options['label'])
         line.set_linestyle(line_options['style'])
         line.set_marker(line_options['marker'])
-        line.set_color(line_options['color'])
+        line.set_color(name_to_color(line_options['color']))
         line.set_linewidth(line_options['width'])
 
     def calc_figure_boundaries(self):

--- a/mslice/tests/colors_test.py
+++ b/mslice/tests/colors_test.py
@@ -14,10 +14,10 @@ class ColorsTest(unittest.TestCase):
             self.assertTrue(':' not in name)
 
     def test_known_color_name_gives_expected_hex(self):
-        self.assertEqual("#008000", name_to_color("green"))
+        self.assertEqual("#2ca02c", name_to_color("green"))
 
     def test_known_hex_gives_expected_color_name(self):
-        self.assertEqual("green", color_to_name("#008000"))
+        self.assertEqual("green", color_to_name("#2ca02c"))
 
     def test_unknown_color_name_raises_valueerror(self):
         self.assertRaises(ValueError, name_to_color, "NotAColorName")
@@ -26,7 +26,7 @@ class ColorsTest(unittest.TestCase):
         self.assertRaises(ValueError, color_to_name, "#12345")
 
     def test_basic_color_is_known(self):
-        self.assertEqual('c', color_to_name('#00bfbf'))
+        self.assertEqual('cyan', color_to_name('#17becf'))
 
 
 if __name__ == '__main__':

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -20,7 +20,7 @@ def setup_line_values(qlo_mock):
     type(quick_line_options).width = PropertyMock(return_value='5')
     type(quick_line_options).label = PropertyMock(return_value='label2')
     type(quick_line_options).shown = PropertyMock(return_value=True)
-    target = Line2D([], [], 3, '-', 'red', 'o', label='label1')
+    target = Line2D([], [], 3, '-', '#d62728', 'o', label='label1')
     return qlo_mock, target
 
 
@@ -68,11 +68,11 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, model)
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': None, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
+            {'shown': None, 'color': '#d62728', 'label': u'label1', 'style': '-', 'width': '3',
              'marker': 'o', 'legend': None, 'error_bar': None}, True)
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
-                             {'shown': None, 'color': '#0000ff', 'label': u'label2',
+                             {'shown': None, 'color': '#1f77b4', 'label': u'label2',
                               'style': '--', 'width': '5', 'marker': '.', 'legend': None,
                               'error_bar': None})
 
@@ -97,11 +97,11 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, model)
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': True, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
+            {'shown': True, 'color': '#d62728', 'label': u'label1', 'style': '-', 'width': '3',
              'marker': 'o', 'legend': True, 'error_bar': False}, True)
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
-                             {'shown': True, 'color': '#0000ff', 'label': u'label2',
+                             {'shown': True, 'color': '#1f77b4', 'label': u'label2',
                               'style': '--', 'width': '5', 'marker': '.', 'legend': True, 'error_bar': False})
 
     @patch.object(QuickAxisOptions, '__init__', lambda t, u, v, w, x, y, z: None)


### PR DESCRIPTION
Instead of using the colour name directly in set_option now the name_to_color function from mslice.models.colors is used. This ensures that a colour name is always mapped to the same hex value. The hex mapping for basic colours has been updated as well to reflect the colour scheme changes within matplotlib. The hex values are now hardcoded instead of generated dynamically on start up to speed up plotting. It is still possible to use colours that are not included in the basic colour mapping though.

**To test:**

Create a cut plot with several lines and change a line setting, for instance 'Show Legends'. After clicking on Ok the colours of the lines should not change.

Also, try to re-test https://github.com/mantidproject/mslice/issues/550 as this should still be fixed.

Fixes #733 
