### PR TITLE
Fix double opening dialog

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -303,8 +303,9 @@ class CutPlot(IPlot):
                 element.set_alpha(1)
 
     def set_is_icut(self, is_icut):
-        self.manager.button_pressed_connected(not is_icut)
-        self.manager.picking_connected(not is_icut)
+        if is_icut: #disconnect quick options if icut
+            self.manager.button_pressed_connected(False)
+            self.manager.picking_connected(False)
 
         self.plot_window.action_save_cut.setVisible(is_icut)
         self.plot_window.action_plot_options.setVisible(not is_icut)


### PR DESCRIPTION
**Description of work**
If not an interactive cut, the `set_is_icut` function of `cut_plot` connected the `button_pressed` and `picking` events for a second time (they are initially connected in `__init__` in `PlotFigureManagerQT`).

This PR ensures this does not happen.

**To test:**
1) Plot a cut
2) double click on axis/label/line
3) ensure options only opens once as expected.

Fixes #675.
