### PR TITLE
Fix bug that causes continual calls to "toggle_waterfall"

### DIFF
--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -83,8 +83,8 @@ class CutPlot(IPlot):
         plot_window.action_gen_script.triggered.connect(self.generate_script)
         plot_window.action_gen_script_clipboard.triggered.connect(lambda: self.generate_script(clipboard=True))
         plot_window.action_waterfall.triggered.connect(self.toggle_waterfall)
-        plot_window.waterfall_x_edt.editingFinished.connect(self.toggle_waterfall)
-        plot_window.waterfall_y_edt.editingFinished.connect(self.toggle_waterfall)
+        plot_window.waterfall_x_edt.editingFinished.connect(self.update_waterfall)
+        plot_window.waterfall_y_edt.editingFinished.connect(self.update_waterfall)
         plot_window.waterfall_x_edt.editingFinished.connect(plot_window.lose_waterfall_x_edt_focus)
         plot_window.waterfall_y_edt.editingFinished.connect(plot_window.lose_waterfall_y_edt_focus)
         plot_window.action_aluminium.triggered.connect(
@@ -442,13 +442,16 @@ class CutPlot(IPlot):
             return line_visible
 
     def toggle_waterfall(self):
+        self._datum_dirty = True
+        self.update_bragg_peaks(refresh=True)
+        self.update_waterfall()
+
+    def update_waterfall(self):
         if self.waterfall:
             self._apply_offset(self.plot_window.waterfall_x, self.plot_window.waterfall_y)
         else:
             self._apply_offset(0., 0.)
 
-        self._datum_dirty = True
-        self.update_bragg_peaks(refresh=True)
         self._canvas.draw()
 
     def _cache_line(self, line):
@@ -492,8 +495,8 @@ class CutPlot(IPlot):
                 if line not in self._waterfall_cache:
                     self._waterfall_cache[line] = [line.get_xdata(), line.get_ydata()]
                     new_line = True
-        if new_line and num_lines > 1:
-            self.toggle_waterfall()
+        if new_line and num_lines > 1 and self.plot_window.waterfall:
+            self.update_waterfall()
 
         self._datum_dirty = True
         self.update_bragg_peaks(refresh=True)

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -85,6 +85,8 @@ class CutPlot(IPlot):
         plot_window.action_waterfall.triggered.connect(self.toggle_waterfall)
         plot_window.waterfall_x_edt.editingFinished.connect(self.toggle_waterfall)
         plot_window.waterfall_y_edt.editingFinished.connect(self.toggle_waterfall)
+        plot_window.waterfall_x_edt.editingFinished.connect(plot_window.lose_waterfall_x_edt_focus)
+        plot_window.waterfall_y_edt.editingFinished.connect(plot_window.lose_waterfall_y_edt_focus)
         plot_window.action_aluminium.triggered.connect(
             partial(toggle_overplot_line, self, self._cut_plotter_presenter, 'Aluminium', False))
         plot_window.action_copper.triggered.connect(

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -160,6 +160,7 @@ class PlotWindow(QtWidgets.QMainWindow):
 
     def add_waterfall_edit(self, parent):
         self.waterfall_x_lbl = QtWidgets.QLabel("x:", parent)
+        self.waterfall_x_lbl.setFocusPolicy(QtCore.Qt.TabFocus)
         self.waterfall_y_lbl = QtWidgets.QLabel("y:", parent)
         self.waterfall_x_edt = QtWidgets.QLineEdit("0", parent)
         self.waterfall_y_edt = QtWidgets.QLineEdit("0", parent)

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -37,6 +37,8 @@ class PlotWindow(QtWidgets.QMainWindow):
         self._first_time_show = False
 
     def closeEvent(self, _):
+        self.lose_waterfall_x_edt_focus()  # lose focus so toggle_waterfall does not trigger upon close
+        self.lose_waterfall_y_edt_focus()
         self.canvas.manager.window_closing()
 
     def showEvent(self, evt):
@@ -183,6 +185,18 @@ class PlotWindow(QtWidgets.QMainWindow):
         self.waterfall_y_lbl_act.setVisible(is_waterfall)
         self.waterfall_x_edt_act.setVisible(is_waterfall)
         self.waterfall_y_edt_act.setVisible(is_waterfall)
+
+    def lose_waterfall_x_edt_focus(self):
+        self._lose_focus_without_signal(self.waterfall_x_edt)
+
+    def lose_waterfall_y_edt_focus(self):
+        self._lose_focus_without_signal(self.waterfall_y_edt)
+
+    @staticmethod
+    def _lose_focus_without_signal(qt_obj):
+        qt_obj.blockSignals(True)  # prevents a subsequent call to this function
+        qt_obj.clearFocus()
+        qt_obj.blockSignals(False)
 
     def create_status_bar(self):
         self.statusbar = QtWidgets.QStatusBar(self)


### PR DESCRIPTION
**Description of work:**
A bug was caused by the waterfall x and y edit boxes never losing focus on a cut plot. Once either box was selected every subsequent action caused by clicking on a menu/plot takes focus away from the box, but then seems to gives it back again as  the clicked object has `qt focus policy` set to disabled by default. This causes an unnecessary signal and subsequent call to `toggle_waterfall` upon each action.

Upon closing a cut plot, the erroneous signal is emitted in this way, but the `toggle_waterfall` function called after the plot has been closed.

This conflicts with a recent change which requires the `toggle_waterfall` function to update the bragg peak lines when called (this may be unnecessary, considering removal in subsequent PR),

This PR ensures that the waterfall edit boxes lose focus upon finish editing, and closing the cut plot window.

**To test:**
Follow instructions on the issue #793 
Observe how many times `toggle_waterfall` is called when waterfall plots are active, and navigating around making other changes to the cut plot (this is best done with a print statement in `toggle_waterfall` as a break point there prevents a lot of menu functionality).


Fixes #793
