### PR TITLE
Fix GDOS intensity correction + enable for cuts

### DIFF
--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -7,8 +7,7 @@ from mslice.models.alg_workspace_ops import get_axis_range, get_available_axes
 from mslice.models.axis import Axis
 from mslice.models.workspacemanager.workspace_provider import workspace_exists
 from mslice.models.intensity_correction_algs import (compute_chi, compute_d2sigma,
-                                                     compute_symmetrised)
-from mslice.models.labels import is_momentum, is_twotheta
+                                                     compute_symmetrised, cut_compute_gdos)
 from mslice.models.cut.cut import SampleTempValueError
 from mslice.plotting.globalfiguremanager import GlobalFigureManager
 
@@ -212,7 +211,7 @@ def hide_a_line_and_errorbars(ax, idx: int):
     return None
 
 
-def _correct_intensity(scattering_data, intensity_correction, e_axis, sample_temp=None):
+def _correct_intensity(scattering_data, intensity_correction, e_axis, q_axis, NormToOne, Algorithm, rotated, sample_temp):
     if not intensity_correction or intensity_correction == "scattering_function":
         return scattering_data
     if intensity_correction == "dynamical_susceptibility":
@@ -225,8 +224,10 @@ def _correct_intensity(scattering_data, intensity_correction, e_axis, sample_tem
         return compute_d2sigma(scattering_data, e_axis, scattering_data.e_fixed)
     if intensity_correction == "symmetrised":
         _check_sample_temperature(sample_temp, scattering_data.name)
-        rotated = not is_twotheta(scattering_data.cut_axis.units) and not is_momentum(scattering_data.cut_axis.units)
         return compute_symmetrised(scattering_data, sample_temp, e_axis, rotated)
+    if intensity_correction == "gdos":
+        _check_sample_temperature(sample_temp, scattering_data.name)
+        return cut_compute_gdos(scattering_data, sample_temp, q_axis, e_axis, rotated, NormToOne, Algorithm) #needs q axis
 
 
 def _check_sample_temperature(sample_temperature, workspace_name):

--- a/mslice/cli/helperfunctions.py
+++ b/mslice/cli/helperfunctions.py
@@ -227,7 +227,7 @@ def _correct_intensity(scattering_data, intensity_correction, e_axis, q_axis, No
         return compute_symmetrised(scattering_data, sample_temp, e_axis, rotated)
     if intensity_correction == "gdos":
         _check_sample_temperature(sample_temp, scattering_data.name)
-        return cut_compute_gdos(scattering_data, sample_temp, q_axis, e_axis, rotated, NormToOne, Algorithm) #needs q axis
+        return cut_compute_gdos(scattering_data, sample_temp, q_axis, e_axis, rotated, NormToOne, Algorithm)
 
 
 def _check_sample_temperature(sample_temperature, workspace_name):

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -1,5 +1,5 @@
 from mslice.models.intensity_correction_algs import (compute_chi, compute_d2sigma,
-                                                     compute_symmetrised)
+                                                     compute_symmetrised, cut_compute_gdos)
 from mslice.models.labels import is_momentum, is_twotheta
 
 import numpy as np
@@ -33,6 +33,7 @@ class Cut(object):
         self._chi_magnetic = None
         self._d2sigma = None
         self._symmetrised = None
+        self._gdos = None
 
     @property
     def cut_ws(self):
@@ -182,6 +183,15 @@ class Cut(object):
             self._corrected_intensity_range_cache["symmetrised"] = self._get_intensity_range_from_ws(self._symmetrised)
         return self._symmetrised
 
+    @property
+    def gdos(self):
+        if self._gdos is None:
+            self._gdos = cut_compute_gdos(self._cut_ws, self.sample_temp, self.q_axis, self.e_axis, self.rotated,
+                                          self.norm_to_one, self.algorithm)
+            self._gdos.intensity_corrected = True
+            self._corrected_intensity_range_cache["gdos"] = self._get_intensity_range_from_ws(self._gdos)
+        return self._gdos
+
     def get_intensity_corrected_ws(self, intensity_correction_type):
         if intensity_correction_type == "dynamical_susceptibility":
             return self.chi
@@ -191,6 +201,8 @@ class Cut(object):
             return self.d2sigma
         elif intensity_correction_type == "symmetrised":
             return self.symmetrised
+        elif intensity_correction_type == "gdos":
+            return self.gdos
 
     @property
     def e_axis(self):

--- a/mslice/models/slice/slice.py
+++ b/mslice/models/slice/slice.py
@@ -68,5 +68,5 @@ class Slice:
     @property
     def gdos(self):
         if self._gdos is None:
-            self._gdos = slice_compute_gdos(self.scattering_function, self.sample_temp, self.momentum_axis, self.energy_axis)
+            self._gdos = slice_compute_gdos(self.scattering_function, self.sample_temp, self.momentum_axis, self.energy_axis, self.rotated)
         return self._gdos

--- a/mslice/plotting/plot_window/cut_plot.py
+++ b/mslice/plotting/plot_window/cut_plot.py
@@ -132,6 +132,9 @@ class CutPlot(IPlot):
             partial(self.show_intensity_plot, plot_window.action_symmetrised_sqe,
                     self._cut_plotter_presenter.show_symmetrised, True))
 
