### PR TITLE
Revert default Cut algo to Rebin

### DIFF
--- a/mslice/app/mainwindow.py
+++ b/mslice/app/mainwindow.py
@@ -263,9 +263,15 @@ class MainWindow(MainView, QMainWindow):
 
     def print_startup_notifications(self):
         #if notifications are required to be printed on mslice start up, add to list.
-        print_list = ["WARNING: The default cut algorithm in mslice has been changed from 'Rebin (average counts)' \
-to 'Intergration (summed counts)'. This is expected to result in different output values to those obtained historically. \n\
-For more information, please refer to documentation at: https://mantidproject.github.io/mslice/cutting.html"]
+
+        # Disable this notification pending decision on changing the default
+        #print_list = ["\nWARNING: The default cut algorithm in mslice has been changed " \
+        #              "from 'Rebin (average counts)' to 'Intergration (summed counts)'.\n" \
+        #              "This is expected to result in different output values to those obtained historically.\n" \
+        #              "For more information, please refer to documentation at: " \
+        #              "https://mantidproject.github.io/mslice/cutting.html"]
+        print_list = []
 
         for item in print_list:
-            print(item)
+            for strn in item.split('\n'):
+                self._console.execute(f'print("{strn}")', hidden=True)

--- a/mslice/app/mainwindow.ui
+++ b/mslice/app/mainwindow.ui
@@ -466,15 +466,15 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
    <property name="text">
     <string>Integration (Sum Counts)</string>
    </property>
   </action>
   <action name="actionCutAlgoRebin">
    <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
     <bool>true</bool>
    </property>
    <property name="text">

--- a/mslice/cli/_mslice_commands.py
+++ b/mslice/cli/_mslice_commands.py
@@ -167,7 +167,7 @@ def Slice(InputWorkspace, Axis1=None, Axis2=None, NormToOne=False):
     return get_slice_plotter_presenter().create_slice(workspace, x_axis, y_axis, None, None, NormToOne, DEFAULT_CMAP)
 
 
-def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False, Algorithm='Integration'):
+def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False, Algorithm='Rebin'):
     """
     Cuts workspace.
     :param InputWorkspace: Workspace to cut. The parameter can be either a python
@@ -183,6 +183,7 @@ def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False, Alg
             '<name>, <start>, <end>, <step>, cm-1', or '<name>, <start>, <end>, meV'
             Recognised energy units are 'meV' (default) and 'cm-1'
     :param NormToOne: if True the cut will be normalized to one.
+    :param Algorithm: the cut algorithm to use. Either 'Rebin' (default) or 'Integration'
     :return:
     """
     from mslice.app.presenters import get_cut_plotter_presenter

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -2,7 +2,7 @@ class Cut(object):
     """Groups parameters needed to cut and validates them"""
 
     def __init__(self, cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one=False, width=None,
-                 algorithm='Integration'):
+                 algorithm='Rebin'):
         self.cut_axis = cut_axis
         self.integration_axis = integration_axis
         self.intensity_start = intensity_start

--- a/mslice/models/cut/cut_functions.py
+++ b/mslice/models/cut/cut_functions.py
@@ -13,7 +13,7 @@ def output_workspace_name(selected_workspace, integration_start, integration_end
         integration_end) + ")"
 
 
-def compute_cut(workspace, cut_axis, integration_axis, is_norm, algo='Integration', store=True):
+def compute_cut(workspace, cut_axis, integration_axis, is_norm, algo='Rebin', store=True):
     out_ws_name = output_workspace_name(workspace.name, integration_axis.start, integration_axis.end)
     cut = mantid_algorithms.Cut(OutputWorkspace=out_ws_name, store=store, InputWorkspace=workspace,
                                 CutAxis=cut_axis.to_dict(), IntegrationAxis=integration_axis.to_dict(),

--- a/mslice/scripting/helperfunctions.py
+++ b/mslice/scripting/helperfunctions.py
@@ -176,7 +176,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts):
         cut_start, cut_end = integration_start, min(integration_start + cut.width, integration_end)
         intensity_range = (cut.intensity_start, cut.intensity_end)
         norm_to_one = cut.norm_to_one
