### PR TITLE
Fix bragg peak qops to work with new colour mapping and line width

### DIFF
--- a/mslice/models/colors.py
+++ b/mslice/models/colors.py
@@ -38,7 +38,7 @@ except ImportError:
 
 _BASIC_COLORS_HEX_MAPPING = {'blue': '#1f77b4', 'orange': '#ff7f0e', 'green': '#2ca02c', 'red': '#d62728',
                              'purple': '#9467bd', 'brown': '#8c564b', 'pink': '#e377c2', 'gray': '#7f7f7f',
-                             'olive': '#bcbd22', 'cyan': '#17becf'}
+                             'olive': '#bcbd22', 'cyan': '#17becf', 'yellow': '#bfbf00', 'magenta': '#bf00bf'}
 
 
 def pretty_name(name):

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -208,7 +208,7 @@ class CutPlot(IPlot):
                 'shown': None,
                 'color': to_hex(line.get_color()),
                 'style': line.get_linestyle(),
-                'width': str(int(line.get_linewidth())),
+                'width': str(line.get_linewidth()),
                 'marker': line.get_marker(),
                 'error_bar': None
             }


### PR DESCRIPTION
**Description of work:**

**To test:**
Line quick options (specifically the functions that deal with Bragg peaks) had not been updated for the new colour mapping or line width changes.

This PR updates them to not expect an int, and adds default Bragg peak colours to the colourmap,


<!-- Instructions for testing. -->
1. Plot a cut
2. Add Copper Bragg peaks
3. Right Click on Bragg peak lines
4. Observe correct colour and line width in boxes
5. Click ok, no error

No Issue
