### PR TITLE
Moved flake8 step before step with Mantid installation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,14 +25,14 @@ jobs:
           python-version: 3.8
           auto-activate-base: false
 
+      - name: Flake8
+        run: |
+          python -m flake8
+
       - name: Install Mantid
         run: |
           conda install -c mantid/label/nightly mantid mantidqt
           conda install -c conda-forge setuptools==47.0.0
-
-      - name: Flake8
-        run: |
-          python -m flake8
 
       - name: Nosetests
         run: |

--- a/.github/workflows/unit_tests_nightly.yml
+++ b/.github/workflows/unit_tests_nightly.yml
@@ -25,14 +25,14 @@ jobs:
           python-version: 3.8
           auto-activate-base: false
 
+      - name: Flake8
+        run: |
+          python -m flake8
+
       - name: Install Mantid
         run: |
           conda install -c mantid/label/nightly mantid mantidqt
           conda install -c conda-forge setuptools==47.0.0
-
-      - name: Flake8
-        run: |
-          python -m flake8
 
       - name: Nosetests
         run: |


### PR DESCRIPTION
In both GitHub workflows running unit tests the step running flake8 has been moved before the step installing Mantid to reduce the waiting time in case of formatting errors as the Mantid installation takes much longer than the flake8 check.