+        plot_window.action_gdos.triggered.connect(
+            partial(self.show_intensity_plot, plot_window.action_gdos,
+                    self._cut_plotter_presenter.show_gdos, True))
 
     def disconnect(self, plot_window):
         plot_window.action_save_cut.triggered.disconnect()
@@ -582,6 +585,8 @@ class CutPlot(IPlot):
             return self.plot_window.action_d2sig_dw_de
         if intensity_method == "show_symmetrised":
             return self.plot_window.action_symmetrised_sqe
+        if intensity_method == "show_gdos":
+            return self.plot_window.action_gdos
 
     def trigger_action_from_method(self, intensity_method):
         action = self._get_action_from_method(intensity_method)

--- a/mslice/plotting/plot_window/plot_window.py
+++ b/mslice/plotting/plot_window/plot_window.py
@@ -118,12 +118,7 @@ class PlotWindow(QtWidgets.QMainWindow):
         menu.addAction(self.action_d2sig_dw_de)
         self.action_symmetrised_sqe = add_action(menu, self, "Symmetrised S(Q,E)", checkable=True, visible=True)
         menu.addAction(self.action_symmetrised_sqe)
-
-        menu.setToolTipsVisible(True)
         self.action_gdos = add_action(menu, self, "GDOS", checkable=True, visible=True)
-        self.action_gdos.setEnabled(False)
-        self.action_gdos.setToolTip("GDOS intensity correction has temporarily been disabled as it is causing an error "
-                                    "on some datasets ")
         menu.addAction(self.action_gdos)
 
     def create_toolbar(self):

--- a/mslice/presenters/cut_plotter_presenter.py
+++ b/mslice/presenters/cut_plotter_presenter.py
@@ -266,6 +266,9 @@ class CutPlotterPresenter(PresenterUtility):
     def show_symmetrised(self, axes):
         self._show_intensity(self._cut_cache_dict[axes], "symmetrised")
 
+    def show_gdos(self, axes):
+        self._show_intensity(self._cut_cache_dict[axes], "gdos")
+
     def set_sample_temperature(self, axes, ws_name, temp):
         cut_dict = {}
         parent_ws_name = None

--- a/mslice/tests/intensity_correction_algs_test.py
+++ b/mslice/tests/intensity_correction_algs_test.py
@@ -1,12 +1,13 @@
 from __future__ import (absolute_import, division, print_function)
 
