### PR TITLE
Change formatting of start up warning re change to cut by integration

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -263,10 +263,9 @@ class MainWindow(MainView, QMainWindow):
 
     def print_startup_notifications(self):
         #if notifications are required to be printed on mslice start up, add to list.
-        print_list = ["WARNING: The default cut algorithm in mslice has been changed from 'Rebin (average counts)'\n\
-         to 'Intergration (summed counts)'. This is expected to result in different output values\n\
-         to those obtained historically. For more information, please refer to documentation at:\n\
-         https://mantidproject.github.io/mslice/cutting.html"]
+        print_list = ["WARNING: The default cut algorithm in mslice has been changed from 'Rebin (average counts)' \
+to 'Intergration (summed counts)'. This is expected to result in different output values to those obtained historically. \n\
+For more information, please refer to documentation at: https://mantidproject.github.io/mslice/cutting.html"]
 
         for item in print_list:
             print(item)


### PR DESCRIPTION
Description of work.

Previously  the warning upon start-up  regarding the change of default cut to cut by integration was formatted to look nice in the console in pycharm. When printed to the mantid console, it does not look right at all.

I've updated the formatting to correct this.

**To test:**
Open mslice via mantid, observe formatting of output warning looks ok.
