### PR TITLE
Fix IndexError caused by saving a slice as a matlab file

### DIFF
--- a/mslice/models/workspacemanager/file_io.py
+++ b/mslice/models/workspacemanager/file_io.py
@@ -86,6 +86,7 @@ def save_matlab(workspace, path, is_slice):
             x = []
             for dim in [workspace.raw_ws.getDimension(i) for i in range(2)]:
                 x.append(np.linspace(dim.getMinimum(), dim.getMaximum(), dim.getNBins()))
+            x = np.array(x, dtype=object)
             # We're saving a 2D RebinnedWorkspace which always has DeltaE along x
             ix = [i for i, ax in enumerate(workspace.axes) if 'DeltaE' in ax.units][0]
             iy = 0 if ix == 1 else 1

--- a/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/mslice/models/workspacemanager/workspace_algorithms.py
@@ -377,15 +377,11 @@ def _get_exp_info_using(raw_ws, get_exp_info):
 
 def propagate_properties(old_workspace, new_workspace):
     """Propagates MSlice only properties of workspaces, e.g. limits"""
-    new_workspace.is_PSD = old_workspace.is_PSD
-    new_workspace.parent = old_workspace.parent
-    new_workspace.intensity_corrected = old_workspace.intensity_corrected
-    new_workspace.axes = old_workspace.axes
-    new_workspace.ef_defined = old_workspace.ef_defined
-    new_workspace.e_mode = old_workspace.e_mode
-    new_workspace.limits = old_workspace.limits
-    new_workspace.e_fixed = old_workspace.e_fixed
-
+    properties = ['is_PSD', 'parent', 'intensity_corrected', 'axes', 'ef_defined', 'e_mode', 'limits', 'e_fixed']
+    for prop in properties:
+        old_prop = getattr(old_workspace, prop)
+        if old_prop:
+            setattr(new_workspace, prop, old_prop)
 
 
 def get_comment(workspace):


### PR DESCRIPTION
**Description of work:**

**To test:**

Follow instructions in https://github.com/mantidproject/mslice/issues/830.

This PR ensures that properties of a workspace are only propagated if they are not `None`.

Fixes #830
