### PR TITLE
Fix Rect selector and CrossCursor dissappearing after change of intensity

### DIFF
--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -34,6 +34,7 @@ class InteractiveCut(object):
 
         self.connect_event[3] = self._canvas.mpl_connect('draw_event', self.redraw_rectangle)
         self._canvas.draw()
+        self.slice_plot.set_cross_cursor()
 
     def plot_from_mouse_event(self, eclick, erelease):
         # Make axis orientation sticky, until user selects entirely new rectangle.
@@ -113,3 +114,9 @@ class InteractiveCut(object):
     def window_closing(self):
         self.slice_plot.toggle_interactive_cuts()
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
+
+    def refresh_rect_selector(self, ax):
+        self.rect = RectangleSelector(ax, self.plot_from_mouse_event,
+                                      drawtype='box', useblit=True,
+                                      button=[1, 3], spancoords='pixels', interactive=True)
+        self.slice_plot.set_cross_cursor()

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -403,7 +403,6 @@ class SlicePlot(IPlot):
             self.plot_window.action_keep.setEnabled(False)
             self.plot_window.action_make_current.setEnabled(False)
             self.plot_window.action_flip_axis.setVisible(True)
-            self._canvas.setCursor(Qt.CrossCursor)
         else:
             self.manager.picking_connected(True)
             self.plot_window.action_zoom_in.setEnabled(True)
@@ -584,3 +583,6 @@ class SlicePlot(IPlot):
     @staticmethod
     def _get_overplot_datum():  # needed for interface consistency with cut plot
         return 0
+
+    def set_cross_cursor(self):
+        self._canvas.setCursor(Qt.CrossCursor)

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -30,17 +30,17 @@ def _show_plot(slice_cache, workspace):
 
     plt_handler = cur_fig.canvas.manager.plot_handler
 
-    # Because the axis is cleared, RectangleSelector needs to use the new axis
-    # otherwise it can't be used after doing an intensity plot (as it clears the axes)
-    if plt_handler.icut is not None:
-        plt_handler.icut.rect.ax = ax
-
     plt_handler._update_lines()
 
     cur_fig.canvas.manager.plot_handler._update_lines()
 
     cur_fig.canvas.draw_idle()
     cur_fig.show()
+
+    # Because the axis is cleared, RectangleSelector needs to use the new axis
+    # otherwise it can't be used after doing an intensity plot (as it clears the axes)
+    if plt_handler.icut is not None:
+        plt_handler.icut.refresh_rect_selector(ax)
 
     # This ensures that another slice plotted in the same window saves the plot options
     # as the plot window's showEvent is called only once. The equivalent command is left


### PR DESCRIPTION
**Description of work:**
When changing intensity prior to the plotting of an `icut`, the rectangle selector and CrossCursor will appear upon interacting with the plot.

**To test:**
1. Plot any slice
2. Toggle` interactive cut` on the `slice plot`.
3. Use the rectangle selector to take an `icut`
4. Observe CrossCursor remains, and that drawn rectangle is visible

Fixes #808.
