### PR TITLE
Prevent QAccessibleTable error message

### DIFF
--- a/mslice/widgets/dataloader/dataloader.py
+++ b/mslice/widgets/dataloader/dataloader.py
@@ -100,6 +100,9 @@ class DataLoaderWidget(QWidget):  # and some view interface
         self.txtpath.setText(new_path)
         self._clear_displayed_error()
 
+        # Reseting the QFileSystemModel prevents warning messages about QAccessibleTable
+        self.reload_model()
+
     def back(self):
         self.directory.cdUp()
         self._update_from_path()


### PR DESCRIPTION
Not important - maybe something for the next release
==================

**Description of work:**
This PR fixes an error message to do with `QAccessibleTable` by resetting the `QFileSystemModel`.

Although this does fix the problem, I am not particularly happy with this fix. Some assistance finding a better solution would be great. Some things to try:
- [ ] Placing `qtaccessiblewidgets.dll` in a `plugins/qt5/accessibility/` folder https://forum.qt.io/topic/23872/5-0-1-cannot-create-accessible-interface-for-object-warnings/10 
- [ ] Setting QPLUGINS += qtaccessiblewidgets somehow

**To test:**
I was able to replicate the error on a conda build and non-conda build. You just don't usually see the message in a non-conda build because we usually don't open it from a command prompt.

1. Open mslice from a git bash terminal e.g. `C:\\MantidUnstableInstall\\bin\\python.exe scripts/start_mslice.py`. Make sure you have set the relevant environment variables in your system before running this command
2. When Mslice is open, double click to open a folder
3. Then single click a folder in that folder. The error message should no longer appear in the git bash terminal.

Fixes #723
