### PR TITLE
Prevent strings in options for plot min and max axes values

### DIFF
--- a/mslice/plotting/plot_window/plot_options.py
+++ b/mslice/plotting/plot_window/plot_options.py
@@ -9,6 +9,8 @@ from qtpy.QtCore import Signal
 from mslice.models.colors import named_cycle_colors, color_to_name
 from mslice.util.qt import load_ui
 
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
+
 
 class PlotOptionsDialog(QtWidgets.QDialog):
 
@@ -24,6 +26,15 @@ class PlotOptionsDialog(QtWidgets.QDialog):
     def __init__(self, parent=None, redraw_signal=None):
         QtWidgets.QDialog.__init__(self, parent)
         load_ui(__file__, 'plot_options.ui', self)
+
+        self.x_min_validator = LineEditDoubleValidator(self.lneXMin, 0.0)
+        self.lneXMin.setValidator(self.x_min_validator)
+        self.x_max_validator = LineEditDoubleValidator(self.lneXMax, 0.0)
+        self.lneXMax.setValidator(self.x_max_validator)
+        self.y_min_validator = LineEditDoubleValidator(self.lneYMin, 0.0)
+        self.lneYMin.setValidator(self.y_min_validator)
+        self.y_max_validator = LineEditDoubleValidator(self.lneYMax, 0.0)
+        self.lneYMax.setValidator(self.y_max_validator)
 
         self.lneFigureTitle.editingFinished.connect(self.titleEdited)
         self.lneXAxisLabel.editingFinished.connect(self.xLabelEdited)
@@ -136,6 +147,11 @@ class SlicePlotOptions(PlotOptionsDialog):
         self.chkYLog.hide()
         self.cut_options.hide()
         self.setMaximumWidth(350)
+
+        self.c_min_validator = LineEditDoubleValidator(self.lneCMin, 0.0)
+        self.lneCMin.setValidator(self.c_min_validator)
+        self.c_max_validator = LineEditDoubleValidator(self.lneCMax, 0.0)
+        self.lneCMax.setValidator(self.c_max_validator)
 
         self.lneCMin.editingFinished.connect(self.cRangeEdited)
         self.lneCMax.editingFinished.connect(self.cRangeEdited)

--- a/mslice/plotting/plot_window/quick_options.py
+++ b/mslice/plotting/plot_window/quick_options.py
@@ -1,5 +1,7 @@
 from mslice.plotting.plot_window.plot_options import LegendAndLineOptionsSetter
 
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
+
 from qtpy import QtWidgets
 from qtpy.QtCore import Signal
 
@@ -31,9 +33,15 @@ class QuickAxisOptions(QuickOptions):
         self.min_label = QtWidgets.QLabel("Min:")
         self.min = QtWidgets.QLineEdit()
         self.min.setText(str(existing_values[0]))
+        self.min_validator = LineEditDoubleValidator(self.min, str(existing_values[0]))
+        self.min.setValidator(self.min_validator)
+
         self.max_label = QtWidgets.QLabel("Max:")
         self.max = QtWidgets.QLineEdit()
         self.max.setText(str(existing_values[1]))
+        self.max_validator = LineEditDoubleValidator(self.max, str(existing_values[1]))
+        self.max.setValidator(self.max_validator)
+
         self.font_size_label = QtWidgets.QLabel("Font Size:")
         self.font_size = QtWidgets.QDoubleSpinBox()
         self.decimals = 1


### PR DESCRIPTION
**Description of work:**
This PR uses a custom Line Edit Double Validator to ensure only double values are entered into the min and max axes value boxes for the quick options and plot options. This can prevent confusing error messages.

**To test:**
See the test instructions in the issue.

1. Try opening the Plot options using the cog, and try changing the double values to invalid values.
2. Try opening the Axes Quick options and do the same.

Fixes #765
