### PR TITLE
Prevent error when loading OSIRIS data

### DIFF
--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -135,8 +135,8 @@ def set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep):
 
 
 def _get_theta_for_limits(ws):
-    num_hist = ws.raw_ws.getNumberHistograms()
-    theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_hist)]
+    num_detectors = ws.raw_ws.getInstrument().getNumberDetectors()
+    theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_detectors)]
     round_fac = 100
     ws.is_PSD = not all(x < y for x, y in zip(theta, theta[1:]))
     # Rounds the differences to avoid pixels with same 2theta. Implies min limit of ~0.5 degrees

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -135,8 +135,8 @@ def set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep):
 
 
 def _get_theta_for_limits(ws):
-    num_detectors = ws.raw_ws.getInstrument().getNumberDetectors(skipMonitors=True)
-    theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_detectors)]
+    num_hist = ws.raw_ws.getNumberHistograms()
+    theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_hist)]
     round_fac = 100
     ws.is_PSD = not all(x < y for x, y in zip(theta, theta[1:]))
     # Rounds the differences to avoid pixels with same 2theta. Implies min limit of ~0.5 degrees

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -135,7 +135,7 @@ def set_limits(ws, qmin, qmax, qstep, theta, emin, emax, estep):
 
 
 def _get_theta_for_limits(ws):
-    num_detectors = ws.raw_ws.getInstrument().getNumberDetectors()
+    num_detectors = ws.raw_ws.getInstrument().getNumberDetectors(skipMonitors=True)
     theta = [ws.raw_ws.detectorTwoTheta(ws.raw_ws.getDetector(i)) for i in range(num_detectors)]
     round_fac = 100
     ws.is_PSD = not all(x < y for x, y in zip(theta, theta[1:]))

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -59,18 +59,16 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                         allChecked = True
                     else:
                         load(filename=file_paths[i], output_workspace=ws_name)
+
+                    if not allChecked:
+                        allChecked = self.check_efixed(ws_name, multi)
+                    else:
+                        apply_fixed_final_energy_to_a_valid_workspace(ws_name, self._EfCache)
                 except (ValueError, TypeError) as e:
                     self._view.error_loading_workspace(e)
                 except RuntimeError:
                     not_opened.append(ws_name)
                 else:
-                    if not allChecked:
-                        try:
-                            allChecked = self.check_efixed(ws_name, multi)
-                        except ValueError:
-                            not_opened.append(ws_name)
-                    else:
-                        apply_fixed_final_energy_to_a_valid_workspace(ws_name, self._EfCache)
                     if self._main_presenter is not None:
                         self._main_presenter.show_workspace_manager_tab()
                         self._main_presenter.show_tab_for_workspace(get_workspace_handle(ws_name))

--- a/mslice/presenters/data_loader_presenter.py
+++ b/mslice/presenters/data_loader_presenter.py
@@ -65,7 +65,10 @@ class DataLoaderPresenter(PresenterUtility, DataLoaderPresenterInterface):
                     not_opened.append(ws_name)
                 else:
                     if not allChecked:
-                        allChecked = self.check_efixed(ws_name, multi)
+                        try:
+                            allChecked = self.check_efixed(ws_name, multi)
+                        except ValueError:
+                            not_opened.append(ws_name)
                     else:
                         apply_fixed_final_energy_to_a_valid_workspace(ws_name, self._EfCache)
                     if self._main_presenter is not None:

--- a/mslice/tests/workspace_algorithms_test.py
+++ b/mslice/tests/workspace_algorithms_test.py
@@ -1,0 +1,44 @@
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+from mslice.models.workspacemanager.workspace_algorithms import process_limits
+from mslice.util.mantid.mantid_algorithms import AppendSpectra, CreateSimulationWorkspace, CreateWorkspace
+
+from mantid.api import AnalysisDataService
+
+
+class WorkspaceAlgorithmsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.direct_workspace = CreateSimulationWorkspace(OutputWorkspace='MAR_workspace', Instrument='MAR',
+                                                         BinParams=[-10, 1, 10], UnitX='DeltaE')
+        cls.direct_workspace.e_mode = "Direct"
+        cls.direct_workspace.e_fixed = 1.1
+
+        cls.indirect_workspace = CreateSimulationWorkspace(OutputWorkspace='OSIRIS_workspace', Instrument='OSIRIS',
+                                                           BinParams=[-10, 1, 10], UnitX='DeltaE')
+        cls.indirect_workspace.e_mode = "Indirect"
+        cls.indirect_workspace.e_fixed = 1.1
+
+        CreateWorkspace(DataX=cls.indirect_workspace.raw_ws.readX(0), DataY=cls.indirect_workspace.raw_ws.readY(0),
+                        ParentWorkspace='OSIRIS_workspace', UnitX='DeltaE', OutputWorkspace="extra_spectra_ws")
+
+        cls.extended_workspace = AppendSpectra(InputWorkspace1='OSIRIS_workspace', InputWorkspace2='extra_spectra_ws',
+                                               OutputWorkspace='extended_workspace')
+        cls.extended_workspace.e_mode = "Indirect"
+        cls.extended_workspace.e_fixed = 1.1
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        AnalysisDataService.clear()
+
+    def test_process_limits_does_not_fail_for_direct_data(self):
+        process_limits(self.direct_workspace)
+
+    def test_process_limits_does_not_fail_for_indirect_data(self):
+        process_limits(self.indirect_workspace)
+
+    def test_process_limits_does_not_fail_for_workspace_where_not_every_histogram_corresponds_to_a_detector(self):
+        process_limits(self.extended_workspace)

--- a/mslice/tests/workspace_algorithms_test.py
+++ b/mslice/tests/workspace_algorithms_test.py
@@ -40,5 +40,6 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
     def test_process_limits_does_not_fail_for_indirect_data(self):
         process_limits(self.indirect_workspace)
 
-    def test_process_limits_does_not_fail_for_workspace_where_not_every_histogram_corresponds_to_a_detector(self):
-        process_limits(self.extended_workspace)
+    def test_process_limits_will_raise_a_runtime_error_for_a_workspace_where_not_every_histogram_has_a_detector(self):
+        with self.assertRaises(RuntimeError):
+            process_limits(self.extended_workspace)


### PR DESCRIPTION
~~**Need to wait for https://github.com/mantidproject/mantid/pull/33981 to get merged**~~


**Description of work:**
This PR fixes an error caused when loading OSIRIS data due to the OSIRIS data file containing spectra which do not correspond to detectors at the end of the file.

I am unsure if this OSIRIS data is valid data to be loaded into the interface, however there was an easy way to prevent the error, which was caused by an dangerous assumption that the number of histograms == number of detectors.

**To test:**

1) Load the following data into mslice
[OSIRIS00144076.zip](https://github.com/mantidproject/mslice/files/8772816/OSIRIS00144076.zip)

2) Click OK on the pop up that appears upon load.
3) Observe that there isn't an error in the log, but I nicer error in the status bar.
4) In the workspace manager, most of the Slice/Cut functionality is disabled. I assume this is because the data is not appropriate for this

**Test 2**
1) Load the following data into mslice
[OSIRIS00144076.zip](https://github.com/mantidproject/mslice/files/8772816/OSIRIS00144076.zip)
2) Exit the popup using the cross `x`
3) There should not be a crash, and instead there is a status message saying the an EFixed was not provided

Fixes #754
