### PR TITLE
Add warning to gdos cut intensity correction

### DIFF
--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -4,6 +4,7 @@ from mslice.models.labels import is_momentum, is_twotheta
 from mslice.util.intensity_correction import IntensityType
 
 import numpy as np
+import warnings
 
 
 class Cut(object):
@@ -187,6 +188,8 @@ class Cut(object):
 
     @property
     def gdos(self):
+        warnings.warn("Please note that GDOS intensity correction with regards to cuts is not functioning as expected "
+                      "(Github Issue #843). This will be fixed imminently and made available in the next release/nightly. ")
         if self._gdos is None:
             self._gdos = cut_compute_gdos(self._cut_ws, self.sample_temp, self.q_axis, self.e_axis, self.rotated,
                                           self.norm_to_one, self.algorithm)


### PR DESCRIPTION
**Description of work:**

As GDOS intensity correction does not currently work correctly regarding cuts, a warning has been added when a user uses this feature.

<!-- Instructions for testing. --

1) Load an mslice dataset, plot slice
2) Use interactive cut to plot a cut
3) Change the intensity to GDOS via the slice
4) Observe warning emitted.
