### PR TITLE
Update for latest mock version 

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install mantid mantidqt
+          conda install -c mantid/label/nightly mantid mantidqt
 
       - name: Flake8
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install -c mantid/label/nightly mantid mantidqt
+          conda install -c mantid mantid=6.5.0 mantidqt=6.5.0
 
       - name: Flake8
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install -c mantid/label/nightly mantid mantidqt
+          conda install mantid mantidqt
 
       - name: Flake8
         run: |

--- a/mslice/tests/slice_test.py
+++ b/mslice/tests/slice_test.py
@@ -53,11 +53,12 @@ class SliceTest(unittest.TestCase):
     def test_d2sigma_computes_if_none(self, compute_d2sigma_fn):
         test_output_workspace = MagicMock()
         test_energy_axis = MagicMock()
+        test_output_workspace.e_fixed = 10
 
         test_slice = self._create_slice(workspace=test_output_workspace, e_axis=test_energy_axis)
         test_slice.d2sigma
         compute_d2sigma_fn.assert_called_once_with(test_output_workspace, test_energy_axis,
-                                                   test_output_workspace.scattering_function.e_fixed)
+                                                   test_output_workspace.e_fixed)
 
     def test_d2sigma_returns_if_already_computed(self):
         test_d2sigma = 5.0
@@ -75,7 +76,7 @@ class SliceTest(unittest.TestCase):
         test_slice = self._create_slice(workspace=test_output_workspace, sample_temp=test_sample_temp,
                                         q_axis=test_momentum_axis, e_axis=test_energy_axis)
         test_slice.symmetrised
-        compute_symmetrised_fn.assert_called_once_with(test_output_workspace, test_sample_temp,test_momentum_axis, test_energy_axis, None)
+        compute_symmetrised_fn.assert_called_once_with(test_output_workspace, test_sample_temp, test_energy_axis, None)
 
     def test_symmetrised_returns_if_already_computed(self):
         test_symmetrised = 5.0

--- a/mslice/tests/slice_test.py
+++ b/mslice/tests/slice_test.py
@@ -56,7 +56,8 @@ class SliceTest(unittest.TestCase):
 
         test_slice = self._create_slice(workspace=test_output_workspace, e_axis=test_energy_axis)
         test_slice.d2sigma
-        compute_d2sigma_fn.assert_called_once_with(test_output_workspace, test_energy_axis)
+        compute_d2sigma_fn.assert_called_once_with(test_output_workspace, test_energy_axis,
+                                                   test_output_workspace.scattering_function.e_fixed)
 
     def test_d2sigma_returns_if_already_computed(self):
         test_d2sigma = 5.0
@@ -74,7 +75,7 @@ class SliceTest(unittest.TestCase):
         test_slice = self._create_slice(workspace=test_output_workspace, sample_temp=test_sample_temp,
                                         q_axis=test_momentum_axis, e_axis=test_energy_axis)
         test_slice.symmetrised
-        compute_symmetrised_fn.assert_called_once_with(test_output_workspace, test_sample_temp,test_momentum_axis, test_energy_axis)
+        compute_symmetrised_fn.assert_called_once_with(test_output_workspace, test_sample_temp,test_momentum_axis, test_energy_axis, None)
 
     def test_symmetrised_returns_if_already_computed(self):
         test_symmetrised = 5.0
@@ -91,7 +92,7 @@ class SliceTest(unittest.TestCase):
         test_slice = self._create_slice(workspace=test_output_workspace, sample_temp=test_sample_temp,
                                         e_axis=test_energy_axis)
         test_slice.gdos
-        compute_gdos_fn.assert_called_once_with(test_output_workspace, test_sample_temp, test_energy_axis)
+        compute_gdos_fn.assert_called_once_with(test_output_workspace, test_sample_temp, None, test_energy_axis, None)
 
     def test_gdos_returns_if_already_computed(self):
         test_gdos = 5.0

--- a/mslice/tests/slice_test.py
+++ b/mslice/tests/slice_test.py
@@ -24,7 +24,7 @@ class SliceTest(unittest.TestCase):
         test_slice = self._create_slice(workspace=test_output_workspace, sample_temp=test_sample_temp,
                                         e_axis=test_energy_axis)
         test_slice.chi
-        compute_chi_fn.called_once_with(test_output_workspace, test_sample_temp, test_energy_axis)
+        compute_chi_fn.assert_called_once_with(test_output_workspace, test_sample_temp, test_energy_axis)
 
     def test_chi_returns_if_already_computed(self):
         test_chi = 5.0
