### PR TITLE
Speed up plotting when using a Slice plot legend

### DIFF
--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -193,8 +193,13 @@ class SlicePlot(IPlot):
         handles, labels = axes.get_legend_handles_labels()
 
         if handles:
-            axes.legend(handles, labels, fontsize='medium')
+            # Uses the 'upper right' location because 'best' causes very slow plotting for large datasets.
+            axes.legend(handles, labels, fontsize='medium', loc='upper right')
             legend_set_draggable(axes.get_legend(), True)
+        else:
+            legend = axes.get_legend()
+            if legend:
+                legend.remove()
 
     def change_axis_scale(self, colorbar_range, logarithmic):
         current_axis = self._canvas.figure.gca()

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -112,7 +112,7 @@ class SlicePlotTest(unittest.TestCase):
             mock_get_legend.return_value = MagicMock()
 
             self.slice_plot.update_legend()
-            mock_add_legend.assert_called_with(self.line, ['some_label'], fontsize=ANY)
+            mock_add_legend.assert_called_with(self.line, ['some_label'], fontsize=ANY, loc='upper right')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work:**
This PR fixes an issue causing very slow plotting times for large datasets. These slow plotting times could be seen whenever making a change to a plot (such as zooming in or out on a plot with recoil lines or bragg peaks), whenever 'Show legend' was turned on. The slow plotting was caused by the computationally expensive process used in matplotlib to find the 'best' legend location, as described in https://github.com/matplotlib/matplotlib/issues/12120/ .

I decided the best solution was to set the location of the legend to be 'upper right' by default, and then the legend can be easily moved by dragging if required by the user. I think in most cases, the upper right location would be a fairly sensible location.

This PR also fixes a problem where the legend would stay on the plot even when the last recoil/bragg peak line was removed.

**To test:**
This might need to be tested on windows.

1. Load a dataset into Mslice
2. Go to the slice tab and click `Display`
3. Whilst `Show Legend` is on, add a couple of recoil lines. You should notice they are added much quicker than they used to be.
4. Zoom in to the plot, and it should zoom in much quicker.

Fixes #729 