-from mock import patch
+from mock import patch, MagicMock
 import numpy as np
 import unittest
 
 from mslice.models.axis import Axis
 from mslice.models.intensity_correction_algs import (compute_boltzmann_dist, compute_chi, compute_d2sigma,
-                                                     compute_symmetrised, sample_temperature)
+                                                     compute_symmetrised, sample_temperature, cut_compute_gdos,
+                                                     slice_compute_gdos)
 from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace
 from mantid.simpleapi import AddSampleLog
 
@@ -19,10 +20,13 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.sim_scattering_data = np.arange(0, 1.5, 0.002).reshape(30,25).transpose()
-        cls.e_axis = Axis('DeltaE', -10, 15, 1)
-        cls.q_axis = Axis('|Q|', 0.1, 3.1, 0.1)
+        cls.sim_scattering_data = np.linspace(0.002, 1.5, 30*25).reshape(30, 25).transpose()
+        cls.e_axis = Axis('DeltaE', cls.sim_scattering_data[0][0], cls.sim_scattering_data[24][29], 0.002 * 25)
+        cls.q_axis = Axis('|Q|', cls.sim_scattering_data[0][0], cls.sim_scattering_data[24][0], 0.002)
         cls.q_axis_degrees = Axis('Degrees', 3, 33, 1)
+        cls.rotated = False
+        cls.norm_to_one = False
+        cls.algorithm = "rebin"
 
         cls.test_ws = CreateSampleWorkspace(OutputWorkspace='test_ws', NumBanks=1, BankPixelWidth=5, XMin=0.1,
                                             XMax=3.1, BinWidth=0.1, XUnit='DeltaE')
@@ -34,35 +38,59 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
     def test_boltzmann_dist(self):
         e_axis = np.arange(self.e_axis.start, self.e_axis.end, self.e_axis.step)
         boltz = compute_boltzmann_dist(10, e_axis)
-        self.assertAlmostEqual(boltz[0], 109592.269, 0)
-        self.assertAlmostEqual(boltz[10], 1.0, 3)
-        self.assertAlmostEqual(boltz[20], 0.000009125, 9)
+        self.assertAlmostEqual(boltz[0], 0.997, 2)
+        self.assertAlmostEqual(boltz[15], 0.418, 2)
+        self.assertAlmostEqual(boltz[29], 0.185, 2)
 
     def test_compute_chi(self):
         chi = compute_chi(self.test_ws, 10, self.e_axis).get_signal()
-        self.assertAlmostEqual(chi[0][0], 0.0, 6)
-        self.assertAlmostEqual(chi[15][10], 1.662609, 6)
-        self.assertAlmostEqual(chi[24][29], 4.706106, 6)
+        self.assertAlmostEqual(chi[0][0], 0.000015, 6)
+        self.assertAlmostEqual(chi[15][10], 0.755691, 6)
+        self.assertAlmostEqual(chi[24][29], 3.885829, 6)
 
     def test_compute_chi_magnetic(self):
         chi_m = compute_chi(self.test_ws, 10, self.e_axis, True).get_signal()
         self.assertAlmostEqual(chi_m[0][0], 0.0, 6)
-        self.assertAlmostEqual(chi_m[15][10], 0.005713, 6)
-        self.assertAlmostEqual(chi_m[24][29], 0.016172, 6)
+        self.assertAlmostEqual(chi_m[15][10], 0.002597, 6)
+        self.assertAlmostEqual(chi_m[24][29], 0.013353, 6)
 
     @patch('mslice.models.slice.slice_functions.get_workspace_handle')
     def test_compute_d2sigma(self, ws_handle_mock):
         ws_handle_mock.return_value = self.test_ws
         d2sigma = compute_d2sigma(self.test_ws, self.e_axis, self.test_ws.e_fixed).get_signal()
-        self.assertAlmostEqual(d2sigma[0][0], 0.0, 6)
-        self.assertAlmostEqual(d2sigma[15][10], 0.449329, 6)
-        self.assertAlmostEqual(d2sigma[24][29], 0.749, 6)
+        self.assertAlmostEqual(d2sigma[0][0], 0.002, 6)
+        self.assertAlmostEqual(d2sigma[15][10], 0.525058, 6)
+        self.assertAlmostEqual(d2sigma[24][29], 1.442654, 6)
 
     def test_compute_symmetrised(self):
         symmetrised = compute_symmetrised(self.test_ws, 10, self.e_axis, False).get_signal()