@@ -41,7 +41,7 @@ class SliceTest(unittest.TestCase):
         test_slice = self._create_slice(workspace=test_output_workspace, sample_temp=test_sample_temp,
                                         e_axis=test_energy_axis)
         test_slice.chi_magnetic
-        compute_chi_fn.called_once_with(test_output_workspace, test_sample_temp, test_energy_axis, True)
+        compute_chi_fn.assert_called_once_with(test_output_workspace, test_sample_temp, test_energy_axis, True)
 
     def test_ch_magnetic_returns_if_already_computed(self):
         test_chi_magnetic = 5.0
@@ -56,7 +56,7 @@ class SliceTest(unittest.TestCase):
 
         test_slice = self._create_slice(workspace=test_output_workspace, e_axis=test_energy_axis)
         test_slice.d2sigma
-        compute_d2sigma_fn.called_once_with(test_output_workspace, test_energy_axis)
+        compute_d2sigma_fn.assert_called_once_with(test_output_workspace, test_energy_axis)
 
     def test_d2sigma_returns_if_already_computed(self):
         test_d2sigma = 5.0
@@ -74,7 +74,7 @@ class SliceTest(unittest.TestCase):
         test_slice = self._create_slice(workspace=test_output_workspace, sample_temp=test_sample_temp,
                                         q_axis=test_momentum_axis, e_axis=test_energy_axis)
         test_slice.symmetrised
-        compute_symmetrised_fn.called_once_with(test_output_workspace, test_sample_temp,test_momentum_axis, test_energy_axis)
+        compute_symmetrised_fn.assert_called_once_with(test_output_workspace, test_sample_temp,test_momentum_axis, test_energy_axis)
 
     def test_symmetrised_returns_if_already_computed(self):
         test_symmetrised = 5.0
@@ -91,7 +91,7 @@ class SliceTest(unittest.TestCase):
         test_slice = self._create_slice(workspace=test_output_workspace, sample_temp=test_sample_temp,
                                         e_axis=test_energy_axis)
         test_slice.gdos
-        compute_gdos_fn.called_once_with(test_output_workspace, test_sample_temp, test_energy_axis)
+        compute_gdos_fn.assert_called_once_with(test_output_workspace, test_sample_temp, test_energy_axis)
 
     def test_gdos_returns_if_already_computed(self):
         test_gdos = 5.0

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -266,8 +266,9 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter = WorkspaceManagerPresenter(self.view)
         self.view.get_workspace_index = mock.Mock(return_value=0)
         get_ws_name_mock.return_value = 'ws'
-        self.presenter.set_selected_workspaces([mock.Mock()])
-        get_ws_name_mock.assert_called_once_with(None)
+        ws_mock = mock.Mock()
+        self.presenter.set_selected_workspaces([ws_mock])
+        get_ws_name_mock.assert_called_once_with(ws_mock)
         self.view.get_workspace_index.assert_called_once_with('ws')
         self.view.set_workspace_selected.assert_called_once_with([0])
 

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -267,7 +267,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_index = mock.Mock(return_value=0)
         get_ws_name_mock.return_value = 'ws'
         self.presenter.set_selected_workspaces([mock.Mock()])
-        get_ws_name_mock.called_once_with(mock.Mock())
+        get_ws_name_mock.assert_called_once_with(mock.Mock())
         self.view.get_workspace_index.assert_called_once_with('ws')
         self.view.set_workspace_selected.assert_called_once_with([0])
 

--- a/mslice/tests/workspacemanager_presenter_test.py
+++ b/mslice/tests/workspacemanager_presenter_test.py
@@ -267,7 +267,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_index = mock.Mock(return_value=0)
         get_ws_name_mock.return_value = 'ws'
         self.presenter.set_selected_workspaces([mock.Mock()])
-        get_ws_name_mock.assert_called_once_with(mock.Mock())
+        get_ws_name_mock.assert_called_once_with(None)
         self.view.get_workspace_index.assert_called_once_with('ws')
         self.view.set_workspace_selected.assert_called_once_with([0])
 


### PR DESCRIPTION
**Description of work:**

We are using the latest version of mock for the unit tests. Mock was upgraded from 5.0.0. to 5.0.1 recently and one of the changes was that calls to `called_once_with` now result in an AttributeError to enforce usage of `assert_called_once_with` instead. 

There are unrelated issues with the mantid and mantidqt nightly at the moment. That is the reason why the unit test workflow uses mantid and mantidqt 6.5.0 at the moment.

**To test:**

Check that the unit tests are running successfully.

