### PR TITLE
Fix temperature not cached when set from a log/field

### DIFF
--- a/mslice/plotting/plot_window/slice_plot.py
+++ b/mslice/plotting/plot_window/slice_plot.py
@@ -338,7 +338,7 @@ class SlicePlot(IPlot):
                 return False
             if field:
                 self._slice_plotter_presenter.add_sample_temperature_field(temp_value_raw)
-                self._slice_plotter_presenter.update_sample_temperature(self.ws_name)
+                self.temp = self._slice_plotter_presenter.update_sample_temperature_from_field(self.ws_name)
             else:
                 temp_value = get_sample_temperature_from_string(temp_value_raw)
                 if temp_value is not None:

--- a/mslice/presenters/slice_plotter_presenter.py
+++ b/mslice/presenters/slice_plotter_presenter.py
@@ -113,9 +113,10 @@ class SlicePlotterPresenter(PresenterUtility):
     def add_sample_temperature_field(self, field_name):
         self._sample_temp_fields.append(field_name)
 
-    def update_sample_temperature(self, workspace_name):
+    def update_sample_temperature_from_field(self, workspace_name):
         temp = sample_temperature(workspace_name, self._sample_temp_fields)
         self.set_sample_temperature(workspace_name, temp)
+        return temp
 
     def set_sample_temperature(self, workspace_name, temp):
         self._slice_cache[workspace_name].sample_temp = temp


### PR DESCRIPTION
**Description of work:**

**To test:**

1) Load any `.nxs` mslice dataset (I used `MAR21335_Ei60meV.nxs`)
2) `Display` slice
3) Change intensity to `GDOS` via the `intensity` drop down.
4) When promoted to select a temperature, choose `T_Head` from the drop down.
5) Take an interactive cut
6) Observe no crash

Fixes #827
