### PR TITLE
Fix scaling of Bragg peaks for log scales

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -323,13 +323,13 @@ class CutPlot(IPlot):
 
     def update_bragg_peaks(self):
         if self.plot_window.action_aluminium.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Aluminium', False, cif=None)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Aluminium', False, None, self.y_log)
         if self.plot_window.action_copper.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Copper', False, cif=None)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Copper', False, None, self.y_log)
         if self.plot_window.action_niobium.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Niobium', False, cif=None)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Niobium', False, None, self.y_log)
         if self.plot_window.action_tantalum.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Tantalum', False, cif=None)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Tantalum', False, None, self.y_log)
         self.update_legend()
 
     def save_icut(self):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -185,7 +185,6 @@ class CutPlot(IPlot):
 
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])
-
         else:
             current_axis.set_yscale('linear')
         self.x_range = xy_config['x_range']

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -321,15 +321,23 @@ class CutPlot(IPlot):
     def is_icut(self):
         return self._is_icut
 
+    def _get_overplot_datum(self):
+        return np.nanmedian([line.get_ydata() for line in self._canvas.figure.gca().get_lines()
+                             if not self._cut_plotter_presenter.is_overplot(line)])
+
     def update_bragg_peaks(self):
         if self.plot_window.action_aluminium.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Aluminium', False, None, self.y_log)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Aluminium', False, None, self.y_log,
+                                                          self._get_overplot_datum())
         if self.plot_window.action_copper.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Copper', False, None, self.y_log)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Copper', False, None, self.y_log,
+                                                          self._get_overplot_datum())
         if self.plot_window.action_niobium.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Niobium', False, None, self.y_log)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Niobium', False, None, self.y_log,
+                                                          self._get_overplot_datum())
         if self.plot_window.action_tantalum.isChecked():
-            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Tantalum', False, None, self.y_log)
+            self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Tantalum', False, None, self.y_log,
+                                                          self._get_overplot_datum())
         self.update_legend()
 
     def save_icut(self):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -158,6 +158,7 @@ class CutPlot(IPlot):
 
     def change_axis_scale(self, xy_config):
         current_axis = self._canvas.figure.gca()
+        orig_y_scale_log = self.y_log
         if xy_config['x_log']:
             xmin = xy_config['x_range'][0]
             xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
@@ -184,10 +185,14 @@ class CutPlot(IPlot):
 
             if ymin > 0:
                 xy_config['y_range'] = (ymin, xy_config['y_range'][1])
+
         else:
             current_axis.set_yscale('linear')
         self.x_range = xy_config['x_range']
         self.y_range = xy_config['y_range']
+
+        if xy_config['y_log'] or (xy_config['y_log'] != orig_y_scale_log):
+            self.update_bragg_peaks(refresh=True)
 
     def get_line_options(self, line):
         index = self._get_line_index(line)
@@ -325,17 +330,22 @@ class CutPlot(IPlot):
         return np.nanmedian([line.get_ydata() for line in self._canvas.figure.gca().get_lines()
                              if not self._cut_plotter_presenter.is_overplot(line)])
 
-    def update_bragg_peaks(self):
+    def update_bragg_peaks(self, refresh=None):
+        refresh = False if refresh is None else True
         if self.plot_window.action_aluminium.isChecked():
+            refresh and self._cut_plotter_presenter.hide_overplot_line(None, 'Aluminium')
             self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Aluminium', False, None, self.y_log,
                                                           self._get_overplot_datum())
         if self.plot_window.action_copper.isChecked():
+            refresh and self._cut_plotter_presenter.hide_overplot_line(None, 'Copper')
             self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Copper', False, None, self.y_log,
                                                           self._get_overplot_datum())
         if self.plot_window.action_niobium.isChecked():
+            refresh and self._cut_plotter_presenter.hide_overplot_line(None, 'Niobium')
             self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Niobium', False, None, self.y_log,
                                                           self._get_overplot_datum())
         if self.plot_window.action_tantalum.isChecked():
+            refresh and self._cut_plotter_presenter.hide_overplot_line(None, 'Tantalum')
             self._cut_plotter_presenter.add_overplot_line(self.ws_name, 'Tantalum', False, None, self.y_log,
                                                           self._get_overplot_datum())
         self.update_legend()

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -332,8 +332,15 @@ class CutPlot(IPlot):
 
     def _get_overplot_datum(self):
         if self._datum_dirty:
-            self._datum_cache = np.nanmedian([line.get_ydata() for line in self._canvas.figure.gca().get_lines()
-                                              if not self._cut_plotter_presenter.is_overplot(line)])
+            if not self.waterfall:
+                self._datum_cache = np.nanmedian([line.get_ydata() for line in self._canvas.figure.gca().get_lines()
+                                                  if not self._cut_plotter_presenter.is_overplot(line)])
+            else:
+                for line in self._canvas.figure.gca().get_lines():
+                    if not self._cut_plotter_presenter.is_overplot(line):
+                        self._datum_cache = np.nanmedian([line.get_ydata()])
+                        break
+
             self._datum_dirty = False
 
         return self._datum_cache
@@ -434,6 +441,9 @@ class CutPlot(IPlot):
             self._apply_offset(self.plot_window.waterfall_x, self.plot_window.waterfall_y)
         else:
             self._apply_offset(0., 0.)
+
+        self._datum_dirty = True
+        self.update_bragg_peaks(refresh=True)
         self._canvas.draw()
 
     def _apply_offset(self, x, y):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -455,9 +455,10 @@ class CutPlot(IPlot):
                     line.set_xdata(self._waterfall_cache[line][0] + ind * x)
                     line.set_ydata(self._waterfall_cache[line][1] + ind * y)
                 elif isinstance(line, LineCollection):
-                    if LooseVersion(mpl_version) < LooseVersion('3.3'):
-                        line.set_offset_position('data')  # set_offset_position is deprecated since 3.3
-                    line.set_offsets((ind * x, ind * y))
+                    for index, path in enumerate(line._paths):
+                        if not np.isnan(path.vertices).any():
+                            path.vertices = np.add(self._waterfall_cache[line][index],
+                                                   np.array([[ind * x, ind * y], [ind * x, ind * y]]))
 
     def on_newplot(self, ax):
         # This callback should be activated by a call to errorbar

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -34,7 +34,8 @@ def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, 
     plot_handler.manager.report_as_current()
 
     if checked:
-        plotter_presenter.add_overplot_line(plot_handler.ws_name, key, recoil, cif_file, plot_handler.y_log)
+        plotter_presenter.add_overplot_line(plot_handler.ws_name, key, recoil, cif_file, plot_handler.y_log,
+                                            plot_handler._get_overplot_datum())
     else:
         plotter_presenter.hide_overplot_line(plot_handler.ws_name, key)
 

--- a/mslice/plotting/plot_window/overplot_interface.py
+++ b/mslice/plotting/plot_window/overplot_interface.py
@@ -34,7 +34,7 @@ def toggle_overplot_line(plot_handler, plotter_presenter, key, recoil, checked, 
     plot_handler.manager.report_as_current()
 
     if checked:
-        plotter_presenter.add_overplot_line(plot_handler.ws_name, key, recoil, cif_file)
+        plotter_presenter.add_overplot_line(plot_handler.ws_name, key, recoil, cif_file, plot_handler.y_log)
     else:
         plotter_presenter.hide_overplot_line(plot_handler.ws_name, key)
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -570,3 +570,7 @@ class SlicePlot(IPlot):
         if self.default_options is None:
             return False
         return self.default_options[item] != getattr(self, item)
+
+    @property
+    def y_log(self):  # needed for interface consistency with cut plot
+        return False

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -574,3 +574,7 @@ class SlicePlot(IPlot):
     @property
     def y_log(self):  # needed for interface consistency with cut plot
         return False
+
+    @staticmethod
+    def _get_overplot_datum():  # needed for interface consistency with cut plot
+        return 0

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -139,7 +139,7 @@ class CutPlotterPresenter(PresenterUtility):
                 y = self._get_log_bragg_y_coords(len(y), 0.15, datum)
 
             self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
-        except (ValueError, IndexError) as e:
+        except (ValueError, IndexError):
             warnings.warn("No Bragg peak found.")
 
     def store_icut(self, icut):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -102,18 +102,20 @@ class CutPlotterPresenter(PresenterUtility):
         datum = 0.001 if datum == 0 else datum
         y1, y2 = plt.gca().get_ylim()
         if (y2 > 0 and y1 > 0) or (y2 < 0 and y1 < 0):
-            total_steps = np.log10(y2/y1)
+            total_steps = np.log10(y2 / y1)
         elif y1 < 0:
             y1_int = -1
             y2_int = 1
-            total_steps = np.log10(y2 / y2_int) + np.log10(y1 / y1_int) + 2
+            total_steps_up = np.log10(y2 / y2_int) + 1 if abs(y2) >= 1 else abs(y2)
+            total_steps_down = np.log10(y1 / y1_int) + 1 if abs(y1) >= 1 else abs(y1)
+            total_steps = total_steps_up + total_steps_down
         else:
             y1 = 1 if y1 == 0 else y1
             y2 = 1 if y2 == 0 else y2
-            total_steps = np.log10(y2/y1) + 1
+            total_steps = np.log10(y2 / y1) + 1
 
         adj_factor = total_steps * portion_of_axes / 2
-        return np.resize(np.array([10**adj_factor, 10**(-adj_factor), np.nan]), size) * datum
+        return np.resize(np.array([10 ** adj_factor, 10 ** (-adj_factor), np.nan]), size) * datum
 
     def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None, datum=None):
         datum = 0 if datum is None else datum

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -136,7 +136,7 @@ class CutPlotterPresenter(PresenterUtility):
             if not y_has_logarithmic:
                 y = np.array(y) * scale_fac / np.nanmax(y) + datum
             else:
-                y = self._get_log_bragg_y_coords(len(y), 0.25, datum)
+                y = self._get_log_bragg_y_coords(len(y), 0.15, datum)
 
             self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
         except (ValueError, IndexError) as e:

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -11,6 +11,8 @@ from mslice.plotting.plot_window.overplot_interface import remove_line, plot_ove
 from mslice.models.powder.powder_functions import compute_powder_line
 import warnings
 
+BRAGG_SIZE_ON_AXES = 0.15
+
 
 class CutPlotterPresenter(PresenterUtility):
 
@@ -104,10 +106,8 @@ class CutPlotterPresenter(PresenterUtility):
         if (y2 > 0 and y1 > 0) or (y2 < 0 and y1 < 0):
             total_steps = np.log10(y2 / y1)
         elif y1 < 0:
-            y1_int = -1
-            y2_int = 1
-            total_steps_up = np.log10(y2 / y2_int) + 1 if abs(y2) >= 1 else abs(y2)
-            total_steps_down = np.log10(y1 / y1_int) + 1 if abs(y1) >= 1 else abs(y1)
+            total_steps_up = np.log10(y2) + 1 if abs(y2) >= 1 else abs(y2)
+            total_steps_down = np.log10(-y1) + 1 if abs(y1) >= 1 else abs(y1)
             total_steps = total_steps_up + total_steps_down
         else:
             y1 = 1 if y1 == 0 else y1
@@ -117,8 +117,7 @@ class CutPlotterPresenter(PresenterUtility):
         adj_factor = total_steps * portion_of_axes / 2
         return np.resize(np.array([10 ** adj_factor, 10 ** (-adj_factor), np.nan]), size) * datum
 
-    def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None, datum=None):
-        datum = 0 if datum is None else datum
+    def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None, datum=0):
         cache = self._cut_cache_dict[plt.gca()][0]
         cache.rotated = not is_twotheta(cache.cut_axis.units) and not is_momentum(cache.cut_axis.units)
         try:
@@ -138,7 +137,7 @@ class CutPlotterPresenter(PresenterUtility):
             if not y_has_logarithmic:
                 y = np.array(y) * scale_fac / np.nanmax(y) + datum
             else:
-                y = self._get_log_bragg_y_coords(len(y), 0.15, datum)
+                y = self._get_log_bragg_y_coords(len(y), BRAGG_SIZE_ON_AXES, datum)
 
             self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
         except (ValueError, IndexError):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -97,8 +97,7 @@ class CutPlotterPresenter(PresenterUtility):
             line = cache.pop(key)
             remove_line(line)
 
-    def add_overplot_line(self, workspace_name, key, recoil, cif=None):
-        recoil = False
+    def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None):
         cache = self._cut_cache_dict[plt.gca()][0]
         cache.rotated = not is_twotheta(cache.cut_axis.units) and not is_momentum(cache.cut_axis.units)
         try:
@@ -115,7 +114,8 @@ class CutPlotterPresenter(PresenterUtility):
             q_axis = cache.cut_axis
         x, y = compute_powder_line(workspace_name, q_axis, key, cif_file=cif)
         try:
-            y = np.array(y) * (scale_fac / np.nanmax(y))
+            adj_scale_fac = (scale_fac / np.nanmax(y)) if not  y_has_logarithmic else (scale_fac / np.nanmax(y))
+            y = np.array(y) * adj_scale_fac
             self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
         except ValueError:
             warnings.warn("No Bragg peak found.")

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -92,7 +92,7 @@ class SlicePlotterPresenter(PresenterUtility):
             line = cache.overplot_lines.pop(key)
             remove_line(line)
 
