### PR TITLE
864 fix intensity change crash

### DIFF
--- a/mslice/models/intensity_correction_algs.py
+++ b/mslice/models/intensity_correction_algs.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 from six import string_types
 import numpy as np
-from functools import partial
 
 from scipy import constants
 

--- a/mslice/models/intensity_correction_algs.py
+++ b/mslice/models/intensity_correction_algs.py
@@ -72,7 +72,7 @@ def compute_symmetrised(scattering_data, sample_temp, e_axis, data_rotated):
     if data_rotated and scattering_data.is_PSD:
         transposed_signal = np.transpose(signal)
         signal_modification_array = generate_modification_array(boltzmann_dist, negative_de_len, transposed_signal)
-        symm_workspace = np.transpose(transposed_signal * signal_modification_array)
+        symm_workspace = scattering_data * np.transpose(signal_modification_array)
     else:
         signal_modification_array = generate_modification_array(boltzmann_dist, negative_de_len, signal)
         symm_workspace = scattering_data * signal_modification_array

--- a/mslice/tests/intensity_correction_algs_test.py
+++ b/mslice/tests/intensity_correction_algs_test.py
@@ -68,6 +68,14 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
         self.assertAlmostEqual(symmetrised[15][10], 0.532, 6)
         self.assertAlmostEqual(symmetrised[24][29], 1.5, 6)
 
+    def test_compute_symmetrised_rotated_psd(self):
+        self.test_ws.is_PSD = True
+        symmetrised = compute_symmetrised(self.test_ws, 10, self.e_axis, True).get_signal()
+        self.assertAlmostEqual(symmetrised[0][0], 0.002, 6)
+        self.assertAlmostEqual(symmetrised[15][10], 0.532, 6)
+        self.assertAlmostEqual(symmetrised[24][29], 1.5, 6)
+        self.test_ws.is_PSD = None  # reset workspace for other tests.
+
     def test_compute_gdos_slice(self):
         gdos = slice_compute_gdos(self.test_ws, 10, self.q_axis, self.e_axis, self.rotated).get_signal()
         self.assertAlmostEqual(gdos[0][0], 0.002318, 6)


### PR DESCRIPTION
**Description of work:**
Fix PR fixes a bug where a second symmetrised intensity correction performed (which only happens when you have an interactive cut open) would overwrite the underlying slice due to `CloneWorkspace`.

The algorithm has been rewritten to make use of mslice workspace specific binary operations, more inline with the other intensity correction algs.


**To test:**
1.  Follow instructions in issue.
2.  Test with PSD dataset 

<!-- Instructions for testing. -->

Fixes #864 
