### PR TITLE
Fix for segmentation fault in unit test workflows

### DIFF
--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -6,19 +6,19 @@ on:
 
 jobs:
   build_conda_and_upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   build_conda_and_upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: main
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Miniconda
         if: ${{ env.recentCommits == 'true'}}
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/online_doc_update.yml
+++ b/.github/workflows/online_doc_update.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Update dependencies

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,19 +4,19 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge
@@ -28,6 +28,7 @@ jobs:
       - name: Install Mantid
         run: |
           conda install -c mantid mantid=6.5.0 mantidqt=6.5.0
+          conda install -c conda-forge setuptools==47.0.0
 
       - name: Flake8
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install -c mantid mantid=6.5.0 mantidqt=6.5.0
+          conda install -c mantid/label/nightly mantid mantidqt
           conda install -c conda-forge setuptools==47.0.0
 
       - name: Flake8

--- a/.github/workflows/unit_tests_nighly.yml
+++ b/.github/workflows/unit_tests_nighly.yml
@@ -6,17 +6,17 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge
@@ -28,6 +28,7 @@ jobs:
       - name: Install Mantid
         run: |
           conda install -c mantid/label/nightly mantid mantidqt
+          conda install -c conda-forge setuptools==47.0.0
 
       - name: Flake8
         run: |

--- a/mslice/tests/plotselector_view_test.py
+++ b/mslice/tests/plotselector_view_test.py
@@ -10,13 +10,13 @@ from qtpy.QtTest import QTest
 import unittest
 
 from unittest import mock
-from mantidqt.utils.qt.testing import start_qapplication
+#from mantidqt.utils.qt.testing import start_qapplication
 from mslice.widgets.plotselector.column_info import Column
 from mslice.widgets.plotselector.view import EXPORT_TYPES, PlotSelectorView
 from mslice.widgets.plotselector.presenter import PlotSelectorPresenter
 
 
-@start_qapplication
+#@start_qapplication
 class PlotSelectorWidgetTest(unittest.TestCase):
 
     def setUp(self):

--- a/mslice/tests/plotselector_view_test.py
+++ b/mslice/tests/plotselector_view_test.py
@@ -10,13 +10,11 @@ from qtpy.QtTest import QTest
 import unittest
 
 from unittest import mock
-#from mantidqt.utils.qt.testing import start_qapplication
 from mslice.widgets.plotselector.column_info import Column
 from mslice.widgets.plotselector.view import EXPORT_TYPES, PlotSelectorView
 from mslice.widgets.plotselector.presenter import PlotSelectorPresenter
 
 
-#@start_qapplication
 class PlotSelectorWidgetTest(unittest.TestCase):
 
     def setUp(self):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def read_requirements_from_file(filepath):
     :param filepath: Path to the file to read
     :return: A list of strings containing the requirements
     '''
-    with open(filepath, 'rU') as req_file:
+    with open(filepath, 'r') as req_file:
         return req_file.readlines()
 
 def get_package_data():


### PR DESCRIPTION
**Description of work:**

Since the mantid/mantidqt upgrade to Qt 5.15 both MSlice unit test workflows failed with segmentation faults. After running the nosetests and coverage successfully the clean up
routine in mantidqt.utils.qt.testing tried to access a QApplication instance that was already closed. This was fixed by removing the start_qapplication decorator that is not 
required in MSlice tests as a QApplication instance is created separately for MSlice tests.

In addition, several components of the GitHub workflows have been upgraded:
- Ubuntu from 20.04 to latest
- actions/checkout from v2 to v3
- conda-incubator/setup-miniconda from v2.1.1 to v2.2.0

To remove deprecation warnings setuptools is now pinned to 47.0.0 and setup.py is now opening files with the 'r' flag instead of 'rU'.

**To test:**

Make sure that the unit tests are passing without a segmentation fault. 