-    def add_overplot_line(self, workspace_name, key, recoil, cif=None):
+    def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None):
         cache = self._slice_cache[workspace_name]
         if recoil:
             x, y = compute_recoil_line(workspace_name, cache.momentum_axis, key)

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -92,7 +92,7 @@ class SlicePlotterPresenter(PresenterUtility):
             line = cache.overplot_lines.pop(key)
             remove_line(line)
 
-    def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None):
+    def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None, datum=None):
         cache = self._slice_cache[workspace_name]
         if recoil:
             x, y = compute_recoil_line(workspace_name, cache.momentum_axis, key)

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -100,6 +100,7 @@ class CutPlotTest(unittest.TestCase):
 
     def test_waterfall(self):
         self.cut_plot._apply_offset = MagicMock()
+        self.cut_plot.update_bragg_peaks = MagicMock()
         self.cut_plot.waterfall = True
         self.cut_plot.waterfall_x = 1
         self.cut_plot.waterfall_y = 2
@@ -108,3 +109,4 @@ class CutPlotTest(unittest.TestCase):
         self.cut_plot.waterfall = False
         self.cut_plot.toggle_waterfall()
         self.cut_plot._apply_offset.assert_called_with(0, 0)
+        self.cut_plot.update_bragg_peaks.assert_called_with(refresh=True)

--- a/mslice/tests/cut_plot_test.py
+++ b/mslice/tests/cut_plot_test.py
@@ -57,7 +57,7 @@ class CutPlotTest(unittest.TestCase):
         self.axes.get_lines = MagicMock(return_value=[line])
         self.canvas.figure.gca = MagicMock(return_value=self.axes)
         xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
-
+        self.cut_plot.update_bragg_peaks = MagicMock()
         self.cut_plot.change_axis_scale(xy_config)
 
         if LooseVersion(mpl_version) < LooseVersion('3.3'):
@@ -67,6 +67,7 @@ class CutPlotTest(unittest.TestCase):
             self.axes.set_xscale.assert_called_once_with('symlog', linthresh=10.0)
             self.axes.set_yscale.assert_called_once_with('symlog', linthresh=1.0)
 
+        self.cut_plot.update_bragg_peaks.assert_called_once_with(refresh=True)
         self.assertEqual(self.cut_plot.x_range, (0, 20))
         self.assertEqual(self.cut_plot.y_range, (1, 7))
 

--- a/mslice/tests/slice_plot_test.py
+++ b/mslice/tests/slice_plot_test.py
@@ -81,7 +81,7 @@ class SlicePlotTest(unittest.TestCase):
         self.plot_figure.action_arbitrary_nuclei.isChecked = MagicMock(return_value=True)
 
         self.slice_plot.arbitrary_recoil_line()
-        self.slice_plotter.add_overplot_line.assert_called_once_with('workspace', 5, True, None)
+        self.slice_plotter.add_overplot_line.assert_called_once_with('workspace', 5, True, None, False, 0)
 
     @patch('mslice.plotting.plot_window.slice_plot.QtWidgets.QInputDialog.getInt')
     def test_arbitrary_recoil_line_cancelled(self, qt_get_int_mock):


### PR DESCRIPTION
**Description of work:**
Previously, the y-coords of Bragg peak lines (which have no physical significance) would not scale when the y axis is set to logarithmic. This means the lines become stretched, not appearing unobtrusive markers as intended (see image on issue).

Through this PR, the Bragg peak lines are now scaled to take up a proportion of the axis (currently hardcoded as 15%) either side of a provided datum (set as the median value of the spectra). As such, they also are refreshed (removed and replotted) every time a change is made to the y axis.

**To test:**

1. Plot cut plot
2. Add Bragg Peaks
3. Change the y axis to logarithmic
4. Change the y axis to reflect the following scenarios:
   - Negative y values
   - Negative y minimum
   - 0 minimum
   - 0 maximum
5. Confirm behaviour of recoil lines and Bragg peak lines on slice plot unaffected.
6. Confirm when waterfall toggle is on, the Bragg peaks are plotted over the first line regardless of offset.
7. Confirm Bragg peaks refresh upon waterfall toggle, plotting of new lines, and removal of existing lines (actions which effect the datum).

Fixes #766 

