### PR TITLE
Install pre commit for a developer environment

### DIFF
--- a/mslice-developer.yml
+++ b/mslice-developer.yml
@@ -10,4 +10,5 @@ dependencies:
   - qtconsole
   - coverage
   - mock
+  - pre-commit
   - pytest


### PR DESCRIPTION
**Description of work:**
Ensures that the pre commit package is installed within the developer environment. This means the only manual setup you have to do to activate pre-commit is to do
```sh
pre-commit install
```

**To test:**
Code review