### PR TITLE
Fix second slice plot opening when changing intensity with icut open

### DIFF
--- a/mslice/plotting/globalfiguremanager.py
+++ b/mslice/plotting/globalfiguremanager.py
@@ -485,6 +485,10 @@ class GlobalFigureManager(object):
         cls._disable_make_current = False
 
     @classmethod
+    def make_current_disabled(cls):
+        return cls._disable_make_current
+
+    @classmethod
     def all_figure_numbers(cls):
         """An iterator over all figure numbers"""
         return list(cls._figures.keys())

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -116,7 +116,11 @@ class InteractiveCut(object):
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
 
     def refresh_rect_selector(self, ax):
+        extents = self.rect.extents
         self.rect = RectangleSelector(ax, self.plot_from_mouse_event,
                                       drawtype='box', useblit=True,
                                       button=[1, 3], spancoords='pixels', interactive=True)
+        if self._rect_pos_cache:
+            self.rect.to_draw.set_visible(True)
+            self.rect.extents = extents
         self.slice_plot.set_cross_cursor()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -120,7 +120,6 @@ class InteractiveCut(object):
         self.rect = RectangleSelector(ax, self.plot_from_mouse_event,
                                       drawtype='box', useblit=True,
                                       button=[1, 3], spancoords='pixels', interactive=True)
-        if self._rect_pos_cache:
-            self.rect.to_draw.set_visible(True)
-            self.rect.extents = extents
+        self.rect.to_draw.set_visible(True)
+        self.rect.extents = extents
         self.slice_plot.set_cross_cursor()

--- a/mslice/plotting/plot_window/interactive_cut.py
+++ b/mslice/plotting/plot_window/interactive_cut.py
@@ -34,6 +34,7 @@ class InteractiveCut(object):
 
         self.connect_event[3] = self._canvas.mpl_connect('draw_event', self.redraw_rectangle)
         self._canvas.draw()
+        self.slice_plot.set_cross_cursor()
 
     def plot_from_mouse_event(self, eclick, erelease):
         # Make axis orientation sticky, until user selects entirely new rectangle.
@@ -113,3 +114,9 @@ class InteractiveCut(object):
     def window_closing(self):
         self.slice_plot.toggle_interactive_cuts()
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
+
+    def refresh_rect_selector(self, ax):
+        self.rect = RectangleSelector(ax, self.plot_from_mouse_event,
+                                      drawtype='box', useblit=True,
+                                      button=[1, 3], spancoords='pixels', interactive=True)
+        self.slice_plot.set_cross_cursor()

--- a/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/mslice/plotting/plot_window/plot_figure_manager.py
@@ -94,6 +94,15 @@ class PlotFigureManagerQT(QtCore.QObject):
         """Report to the global figure manager that this figure should be made active"""
         self._current_figs.set_figure_as_current(self.number)
 
+    def enable_make_current(self):
+        self._current_figs.enable_make_current()
+
+    def disable_make_current(self):
+        self._current_figs.disable_make_current()
+
+    def make_current_disabled(self):
+        return self._current_figs.make_current_disabled()
+
     def flag_as_kept(self):
         self.window.flag_as_kept()
 

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -319,7 +319,7 @@ class SlicePlot(IPlot):
             self.update_canvas(cbar_range, cbar_log, x_range, y_range, title)
         else:
             action.setChecked(True)
-        self._reset_current_figure(disable_make_current_after_plot, disable_make_current_after_plot)
+        self._reset_current_figure(last_active_figure_number, disable_make_current_after_plot)
 
     def update_canvas(self, cbar_range, cbar_log, x_range, y_range, title):
         self.change_axis_scale(cbar_range, cbar_log)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -312,17 +312,14 @@ class SlicePlot(IPlot):
             title = self.title
             if temp_dependent:
                 if not self._run_temp_dependent(slice_plotter_method, previous):
+                    self._reset_current_figure(last_active_figure_number, last_active_figure_number)
                     return
             else:
                 slice_plotter_method(self.ws_name)
             self.update_canvas(cbar_range, cbar_log, x_range, y_range, title)
         else:
             action.setChecked(True)
-        # Reset current active figure
-        if last_active_figure_number is not None:
-            self.manager._current_figs.set_figure_as_current(last_active_figure_number)
-        if disable_make_current_after_plot:
-            self.manager.disable_make_current()
+        self._reset_current_figure(last_active_figure_number, last_active_figure_number)
 
     def update_canvas(self, cbar_range, cbar_log, x_range, y_range, title):
         self.change_axis_scale(cbar_range, cbar_log)
@@ -332,6 +329,12 @@ class SlicePlot(IPlot):
         self.manager.update_grid()
         self._update_lines()
         self._canvas.draw()
+
+    def _reset_current_figure(self, last_active_figure_number, disable_make_current_after_plot):
+        if last_active_figure_number is not None:
+            self.manager._current_figs.set_figure_as_current(last_active_figure_number)
+        if disable_make_current_after_plot:
+            self.manager.disable_make_current()
 
     def _run_temp_dependent(self, slice_plotter_method, previous):
         temp_value_raw = None

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -403,7 +403,6 @@ class SlicePlot(IPlot):
             self.plot_window.action_keep.setEnabled(False)
             self.plot_window.action_make_current.setEnabled(False)
             self.plot_window.action_flip_axis.setVisible(True)
-            self._canvas.setCursor(Qt.CrossCursor)
         else:
             self.manager.picking_connected(True)
             self.plot_window.action_zoom_in.setEnabled(True)
