### PR TITLE
Updated Ubuntu version to 20.04 in GitHub workflows

### DIFF
--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_conda_and_upload:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_conda_and_upload:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/online_doc_update.yml
+++ b/.github/workflows/online_doc_update.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/unit_tests_nighly.yml
+++ b/.github/workflows/unit_tests_nighly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
**Description of work:**

Changed all GitHub workflows from Ubuntu-18.04 to Ubuntu-20.04.

**To test:**

Ensure that workflows are still running. For most workflows that will be only possible after merging into main though.

Fixes #837 
