### PR TITLE
Fix ValueError caused by function get_min

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -24,10 +24,8 @@ from mslice.util.compat import legend_set_draggable
 
 def get_min(data, absolute_minimum=-np.inf):
     """Determines the minimum value in a set of numpy arrays (ignoring values below absolute_minimum)"""
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        mask = np.greater(data, absolute_minimum)
-    return np.min(np.extract(mask, data))
+    masked_data = [np.extract(np.greater(row, absolute_minimum), row) for row in data]
+    return np.min([np.min(row) for row in masked_data])
 
 
 class CutPlot(IPlot):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -8,7 +8,6 @@ from matplotlib.legend import Legend
 from matplotlib.lines import Line2D
 from matplotlib.text import Text
 
-import warnings
 import numpy as np
 
 from mslice.models.colors import to_hex, name_to_color


### PR DESCRIPTION
Description of work.

Previously, if the axis of a cut plot with bragg peaks was changed to logarithmic the `get_min` function throws a value error.

This is because the bragg preak data has a differing number of elements to the spectra data - something the `np.greater` function used can't handle.

The function now performs the operation row by row to alleviate this issue.

**Note:** As part of this PR I've removed the suppression of warnings in the `get_min` function, as I can't see any reason for it.

**Note 2:** This PR does not change the way the coordinates of Bragg peaks are specified. As such, when the y axis is set to log the peaks look like this:
![image](https://user-images.githubusercontent.com/95620982/170467684-2351ed87-31d3-4ed2-852e-dd53a72fe9d2.png)

I suspect we would rather they look like this?
![image](https://user-images.githubusercontent.com/95620982/170467917-db16606e-1f51-4b49-8ec6-7a9f2af279ff.png)

If so I will create a subsequent PR/Issue.

**To test:**
1) Load any data
2) Plot a cut
3) Add Bragg peaks
4) Change x or y scale to logarithmic
5) Observe no error

<!-- Instructions for testing. -->

<!-- Replace #644