### PR TITLE
Refactor run temp dependant function

### DIFF
--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -23,6 +23,8 @@ from mslice.util.compat import legend_set_draggable
 from mslice.util.intensity_correction import IntensityType, IntensityCache
 from mslice.models.intensity_correction_algs import sample_temperature
 
+from typing import Callable
+
 DEFAULT_LABEL_SIZE = 10
 DEFAULT_TITLE_SIZE = 12
 
@@ -331,7 +333,7 @@ class SlicePlot(IPlot):
         self._update_lines()
         self._canvas.draw()
 
-    def _run_temp_dependent(self, slice_plotter_method, previous):
+    def _run_temp_dependent(self, slice_plotter_method: Callable, previous: QtWidgets.QAction) -> bool:
         try:
             slice_plotter_method(self.ws_name)
         except ValueError:  # sample temperature not yet set, get it and reattempt method
@@ -341,7 +343,7 @@ class SlicePlot(IPlot):
                 return False
         return True
 
-    def _set_sample_temperature(self, previous):
+    def _set_sample_temperature(self, previous: QtWidgets.QAction) -> bool:
         try:
             temp_value_raw, field = self.ask_sample_temperature_field(str(self.ws_name))
             temperature_found = self._handle_temperature_input(temp_value_raw, field)
@@ -351,7 +353,7 @@ class SlicePlot(IPlot):
             self.set_intensity(previous)
         return temperature_found
 
-    def _handle_temperature_input(self, temp_value_raw, field):
+    def _handle_temperature_input(self, temp_value_raw: str, field: bool) -> bool:
         if field:
             temp_value = sample_temperature(self.ws_name, [temp_value_raw])
         else:
@@ -361,13 +363,13 @@ class SlicePlot(IPlot):
             self.plot_window.display_error("Invalid value entered for sample temperature. Enter a value in Kelvin \
                                             or a sample log field.")
             return False
-        else:
-            self.default_options['temp'] = temp_value
-            self.temp = temp_value
-            self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
-            return True
 
-    def ask_sample_temperature_field(self, ws_name):
+        self.default_options['temp'] = temp_value
+        self.temp = temp_value
+        self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
+        return True
+
+    def ask_sample_temperature_field(self, ws_name: str) -> str:
         text = 'Sample temperature not found. Select the sample temperature field or enter a value in Kelvin:'
         ws = get_workspace_handle(ws_name)
         try:

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -37,9 +37,8 @@ class SlicePlotterPresenterTest(unittest.TestCase):
     @mock.patch('mslice.presenters.slice_plotter_presenter.plot_cached_slice')
     @mock.patch('mslice.presenters.slice_plotter_presenter.create_slice_figure')
     @mock.patch('mslice.presenters.slice_plotter_presenter.get_workspace_handle')
-    @mock.patch('mslice.presenters.slice_plotter_presenter.sample_temperature')
     @mock.patch('mslice.presenters.slice_plotter_presenter.compute_slice')
-    def test_plot_slice_success(self, compute_slice_mock, sample_temp_mock, get_workspace_handle_mock,
+    def test_plot_slice_success(self, compute_slice_mock, get_workspace_handle_mock,
                                 create_slice_mock, plot_cached_slice_mock):
         workspace_mock = mock.MagicMock()
         name = mock.PropertyMock(return_value='workspace')
@@ -48,7 +47,6 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         slice_name = mock.PropertyMock(return_value='__workspace')
         type(slice_mock).name = slice_name
         get_workspace_handle_mock.return_value = workspace_mock
-        sample_temp_mock.return_value = 5
         compute_slice_mock.return_value = slice_mock
         x_axis = Axis('x', 0, 1, 0.1)
         y_axis = Axis('y', 0, 1, 0.1)


### PR DESCRIPTION
**Description of work:**

Refactors a large function that was getting hard to work with.

Also, I've removed the caching of sample log fields on the `slice_plotter_presenter`. This used to mean that you only had to select a sample log for temperature once, then it would be used for all other subsequent slices. I accidently bypassed this functionality a while ago when adding intensity change for cuts, taking the view that the temperature should be specified for every new dataset introduced.

If users take issue with this, I can reimplement.

**To test:**

<!-- Instructions for testing. -->
