### PR TITLE
Subscribe MSlice algorithms to AlgorithmFactory before running tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Run the Mantid initialization module to ensure MSlice algorithms are subscribed to the AlgorithmFactory
+import mslice.util.mantid.init_mantid # noqa: F401

--- a/tests/rebose_algorithm_test.py
+++ b/tests/rebose_algorithm_test.py
@@ -1,7 +1,5 @@
 import unittest
 
-import mslice.util.mantid.init_mantid # noqa: F401
-
 from mantid.api import AnalysisDataService
 from tests.testhelpers.workspace_creator import create_workspace
 from mslice.util.mantid.mantid_algorithms import Rebose


### PR DESCRIPTION
**Description of work:**
This PR ensures that the Mslice algorithms such as `Rebose` get subscribed to the Mantid `AlgorithmFactory` before the tests are run using nosetest. This prevents the following error occuring when attempting to run a test using nosetest:

```
FAILED (errors=1)

Error
Traceback (most recent call last):
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\unittest\case.py", line 60, in testPartExecutor
    yield
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\unittest\case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\unittest\case.py", line 633, in _callTestMethod
    method()
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\site-packages\nose\failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\site-packages\nose\loader.py", line 416, in loadTestsFromName
    module = self.importer.importFromPath(
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\site-packages\nose\importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\site-packages\nose\importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "C:\Users\mlc47243\AppData\Local\mambaforge\envs\mantidnightly\lib\imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 702, in _load
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "C:\Users\mlc47243\Documents\mantid-dev\mslice\tests\rebose_algorithm_test.py", line 5, in <module>
    from mslice.util.mantid.mantid_algorithms import Rebose
Exception: cannot import name 'Rebose' from 'mslice.util.mantid.mantid_algorithms' (C:\Users\mlc47243\Documents\mantid-dev\mslice\src\mslice\util\mantid\mantid_algorithms.py)
-------------------- >> begin captured logging << --------------------
matplotlib: DEBUG: CACHEDIR=C:\Users\mlc47243\.matplotlib
matplotlib.font_manager: DEBUG: Using fontManager instance from C:\Users\mlc47243\.matplotlib\fontlist-v330.json
h5py._conv: DEBUG: Creating converter from 7 to 5
h5py._conv: DEBUG: Creating converter from 5 to 7
h5py._conv: DEBUG: Creating converter from 7 to 5
h5py._conv: DEBUG: Creating converter from 5 to 7
--------------------- >> end captured logging << ---------------------
```

**To test:**
1. Configure nosetest inside of pycharm to look like the following:
![image](https://user-images.githubusercontent.com/40830825/223704264-7bbf5be2-7cf4-4782-af0f-30c998997a9c.png)


2. Run the test and make sure the test is successful and does not fail

