### PR TITLE
Fix vmin not updated when unticking logarithmic

### DIFF
--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -45,8 +45,10 @@ def _run_quick_options(view, update_model_function, *args):
 
 def _set_axis_options(view, target, model, has_logarithmic, grid):
     range = (float(view.range_min), float(view.range_max))
-    model.change_axis_scale(range, view.log_scale.isChecked() if has_logarithmic is not None else model.colorbar_log)
+    setattr(model, target, range)
 
+    if has_logarithmic is not None:
+        setattr(model, target[:-5] + 'log', view.log_scale.isChecked())
     if grid is not None:
         setattr(model, target[:-5] + 'grid', view.grid_state)
 

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -48,7 +48,7 @@ def _set_axis_options(view, target, model, has_logarithmic, grid):
     setattr(model, target, range)
 
     if has_logarithmic is not None:
-        setattr(model, target[:-5] + 'log', view.log_scale.isChecked())
+        model.change_axis_scale(range, view.log_scale.isChecked())
     if grid is not None:
         setattr(model, target[:-5] + 'grid', view.grid_state)
 

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -45,10 +45,8 @@ def _run_quick_options(view, update_model_function, *args):
 
 def _set_axis_options(view, target, model, has_logarithmic, grid):
     range = (float(view.range_min), float(view.range_max))
-    setattr(model, target, range)
+    model.change_axis_scale(range, view.log_scale.isChecked() if has_logarithmic is not None else model.colorbar_log)
 
-    if has_logarithmic is not None:
-        setattr(model, target[:-5] + 'log', view.log_scale.isChecked())
     if grid is not None:
         setattr(model, target[:-5] + 'grid', view.grid_state)
 

--- a/mslice/presenters/quick_options_presenter.py
+++ b/mslice/presenters/quick_options_presenter.py
@@ -44,13 +44,13 @@ def _run_quick_options(view, update_model_function, *args):
 
 
 def _set_axis_options(view, target, model, has_logarithmic, grid):
-    range = (float(view.range_min), float(view.range_max))
-    setattr(model, target, range)
-
     if has_logarithmic is not None:
-        model.change_axis_scale(range, view.log_scale.isChecked())
+        setattr(model, target[:-5] + 'log', view.log_scale.isChecked())
     if grid is not None:
         setattr(model, target[:-5] + 'grid', view.grid_state)
+
+    range = (float(view.range_min), float(view.range_max))
+    setattr(model, target, range)
 
     setattr(model, target + "_font_size", view.font_size.value())
 

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -130,6 +130,9 @@ class QuickAxisTest(unittest.TestCase):
         x_grid = PropertyMock(return_value=False)
         self.model.x_grid = x_grid
 
+        is_logarithmic = PropertyMock(return_value=False)
+        type(self.model).colorbar_log = is_logarithmic
+
         range_min = PropertyMock(return_value=5)
         type(self.view).range_min = range_min
         range_max = PropertyMock(return_value=10)
@@ -157,14 +160,11 @@ class QuickAxisTest(unittest.TestCase):
     def test_colorbar(self, quick_axis_options_view):
         quick_axis_options_view.return_value = self.view
         self.view.exec_ = MagicMock(return_value=True)
-        colorbar_log = PropertyMock()
-        type(self.model).colorbar_log = colorbar_log
         self.view.log_scale.isChecked = Mock()
         qopt = quick_axis_options('colorbar_range', self.model, True)
         qopt.redraw_signal = PropertyMock()
         qopt.ok_clicked.connect.call_args[0][0]()  # Call the connected signal directly
         self.view.log_scale.isChecked.assert_called_once()
-        colorbar_log.assert_called_once()
 
 
 @patch('mslice.presenters.quick_options_presenter.QuickLabelOptions')

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -157,14 +157,13 @@ class QuickAxisTest(unittest.TestCase):
     def test_colorbar(self, quick_axis_options_view):
         quick_axis_options_view.return_value = self.view
         self.view.exec_ = MagicMock(return_value=True)
-        colorbar_log = PropertyMock()
-        type(self.model).colorbar_log = colorbar_log
-        self.view.log_scale.isChecked = Mock()
+        self.model.change_axis_scale = MagicMock()
+        self.view.log_scale.isChecked = Mock(return_value=True)
         qopt = quick_axis_options('colorbar_range', self.model, True)
         qopt.redraw_signal = PropertyMock()
         qopt.ok_clicked.connect.call_args[0][0]()  # Call the connected signal directly
         self.view.log_scale.isChecked.assert_called_once()
-        colorbar_log.assert_called_once()
+        self.model.change_axis_scale.assert_called_once_with((5, 10), True)
 
 
 @patch('mslice.presenters.quick_options_presenter.QuickLabelOptions')

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -157,13 +157,14 @@ class QuickAxisTest(unittest.TestCase):
     def test_colorbar(self, quick_axis_options_view):
         quick_axis_options_view.return_value = self.view
         self.view.exec_ = MagicMock(return_value=True)
-        self.model.change_axis_scale = MagicMock()
-        self.view.log_scale.isChecked = Mock(return_value=True)
+        colorbar_log = PropertyMock()
+        type(self.model).colorbar_log = colorbar_log
+        self.view.log_scale.isChecked = Mock()
         qopt = quick_axis_options('colorbar_range', self.model, True)
         qopt.redraw_signal = PropertyMock()
         qopt.ok_clicked.connect.call_args[0][0]()  # Call the connected signal directly
         self.view.log_scale.isChecked.assert_called_once()
-        self.model.change_axis_scale.assert_called_once_with((5, 10), True)
+        colorbar_log.assert_called_once()
 
 
 @patch('mslice.presenters.quick_options_presenter.QuickLabelOptions')

--- a/mslice/tests/quick_options_test.py
+++ b/mslice/tests/quick_options_test.py
@@ -130,9 +130,6 @@ class QuickAxisTest(unittest.TestCase):
         x_grid = PropertyMock(return_value=False)
         self.model.x_grid = x_grid
 
-        is_logarithmic = PropertyMock(return_value=False)
-        type(self.model).colorbar_log = is_logarithmic
-
         range_min = PropertyMock(return_value=5)
         type(self.view).range_min = range_min
         range_max = PropertyMock(return_value=10)
@@ -160,11 +157,14 @@ class QuickAxisTest(unittest.TestCase):
     def test_colorbar(self, quick_axis_options_view):
         quick_axis_options_view.return_value = self.view
         self.view.exec_ = MagicMock(return_value=True)
+        colorbar_log = PropertyMock()
+        type(self.model).colorbar_log = colorbar_log
         self.view.log_scale.isChecked = Mock()
         qopt = quick_axis_options('colorbar_range', self.model, True)
         qopt.redraw_signal = PropertyMock()
         qopt.ok_clicked.connect.call_args[0][0]()  # Call the connected signal directly
         self.view.log_scale.isChecked.assert_called_once()
+        colorbar_log.assert_called_once()
 
 
 @patch('mslice.presenters.quick_options_presenter.QuickLabelOptions')


### PR DESCRIPTION
**Description of work:**
This PR fixes an issue where the vmin would not be updated if you changed it along with the Logarithmic option (turning it off)  at the same time in the colorbar options menu.

**To test:**
1. Load data into Mslice
2. Go to the Slice tab and click Display
3. Double click the colorbar to open the options
4. Tick Logarithmic and click Ok
5. Double click the colorbar again to open the options. The vmin should be 0.001.
6. Change the vmin to 0, and untick Logarithmic. Click Ok
7. Open the colorbar options again. Vmin should say `0` and not `0.001`


No related issue