-        algo_str = '' if 'Integration' in cut.algorithm else ', Algorithm="{}"'.format(cut.algorithm)
+        algo_str = '' if 'Rebin' in cut.algorithm else ', Algorithm="{}"'.format(cut.algorithm)
 
         while cut_start != cut_end and index < len(errorbars):
             cut.integration_axis.start = cut_start

--- a/mslice/tests/command_line_test.py
+++ b/mslice/tests/command_line_test.py
@@ -148,13 +148,13 @@ class CommandLineTest(unittest.TestCase):
         get_cpp.return_value = CutPlotterPresenter()
         workspace = self.create_workspace('test_workspace_cut_cli')
         #test rebin
-        rebin_result = Cut(workspace, Algorithm='Rebin')
+        rebin_result = Cut(workspace)
         rebin_signal = rebin_result.get_signal()
         self.assertEqual(type(rebin_result), HistogramWorkspace)
         self.assertAlmostEqual(1.129, rebin_signal[5], 2)
         self.assertAlmostEqual(1.375, rebin_signal[8], 2)
         #test integration
-        int_result = Cut(workspace)
+        int_result = Cut(workspace, Algorithm='Integration')
         int_signal = int_result.get_signal()
         self.assertAlmostEqual(2.258, int_signal[5], 2)
         self.assertAlmostEqual(1.375, int_signal[8], 2)
@@ -178,14 +178,14 @@ class CommandLineTest(unittest.TestCase):
         get_cpp.return_value = CutPlotterPresenter()
         workspace = self.create_pixel_workspace('test_workspace_cut_psd_cli')
         #test rebin
-        rebin_result = Cut(workspace, Algorithm='Rebin')
+        rebin_result = Cut(workspace)
         rebin_signal = rebin_result.get_signal()
         self.assertEqual(type(rebin_result), HistogramWorkspace)
         self.assertEqual(128, rebin_signal[0])
         self.assertEqual(192, rebin_signal[29])
         self.assertEqual(429, rebin_signal[15])
         #test Integration
-        int_result = Cut(workspace)
+        int_result = Cut(workspace, Algorithm='Integration')
         int_signal = int_result.get_signal()
         self.assertEqual(type(int_result), HistogramWorkspace)
         self.assertAlmostEqual(64, int_signal[0], 2)

--- a/mslice/widgets/cut/cut.py
+++ b/mslice/widgets/cut/cut.py
@@ -46,8 +46,8 @@ class CutWidget(CutView, QWidget):
         self.set_validators()
         self._en = EnergyUnits('meV')
         self._en_default = 'meV'
-        self._cut_alg_default = 'Integration'
-        self.set_cut_algorithm('Integration')
+        self._cut_alg_default = 'Rebin'
+        self.set_cut_algorithm('Rebin')
         self.cmbCutEUnits.currentIndexChanged.connect(self._changed_unit)
         self.cmbCutAlg.currentIndexChanged.connect(self.cut_algorithm_changed)
 


### PR DESCRIPTION
**Description of work:**

Reverts the default cut algorithm back to `Rebin` from `Integration`.

After some discussions in the excitations group it was decided that the breaking changes by switching the default algorithm ( #717 ) is too major a change without pre-notification for users. In addition it was pointed out that for cuts which integrated in Q, the `Rebin` behaviour _could_ be more appropriate, whereas for integration in E, the `Integration` behaviour should usually apply. The previous issue #705 which requested the change in default was focused only on the integration in E behaviour.

So, for now the behaviour should be reverted back to the previous default (to use `Rebin`).

**To test:**

* Start MSlice
* Check that the menu option for the Cut Algorithm is set to `Rebin`
* Load a data file
* Go to the "Cut" tab and check that the drop-down box for the Cut Algorithm is set to `Rebin`.
* Change the cut algorithm to `Integration` and make a cut
* Save the plot to a script and check the script has the line `algorithm='Integration'`.
* Load another data file
* Go to the "Cut" tab and check that the drop-down box for _this_ data is still set to `Rebin`.
* Save the plot to a script and check the script has no line with `algorithm=`

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->

No associated issue
