### PR TITLE
Fix error when closing interactive plot

### DIFF
--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -152,8 +152,10 @@ class SlicePlot(IPlot):
         plot_window.action_gen_script.triggered.disconnect()
 
     def window_closing(self):
-        # nothing to do
-        pass
+        if self.icut is not None:
+            self.icut.clear()
+            self.icut.window_closing()
+            self.icut = None
 
     def plot_options(self):
         SlicePlotOptionsPresenter(SlicePlotOptions(self.plot_window, redraw_signal=self.plot_window.redraw), self)

--- a/mslice/presenters/slice_widget_presenter.py
+++ b/mslice/presenters/slice_widget_presenter.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function)
 from .busy import show_busy
-import traceback
 from mslice.models.alg_workspace_ops import get_available_axes, get_axis_range
 from mslice.models.axis import Axis
 from mslice.models.units import EnergyUnits
@@ -67,7 +66,6 @@ class SliceWidgetPresenter(PresenterUtility, SlicePlotterPresenterInterface):
         try:
             self._slice_plotter_presenter.plot_slice(*args)
         except RuntimeError as e:
-            traceback.print_exc(e)
             self._slice_view.error(e.args[0])
         except ValueError as e:
             # This gets thrown by matplotlib if the supplied intensity_min > data_max_value or vise versa


### PR DESCRIPTION
**Description of work:**
This PR fixes an error when closing an interactive plot after having closed its associated slice plot. The solution was to disassociate the interactive plot from the slice plot when the slice plot gets closed.

It also removes an unwanted traceback import which I believe was used for debugging but is no longer needed.

**To test:**
1. Load data
2. Display a slice plot
3. Do interactive cut on this plot
4. Close slice plot window
5. Close interactive cut window
6. There should be no error!

Fixes #798
