### PR TITLE
Fix Default line width not configured correctly

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -247,7 +247,7 @@ class CutPlot(IPlot):
             'shown': self.get_line_visible(line_index),
             'color': to_hex(line.get_color()),
             'style': line.get_linestyle(),
-            'width': str(int(line.get_linewidth())),
+            'width': str(line.get_linewidth()),
             'marker': line.get_marker(),
             'error_bar': self._single_line_has_error_bars(line_index)
         }

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
-from numpy import arange as np_arrange
+from numpy import arange as np_arange
 from six import iteritems
 import functools
 
@@ -293,7 +293,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         self.width_label = QtWidgets.QLabel(self)
         self.width_label.setText("Width:")
         self.line_width = QtWidgets.QComboBox(self)
-        self.line_width.addItems([str(x) for x in np_arrange(1,10.5,0.5)])
+        self.line_width.addItems([str(x) for x in np_arange(1,10.5,0.5)])
         self.line_width.setCurrentIndex(self.line_width.findText(line_options['width']))
 
         self.marker_label = QtWidgets.QLabel(self)

--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+from numpy import arange as np_arrange
 from six import iteritems
 import functools
 
@@ -292,7 +293,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
         self.width_label = QtWidgets.QLabel(self)
         self.width_label.setText("Width:")
         self.line_width = QtWidgets.QComboBox(self)
-        self.line_width.addItems([str(x + 1) for x in range(10)])
+        self.line_width.addItems([str(x) for x in np_arrange(1,10.5,0.5)])
         self.line_width.setCurrentIndex(self.line_width.findText(line_options['width']))
 
         self.marker_label = QtWidgets.QLabel(self)
@@ -420,7 +421,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
 
     @property
     def width(self):
-        return int(self.line_width.currentText())
+        return float(self.line_width.currentText())
 
     @property
     def marker(self):

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -226,7 +226,7 @@ class SlicePlot(IPlot):
             'shown': None,
             'color': to_hex(target.get_color()),
             'style': target.get_linestyle(),
-            'width': str(int(target.get_linewidth())),
+            'width': str(target.get_linewidth()),
             'marker': target.get_marker(),
             'error_bar': None
         }

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -41,7 +41,7 @@ class QuickOptionsTest(unittest.TestCase):
     @patch.object(QuickLineOptions, 'exec_', lambda x: None)
     @patch('mslice.presenters.quick_options_presenter.quick_line_options')
     def test_line(self, line_options_mock):
-        target = Line2D([], [], 3, '-', 'red', 'o', label='label1')
+        target = Line2D([], [], 3.0, '-', 'red', 'o', label='label1')
         quick_options(target, self.model)
         line_options_mock.assert_called_once_with(target, self.model)
 

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -17,10 +17,10 @@ def setup_line_values(qlo_mock):
     type(quick_line_options).marker = PropertyMock(return_value='.')
     type(quick_line_options).color = PropertyMock(return_value='blue')
     type(quick_line_options).style = PropertyMock(return_value='--')
-    type(quick_line_options).width = PropertyMock(return_value='5')
+    type(quick_line_options).width = PropertyMock(return_value='5.0')
     type(quick_line_options).label = PropertyMock(return_value='label2')
     type(quick_line_options).shown = PropertyMock(return_value=True)
-    target = Line2D([], [], 3, '-', 'red', 'o', label='label1')
+    target = Line2D([], [], 3.0, '-', 'red', 'o', label='label1')
     return qlo_mock, target
 
 
@@ -68,12 +68,12 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, model)
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': None, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
+            {'shown': None, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3.0',
              'marker': 'o', 'legend': None, 'error_bar': None}, True)
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
                              {'shown': None, 'color': '#0000ff', 'label': u'label2',
-                              'style': '--', 'width': '5', 'marker': '.', 'legend': None,
+                              'style': '--', 'width': '5.0', 'marker': '.', 'legend': None,
                               'error_bar': None})
 
     @patch('mslice.plotting.plot_window.cut_plot.CutPlot.show_legends', new_callable=PropertyMock(return_value=True))
@@ -97,12 +97,12 @@ class QuickOptionsTest(unittest.TestCase):
         quick_options(target, model)
         # check view is called with existing line parameters
         qlo_mock.assert_called_with(
-            {'shown': True, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3',
+            {'shown': True, 'color': '#ff0000', 'label': u'label1', 'style': '-', 'width': '3.0',
              'marker': 'o', 'legend': True, 'error_bar': False}, True)
         # check model is updated with parameters from view
         self.assertDictEqual(model.get_line_options(target),
                              {'shown': True, 'color': '#0000ff', 'label': u'label2',
-                              'style': '--', 'width': '5', 'marker': '.', 'legend': True, 'error_bar': False})
+                              'style': '--', 'width': '5.0', 'marker': '.', 'legend': True, 'error_bar': False})
 
     @patch.object(QuickAxisOptions, '__init__', lambda t, u, v, w, x, y, z: None)
     @patch.object(QuickAxisOptions, 'range_min', PropertyMock(return_value='0'))
@@ -222,7 +222,7 @@ class QuickLineTest(unittest.TestCase):
         type(self.view).color = color
         style = PropertyMock(return_value=2)
         type(self.view).style = style
-        width = PropertyMock(return_value=3)
+        width = PropertyMock(return_value=3.0)
         type(self.view).width = width
         marker = PropertyMock(return_value=4)
         type(self.view).marker = marker
@@ -250,7 +250,7 @@ class QuickLineTest(unittest.TestCase):
         type(self.view).legend = legend
         self.view.exec_ = MagicMock(return_value=True)
         quick_options(self.target, self.model)
-        values = {'color': 1, 'style': 2, 'width': 3, 'marker': 4, 'label': 5, 'shown': False, 'legend': False,
+        values = {'color': 1, 'style': 2, 'width': 3.0, 'marker': 4, 'label': 5, 'shown': False, 'legend': False,
                   'error_bar': True}
         self.model.set_line_options.assert_called_once_with(self.target, values)
 


### PR DESCRIPTION
Description of work.
Default line width is 1.5, previously only integers line widths could be specified through plot options. This PR introduces line widths at 0,5 intervals.

**To test:**
1) Plot a cut plot
2) Open plot options
3) Observe default line width 1.5
4) Click Ok, observe no change to line width
5) Through plot options, test other line widths

Fixes #757.
