### PR TITLE
Set y lims using intensity range

### DIFF
--- a/src/mslice/cli/plotfunctions.py
+++ b/src/mslice/cli/plotfunctions.py
@@ -36,9 +36,9 @@ def errorbar(axes, workspace, *args, **kwargs):
     presenter = get_cut_plotter_presenter()
 
     plot_over = kwargs.pop('plot_over', True)
-    intensity_range = kwargs.pop('intensity_range', (None, None))
-    intensity_range = intensity_range if intensity_range else (None, None)
-    intensity_min, intensity_max = intensity_range
+    intensity_min, intensity_max = kwargs.pop('intensity_range', (None, None))
+    intensity_min = intensity_min if intensity_min and intensity_min != '' else None
+    intensity_max = intensity_max if intensity_max and intensity_max != '' else None
     label = kwargs.pop('label', None)
     label = workspace.name if label is None else label
     en_conversion_allowed = kwargs.pop('en_conversion', True)
@@ -62,6 +62,9 @@ def errorbar(axes, workspace, *args, **kwargs):
     axesfunctions.errorbar(axes, workspace.raw_ws, label=label, *args, **kwargs)
 
     axes.autoscale()
+    if intensity_min is not None or intensity_max is not None:
+        axes.set_ylim(intensity_min, intensity_max)
+
     if cur_canvas.manager.window.action_toggle_legends.isChecked():
         leg = axes.legend(fontsize='medium')
         legend_set_draggable(leg, True)

--- a/tests/command_line_test.py
+++ b/tests/command_line_test.py
@@ -247,12 +247,28 @@ class CommandLineTest(unittest.TestCase):
         ax.lines = mock.Mock
 
         errorbar(ax, cut, plot_over=False)
+        ax.autoscale.assert_called_once_with()
         mantid_errorbar.assert_called_once_with(ax, cut.raw_ws, label=cut.name)
 
         with mock.patch('mslice.app.presenters.get_cut_plotter_presenter') as get_cpp:
             get_cpp().get_cache().__getitem__().cut_axis.units = '|Q|'
             errorbar(ax, cut, plot_over=True)
             get_cpp().get_cache.assert_called()
+
+    @mock.patch('mantid.plots.axesfunctions.errorbar')
+    @mock.patch('mslice.cli._mslice_commands.is_gui')
+    def test_errorbar_command_with_intensity(self, is_gui, mantid_errorbar):
+        is_gui.return_value = True
+        workspace = self.create_workspace('test_plot_cut_non_psd_cli')
+        cut = Cut(workspace)
+        ax = mock.Mock(spec=Axes)
+        ax.get_ylim.return_value = (0., 1.)
+        ax.lines = mock.Mock
+
+        errorbar(ax, cut, plot_over=False, intensity_range=('1.1', '1.5'))
+        ax.autoscale.assert_called_once_with()
+        ax.set_ylim.assert_called_once_with('1.1', '1.5')
+        mantid_errorbar.assert_called_once_with(ax, cut.raw_ws, label=cut.name)
 
     @mock.patch('mslice.cli._mslice_commands.GlobalFigureManager')
     def test_that_keep_figure_works_for_last_figure_number(self, gfm):


### PR DESCRIPTION
**Description of work:**
This PR ensures the ylims of a cut plot gets set when an intensity range is provided.

**To test:**
Follow the instructions in the attached issue

Fixes #861