-        self.assertAlmostEqual(symmetrised[0][0], 0.0, 6)
-        self.assertAlmostEqual(symmetrised[15][10], 0.53, 6)
-        self.assertAlmostEqual(symmetrised[24][29], 1.498, 6)
+        self.assertAlmostEqual(symmetrised[0][0], 0.002, 6)
+        self.assertAlmostEqual(symmetrised[15][10], 0.532, 6)
+        self.assertAlmostEqual(symmetrised[24][29], 1.5, 6)
+
+    def test_compute_gdos_slice(self):
+        gdos = slice_compute_gdos(self.test_ws, 10, self.q_axis, self.e_axis, self.rotated).get_signal()
+        self.assertAlmostEqual(gdos[0][0], 0.002318, 6)
+        self.assertAlmostEqual(gdos[15][10], 121.811019, 6)
+        self.assertAlmostEqual(gdos[24][29], 742.138661, 6)
+
+    @patch('mslice.models.intensity_correction_algs.compute_cut')
+    @patch('mslice.models.intensity_correction_algs.slice_compute_gdos')
+    @patch('mslice.models.intensity_correction_algs.get_workspace_handle')
+    def test_compute_gdos_cut(self, ws_handle_mock, slice_compute_gdos_mock, compute_cut_mock):
+        workspace = MagicMock()
+        workspace.limits = {self.q_axis.units: [0.1, 3.1, 0.1], self.e_axis.units: [0.1, 3.1, 0.1]}
+        ws_handle_mock.return_value = workspace
+        slice_compute_gdos_mock.return_value = MagicMock()
+        compute_cut_mock.return_value = MagicMock()
+        gdos = cut_compute_gdos(self.test_ws, 10, self.q_axis, self.e_axis, self.rotated, self.norm_to_one,
+                                self.algorithm)
+        slice_q_axis = Axis(self.q_axis.units, 0.1, 3.1, 0.1, self.q_axis.e_unit)
+        slice_e_axis = Axis(self.e_axis.units, 0.1, 3.1, 0.1, self.e_axis.e_unit)
+        slice_compute_gdos_mock.assert_called_with(workspace, 10, slice_q_axis, slice_e_axis, self.rotated)
+        compute_cut_mock.assert_called_with(slice_compute_gdos_mock.return_value, self.q_axis, self.e_axis,
+                                            self.norm_to_one, self.algorithm)
+        self.assertEqual(gdos, compute_cut_mock.return_value)
 
     def test_sample_temperature(self):
         self.assertEqual(sample_temperature(self.test_ws.name, ['Ei']), 3.0)

--- a/mslice/workspace/workspace_mixin.py
+++ b/mslice/workspace/workspace_mixin.py
@@ -3,7 +3,7 @@ import numpy as np
 import operator as op
 
 from mantid.simpleapi import CloneWorkspace, PowerMD
-from mslice.util.numpy_helper import apply_with_corrected_shape, transform_array_to_workspace
+from mslice.util.numpy_helper import apply_with_corrected_shape
 
 
 # Other operators are defined when MSlice is imported in _workspace_ops.attach_binary_operators()


### PR DESCRIPTION
**Description of work:**
As part of a previous PR, the `GDOS` intensity correction for slices was disabled as it threw an unhandled error on some datasets.

This PR fixes this issue, and enables the ability to apply `GDOS` intensity correction to cuts.

**To test:**
1) Observe all tests pass, including new GDOS tests.
2) Following testing instructions on previous intensity PR (https://github.com/mantidproject/mslice/pull/811), correcting for GDOS instead of suggested intensities

<!-- Instructions for testing. -->

Resolves #817
