### PR TITLE
Prevent duplication of suffix when renaming workspaces

### DIFF
--- a/mslice/workspace/histogram_workspace.py
+++ b/mslice/workspace/histogram_workspace.py
@@ -7,6 +7,8 @@ from .common_workspace_properties import CommonWorkspaceProperties
 
 from mantid.api import IMDHistoWorkspace
 
+import re
+
 
 class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase, CommonWorkspaceProperties):
     """workspace wrapper for MDHistoWorkspace"""
@@ -30,7 +32,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
     @WorkspaceMixin.name.setter
     def name(self, new_name: str):
         raw_name = str(self.raw_ws)
-        rename_workspace(raw_name, raw_name.replace(self.name, new_name))
+        rename_workspace(raw_name, re.sub(rf"{self.name}\w*", new_name, raw_name))
 
         self._name = new_name
 

--- a/mslice/workspace/pixel_workspace.py
+++ b/mslice/workspace/pixel_workspace.py
@@ -8,6 +8,8 @@ from .common_workspace_properties import CommonWorkspaceProperties
 
 from mantid.api import IMDEventWorkspace
 
+import re
+
 
 class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase, CommonWorkspaceProperties):
     """workspace wrapper for MDEventWorkspace. Converts to HistogramWorkspace internally."""
@@ -38,10 +40,10 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
     def name(self, new_name: str):
         if self.raw_ws is not None:
             raw_name = str(self.raw_ws)
-            rename_workspace(raw_name, raw_name.replace(self.name, new_name))
+            rename_workspace(raw_name, re.sub(rf"{self.name}\w*", new_name, raw_name))
         elif self._histo_ws is not None:
             histo_name = str(self._histo_ws)
-            rename_workspace(histo_name, histo_name.replace(self.name, new_name))
+            rename_workspace(histo_name, re.sub(rf"{self.name}\w*", new_name, histo_name))
 
         self._name = new_name
 

--- a/mslice/workspace/workspace.py
+++ b/mslice/workspace/workspace.py
@@ -6,6 +6,7 @@ from .common_workspace_properties import CommonWorkspaceProperties
 
 from mantid.api import MatrixWorkspace
 
+import re
 
 class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase, CommonWorkspaceProperties):
     """workspace wrapper for MatrixWorkspace"""
@@ -29,7 +30,7 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase, CommonWor
     @WorkspaceMixin.name.setter
     def name(self, new_name: str):
         raw_name = str(self.raw_ws)
-        rename_workspace(raw_name, raw_name.replace(self.name, new_name))
+        rename_workspace(raw_name, re.sub(rf"{self.name}\w*", new_name, raw_name))
 
         self._name = new_name
 


### PR DESCRIPTION
**Description of work:**
While performing operations like bose or subtract workspaces are renamed internally. This renaming has been slightly modified to prevent the duplication of suffixes like '_subtracted'. 

**To test:**

Follow instructions in https://github.com/mantidproject/mslice/issues/829 and https://github.com/mantidproject/mslice/pull/755.

When generating the script from https://github.com/mantidproject/mslice/issues/829 from scratch the line with 'RenameWorkspace' should not be included anymore. The original script should still run without problems though.

Fixes #829 
