### PR TITLE
Pre commit use `autofix_prs` option

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,10 +25,6 @@ jobs:
           python-version: 3.8
           auto-activate-base: false
 
-      - name: Flake8
-        run: |
-          python -m flake8
-
       - name: Install Mantid
         run: |
           mamba install -c mantid/label/nightly mantid mantidqt

--- a/.github/workflows/unit_tests_nightly.yml
+++ b/.github/workflows/unit_tests_nightly.yml
@@ -25,10 +25,6 @@ jobs:
           python-version: 3.8
           auto-activate-base: false
 
-      - name: Flake8
-        run: |
-          python -m flake8
-
       - name: Install Mantid
         run: |
           mamba install -c mantid/label/nightly mantid mantidqt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 default_language_version:
   python: python3
 
+ci:
+  autofix_prs: true
+
 repos:
 
   # Run fast code improvement/checks before running PR specific helpers.


### PR DESCRIPTION
**Description of work:**
This PR adds the `autofix_prs` option to our pre-commit setup. This allows us to remove `flake8` from our other unit test workflows as the `autofix_prs` option makes sure pre-commit is run, and commits any fixes it makes.

**To do**
- [ ] Add instruction to install `pre-commit` locally (optionally but would be good practise)

**To test:**

