### PR TITLE
Enable anaconda upload

### DIFF
--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -29,14 +29,6 @@ jobs:
 
       - name: Build MSlice conda package
         run: |
-          conda config --set anaconda_upload no
+          conda config --set anaconda_upload yes
           conda install conda-build conda-verify
-          mamba build --label main $GITHUB_WORKSPACE/conda
-          echo "artifactName=$(basename /usr/share/miniconda3/envs/mslice-env/conda-bld/noarch/mslice-*.tar.bz2)" >> $GITHUB_ENV
-
-      - name: Upload artifact # replace with upload to anaconda
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.artifactName }}
-          path: /usr/share/miniconda3/envs/mslice-env/conda-bld/noarch/mslice-*.tar.bz2
-          if-no-files-found: ignore
+          mamba build --label main --user mantid --token ${{ secrets.ANACONDA_API_TOKEN }} $GITHUB_WORKSPACE/conda

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -39,15 +39,6 @@ jobs:
       - name: Build MSlice nightly conda package
         if: ${{ env.recentCommits == 'true'}}
         run: |
-          conda config --set anaconda_upload no
+          conda config --set anaconda_upload yes
           conda install conda-build conda-verify
-          mamba build --label nightly $GITHUB_WORKSPACE/conda
-          echo "artifactName=$(basename /usr/share/miniconda3/envs/mslice-env/conda-bld/noarch/mslice-*.tar.bz2)" >> $GITHUB_ENV
-
-      - name: Upload artifact # replace with upload to anaconda
-        if: ${{ env.recentCommits == 'true'}}
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.artifactName }}
-          path: /usr/share/miniconda3/envs/mslice-env/conda-bld/noarch/mslice-*.tar.bz2
-          if-no-files-found: ignore
+          mamba build --label nightly --user mantid --token ${{ secrets.ANACONDA_API_TOKEN }} $GITHUB_WORKSPACE/conda


### PR DESCRIPTION
Replaced local artefacts with upload to anaconda for both main and nightly MSlice conda packages.

This is a maintenance task and not related to the release so it should go directly into main.
