### PR TITLE
Improve detection of empty cut axes

### DIFF
--- a/mslice/presenters/cut_widget_presenter.py
+++ b/mslice/presenters/cut_widget_presenter.py
@@ -53,7 +53,7 @@ class CutWidgetPresenter(PresenterUtility):
             self._parse_step()
             params = self._parse_input()
         except ValueError as e:
-            if "''" in str(e):
+            if len(str(e).split(":",1)[1]) <= 3:
                 self._cut_view.display_error("Cut axes cannot be empty!")
             else:
                 self._cut_view.display_error(str(e))


### PR DESCRIPTION
The new method is more robust and works for different operating systems.

**To test:**

Open a data set in MSlice and navigate to the Cut tab. Without entering any values, click on Plot and check the error message displayed on the bottom of the MSlice window.
