### PR TITLE
Merge release-next into main for release

### DIFF
--- a/mslice/__init__.py
+++ b/mslice/__init__.py
@@ -6,6 +6,6 @@ A PyQt-based version of the MSlice (http://mslice.isis.rl.ac.uk) program based
 on Mantid (http://www.mantidproject.org).
 """
 
-version_info = (2, 5, 0)
+version_info = (2, 6, 0)
 __version__ = '.'.join(map(str, version_info))
 __project_url__ = 'https://github.com/mantidproject/mslice'

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -24,7 +24,7 @@ def is_momentum(unit):
 
 
 def is_energy(unit):
-    return unit == DELTA_E_LABEL 
+    return unit == DELTA_E_LABEL
 
 
 def are_units_equivalent(unit_lhs, unit_rhs):

--- a/mslice/models/labels.py
+++ b/mslice/models/labels.py
@@ -24,7 +24,7 @@ def is_momentum(unit):
 
 
 def is_energy(unit):
-    return unit == 'DeltaE'
+    return unit == DELTA_E_LABEL 
 
 
 def are_units_equivalent(unit_lhs, unit_rhs):


### PR DESCRIPTION
Since Mantid is released now MSlice release-next needs to be merged into main with the new version number 2.6.0. 