### PR TITLE
Check 'Degrees' and '2Theta' for x dimension

### DIFF
--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -227,7 +227,8 @@ class Cut(object):
 
     def _update_cut_axis(self):
         x_dim = self._cut_ws.raw_ws.getXDimension()
-        if self.cut_axis.units == x_dim.getUnits() or self.cut_axis.units in x_dim.getDimensionId():
+        if self.cut_axis.units == x_dim.getUnits() or self.cut_axis.units in x_dim.getDimensionId()\
+                or is_twotheta(self.cut_axis.units) and is_twotheta(x_dim.getUnits()):
             ws_cut_axis = x_dim
         else:
             ws_cut_axis = self._cut_ws.raw_ws.getYDimension()

--- a/mslice/models/cut/cut.py
+++ b/mslice/models/cut/cut.py
@@ -1,6 +1,6 @@
 from mslice.models.intensity_correction_algs import (compute_chi, compute_d2sigma,
                                                      compute_symmetrised, cut_compute_gdos)
-from mslice.models.labels import is_momentum, is_twotheta
+from mslice.models.labels import are_units_equivalent, is_momentum, is_twotheta
 from mslice.util.intensity_correction import IntensityType
 
 import numpy as np
@@ -227,8 +227,7 @@ class Cut(object):
 
     def _update_cut_axis(self):
         x_dim = self._cut_ws.raw_ws.getXDimension()
-        if self.cut_axis.units == x_dim.getUnits() or self.cut_axis.units in x_dim.getDimensionId()\
-                or is_twotheta(self.cut_axis.units) and is_twotheta(x_dim.getUnits()):
+        if are_units_equivalent(self.cut_axis.units, x_dim.getUnits()) or self.cut_axis.units in x_dim.getDimensionId():
             ws_cut_axis = x_dim
         else:
             ws_cut_axis = self._cut_ws.raw_ws.getYDimension()

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -23,6 +23,21 @@ def is_momentum(unit):
     return any([unit in val for val in MOMENTUM_UNITS])
 
 
+def is_engergy(unit):
+    return unit == 'DeltaE'
+
+
+def are_units_equivalent(unit_lhs, unit_rhs):
+    if is_twotheta(unit_lhs) and is_twotheta(unit_rhs):
+        return True
+    elif is_momentum(unit_lhs) and is_momentum(unit_rhs):
+        return True
+    elif is_engergy(unit_lhs) and is_engergy(unit_rhs):
+        return True
+    else:
+        return False
+
+
 def get_recoil_key(label):
     for key, value in recoil_labels.items():
         if value == label:

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -23,7 +23,7 @@ def is_momentum(unit):
     return any([unit in val for val in MOMENTUM_UNITS])
 
 
-def is_engergy(unit):
+def is_energy(unit):
     return unit == 'DeltaE'
 
 
@@ -32,7 +32,7 @@ def are_units_equivalent(unit_lhs, unit_rhs):
         return True
     elif is_momentum(unit_lhs) and is_momentum(unit_rhs):
         return True
-    elif is_engergy(unit_lhs) and is_engergy(unit_rhs):
+    elif is_energy(unit_lhs) and is_energy(unit_rhs):
         return True
     else:
         return False


### PR DESCRIPTION
**Description of work:**

When updating the cut axis for an interactive cut plot along 2Theta the comparison of units failed as `2Theta` was compared with `Degrees`. This can be avoided by using the `is_twotheta` method for both units as they are then seen as equal.

This fixes both issues regarding cut plots along 2Theta.

**To test:**

Follow instructions for both original issues. There should be no exception anymore but an interactive cut plot displayed for #859 and no error message for a cut plot via the cut tab for #860.

Fixes #859 
Fixes #860 