@@ -584,3 +583,6 @@ class SlicePlot(IPlot):
     @staticmethod
     def _get_overplot_datum():  # needed for interface consistency with cut plot
         return 0
+
+    def set_cross_cursor(self):
+        self._canvas.setCursor(Qt.CrossCursor)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -312,14 +312,14 @@ class SlicePlot(IPlot):
             title = self.title
             if temp_dependent:
                 if not self._run_temp_dependent(slice_plotter_method, previous):
-                    self._reset_current_figure(last_active_figure_number, last_active_figure_number)
+                    self._reset_current_figure(last_active_figure_number, disable_make_current_after_plot)
                     return
             else:
                 slice_plotter_method(self.ws_name)
             self.update_canvas(cbar_range, cbar_log, x_range, y_range, title)
         else:
             action.setChecked(True)
-        self._reset_current_figure(last_active_figure_number, last_active_figure_number)
+        self._reset_current_figure(disable_make_current_after_plot, disable_make_current_after_plot)
 
     def update_canvas(self, cbar_range, cbar_log, x_range, y_range, title):
         self.change_axis_scale(cbar_range, cbar_log)

--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -289,6 +289,10 @@ class SlicePlot(IPlot):
         if self.manager._current_figs._active_figure is not None:
             last_active_figure_number = self.manager._current_figs.get_active_figure().number
 
+        disable_make_current_after_plot = False
+        if self.manager.make_current_disabled():
+            self.manager.enable_make_current()
+            disable_make_current_after_plot = True
         self.manager.report_as_current()
 
         self.default_options['temp_dependent'] = temp_dependent
@@ -317,6 +321,8 @@ class SlicePlot(IPlot):
         # Reset current active figure
         if last_active_figure_number is not None:
             self.manager._current_figs.set_figure_as_current(last_active_figure_number)
+        if disable_make_current_after_plot:
+            self.manager.disable_make_current()
 
     def update_canvas(self, cbar_range, cbar_log, x_range, y_range, title):
         self.change_axis_scale(cbar_range, cbar_log)

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -34,13 +34,12 @@ def _show_plot(slice_cache, workspace):
 
     cur_fig.canvas.manager.plot_handler._update_lines()
 
+    if plt_handler.icut is not None:
+        # Because the axis is cleared, RectangleSelector needs to use the new axis
+        plt_handler.icut.refresh_rect_selector(ax)
+
     cur_fig.canvas.draw_idle()
     cur_fig.show()
-
-    # Because the axis is cleared, RectangleSelector needs to use the new axis
-    # otherwise it can't be used after doing an intensity plot (as it clears the axes)
-    if plt_handler.icut is not None:
-        plt_handler.icut.refresh_rect_selector(ax)
 
     # This ensures that another slice plotted in the same window saves the plot options
     # as the plot window's showEvent is called only once. The equivalent command is left

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -5,8 +5,8 @@ import mslice.plotting.pyplot as plt
 PICKER_TOL_PTS = 5
 
 
-def plot_cached_slice(slice_workspace, slice_cache):
-    _show_plot(slice_workspace, slice_cache)
+def plot_cached_slice(slice_cache, slice_workspace):
+    _show_plot(slice_cache, slice_workspace)
 
 
 @plt.set_category(plt.CATEGORY_SLICE)

--- a/mslice/views/slice_plotter.py
+++ b/mslice/views/slice_plotter.py
@@ -30,17 +30,17 @@ def _show_plot(slice_cache, workspace):
 
     plt_handler = cur_fig.canvas.manager.plot_handler
 
-    # Because the axis is cleared, RectangleSelector needs to use the new axis
-    # otherwise it can't be used after doing an intensity plot (as it clears the axes)
-    if plt_handler.icut is not None:
-        plt_handler.icut.rect.ax = ax
-
     plt_handler._update_lines()
 
     cur_fig.canvas.manager.plot_handler._update_lines()
 
     cur_fig.canvas.draw_idle()
     cur_fig.show()
+
+    # Because the axis is cleared, RectangleSelector needs to use the new axis
+    # otherwise it can't be used after doing an intensity plot (as it clears the axes)
+    if plt_handler.icut is not None:
+        plt_handler.icut.refresh_rect_selector(ax)
 
     # This ensures that another slice plotted in the same window saves the plot options
     # as the plot window's showEvent is called only once. The equivalent command is left


### PR DESCRIPTION
**Description of work:**
Previously, if changing intensity with `interactive cut` toggled on and an `icut ` open, a second slice plot would appear and the rectangle selector would disappear. 

Also, when changing intensity prior to the plotting of an `icut`, the rectangle selector and CrossCursor will appear upon interacting with the plot.

This PR resolves these issues.

NOTE: It is a minor annoyance that the rectangle selector flickers upon a change of intensity, not sure how to get rid of this so let me know if you have a solution.

**To test:**

_Second Plot Window_
1.  Plot any slice
2.  Toggle `interactive cut` on the `slice plot` window
3.  Use the rectangle selector to plot an `icut`
4.  Change the intensity type use the intensity drop down menu of the `slice plot` window.
5. Observe the current slice plot intensity is corrected and that the rectangle selector remains in place.

_Disappearing Slice_
1. Plot any slice
2. Toggle` interactive cut` on the `slice plot`.
3. Change the intensity type use the intensity drop down menu of the `slice plot` window.
4. Use the rectangle selector to take an `icut`
5. Observe CrossCursor remains, and that drawn rectangle is visible

Fixes #807 and #812.
