### PR TITLE
Replace conda install with mamba install

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,7 +24,7 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       conda create -n build-env python=3.8
       conda activate build-env
-      conda install -c conda-forge mamba conda-build anaconda-client conda-verify
+      mamba install -c conda-forge mamba conda-build anaconda-client conda-verify
       conda config --add channels mantid
       conda config --add channels mantid/label/nightly
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install -c mantid/label/nightly mantid mantidqt
-          conda install -c conda-forge setuptools==47.0.0
+          mamba install -c mantid/label/nightly mantid mantidqt
 
       - name: Nosetests
         run: |

--- a/.github/workflows/unit_tests_nightly.yml
+++ b/.github/workflows/unit_tests_nightly.yml
@@ -31,8 +31,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          conda install -c mantid/label/nightly mantid mantidqt
-          conda install -c conda-forge setuptools==47.0.0
+          mamba install -c mantid/label/nightly mantid mantidqt
 
       - name: Nosetests
         run: |


### PR DESCRIPTION
**Description of work:**

To speed up the unit test workflows and the deploy action `conda install` was replaced with `mamba install`. Also, with the new packaging is it not necessary anymore to install setuptools in the conda environment for tests.

**To test:**

Check that unit test are running successfully.
