### PR TITLE
Check that the sample log provided is valid before plotting

### DIFF
--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -332,7 +332,6 @@ class SlicePlot(IPlot):
 
     def _run_temp_dependent(self, slice_plotter_method, previous):
         temp_value_raw = None
-        temp_value = None
         try:
             slice_plotter_method(self.ws_name)
         except ValueError:  # sample temperature not yet set
@@ -345,21 +344,17 @@ class SlicePlot(IPlot):
                 self._slice_plotter_presenter.add_sample_temperature_field(temp_value_raw)
                 self.temp = self._slice_plotter_presenter.update_sample_temperature_from_field(self.ws_name)
             else:
-                temp_value = get_sample_temperature_from_string(temp_value_raw)
-                if temp_value is not None:
-                    try:
-                        temp_value = float(temp_value)
-                    except ValueError:
-                        temp_value = None
-                if temp_value is None or temp_value < 0:
-                    self.plot_window.display_error("Invalid value entered for sample temperature. Enter a value in Kelvin \
-                                               or a sample log field.")
-                    self.set_intensity(previous)
-                    return False
-                else:
-                    self.default_options['temp'] = temp_value
-                    self.temp = temp_value
-                    self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
+                try:
+                    self.temp = float(get_sample_temperature_from_string(temp_value_raw))
+                except ValueError:
+                    self.temp = None
+                self.default_options['temp'] = self.temp
+                self._slice_plotter_presenter.set_sample_temperature(self.ws_name, self.temp)
+            if self.temp is None or self.temp < 0:
+                self.plot_window.display_error("Invalid value or sample log entered for sample temperature. "
+                                               "Enter a value in Kelvin or a valid sample log field.")
+                self.set_intensity(previous)
+                return False
             slice_plotter_method(self.ws_name)
         return True
 


### PR DESCRIPTION
**Description of work:**
This PR fixes an unhandled exception caused when selecting an invalid sample log for the sample temperature. The solution is to check that the sample log returns a valid temperature before attempting to continue with plotting. If it is not valid, and error message is displayed.

**To test:**
Follow the testing instructions in the issue. There should be no exception, but instead a message displayed.

Fixes #809
