### PR TITLE
Resolving conflict with missing imports

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -1,5 +1,7 @@
+from distutils.version import LooseVersion
 from functools import partial
 
+from matplotlib import __version__ as mpl_version
 from matplotlib.collections import LineCollection
 from matplotlib.container import ErrorbarContainer
 from matplotlib.legend import Legend


### PR DESCRIPTION
After merging a bug fix two imports were missing and caused the unit tests to fail. I've just added both back as they are still required:

from distutils.version import LooseVersion
from matplotlib import __version__ as mpl_version

