### PR TITLE
Add warning for small step Cut Plots

### DIFF
--- a/src/mslice/app/mainwindow.py
+++ b/src/mslice/app/mainwindow.py
@@ -20,10 +20,13 @@ TAB_SLICE = 1
 TAB_CUT = 2
 TAB_POWDER = 0
 
+ERROR_STATUS_STYLESHEET = "color: red;"
+WARNING_STATUS_STYLESHEET = "color: orange;"
 
 # ==============================================================================
 # Classes
 # ==============================================================================
+
 
 class MainWindow(MainView, QMainWindow):
 
@@ -85,6 +88,8 @@ class MainWindow(MainView, QMainWindow):
         self.btnSaveToADS.clicked.connect(self.button_savetoads)
         self.btnCompose.clicked.connect(self.button_compose)
         self.ws_tab_changed(0)
+
+        self.wgtCut.warning_occurred.connect(self.show_warning)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
@@ -207,8 +212,14 @@ class MainWindow(MainView, QMainWindow):
         self.splitter.addWidget(ipython)
         self.splitter.setSizes([500, 250])
 
+    def show_warning(self, msg):
+        """Show a warning message on status bar. If msg ==""  the function will clear the displayed message """
+        self.statusbar.setStyleSheet(WARNING_STATUS_STYLESHEET)
+        self.statusbar.showMessage(msg)
+
     def show_error(self, msg):
         """Show an error message on status bar. If msg ==""  the function will clear the displayed message """
+        self.statusbar.setStyleSheet(ERROR_STATUS_STYLESHEET)
         self.statusbar.showMessage(msg)
 
     def get_presenter(self):

--- a/src/mslice/app/mainwindow.ui
+++ b/src/mslice/app/mainwindow.ui
@@ -389,9 +389,6 @@
      <bold>true</bold>
     </font>
    </property>
-   <property name="styleSheet">
-    <string notr="true">color: red</string>
-   </property>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">

--- a/src/mslice/cli/helperfunctions.py
+++ b/src/mslice/cli/helperfunctions.py
@@ -80,8 +80,8 @@ def _process_axis(axis, fallback_index, input_workspace, string_function=_string
             return axis
         x_step = get_axis_range(input_workspace, axis.units)[-1]
         if axis.step < x_step:
-            logging.warning(f"The {axis.units} step provided ({axis.step}) is smaller than the data step in "
-                            f"the workspace ({x_step}). Please provide a larger {axis.units} step.")
+            logging.warning(f"The {axis.units} step provided ({axis.step:.4f}) is smaller than the data step in "
+                            f"the workspace ({x_step:.4f}). Please provide a larger {axis.units} step.")
     elif axis in available_axes:
         range = get_axis_range(input_workspace, axis)
         range = list(map(float, range))

--- a/src/mslice/cli/helperfunctions.py
+++ b/src/mslice/cli/helperfunctions.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.base import WorkspaceBase as Workspace
@@ -75,6 +76,12 @@ def _process_axis(axis, fallback_index, input_workspace, string_function=_string
     # check to see if axis is just a name e.g 'DeltaE' or a full binning spec e.g. 'DeltaE,0,1,100'
     if ',' in axis:
         axis = string_function(axis)
+        if fallback_index != 0:
+            return axis
+        x_step = get_axis_range(input_workspace, axis.units)[-1]
+        if axis.step < x_step:
+            logging.warning(f"The {axis.units} step provided ({axis.step}) is smaller than the data step in "
+                            f"the workspace ({x_step}). Please provide a larger {axis.units} step.")
     elif axis in available_axes:
         range = get_axis_range(input_workspace, axis)
         range = list(map(float, range))

--- a/src/mslice/cli/helperfunctions.py
+++ b/src/mslice/cli/helperfunctions.py
@@ -4,7 +4,7 @@ import logging
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.base import WorkspaceBase as Workspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
-from mslice.models.alg_workspace_ops import get_axis_range, get_available_axes
+from mslice.models.alg_workspace_ops import get_axis_range, get_axis_step, get_available_axes
 from mslice.models.axis import Axis
 from mslice.models.workspacemanager.workspace_provider import workspace_exists
 from mslice.models.intensity_correction_algs import (compute_chi, compute_d2sigma,
@@ -78,7 +78,7 @@ def _process_axis(axis, fallback_index, input_workspace, string_function=_string
         axis = string_function(axis)
         if fallback_index != 0:
             return axis
-        x_step = get_axis_range(input_workspace, axis.units)[-1]
+        x_step = get_axis_step(input_workspace, axis.units)
         if axis.step < x_step:
             logging.warning(f"The {axis.units} step provided ({axis.step:.4f}) is smaller than the data step in "
                             f"the workspace ({x_step:.4f}). Please provide a larger {axis.units} step.")

--- a/src/mslice/models/alg_workspace_ops.py
+++ b/src/mslice/models/alg_workspace_ops.py
@@ -20,6 +20,12 @@ def get_axis_range(workspace, dimension_name):
     return tuple(workspace.limits[dimension_name])
 
 
+def get_axis_step(workspace, dimension_name: str) -> float:
+    axis_range = get_axis_range(workspace, dimension_name)
+    assert len(axis_range) == 3  # Assert that the axis_range tuple is the length we expect
+    return axis_range[2]
+
+
 def fill_in_missing_input(axis, workspace):
     dim = workspace.getDimensionIndexByName(axis.units)
     dim = workspace.getDimension(dim)

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists, get_current_plot
-from mslice.models.alg_workspace_ops import get_axis_range
+from mslice.models.alg_workspace_ops import get_axis_step
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.labels import generate_legend
 from mslice.models.workspacemanager.workspace_algorithms import export_workspace_to_ads
@@ -95,7 +95,7 @@ class CutPlotterPresenter(PresenterUtility):
 
         cut_axis = cut.cut_axis
 
-        x_step = get_axis_range(workspace, cut_axis.units)[-1]
+        x_step = get_axis_step(workspace, cut_axis.units)
         if cut_axis.step < x_step:
             return f"The {cut_axis.units} step provided ({cut_axis.step:.4f}) is smaller than the data step in " \
                    f"the workspace ({x_step:.4f}). Please provide a larger {cut_axis.units} step."

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists, get_current_plot
+from mslice.models.alg_workspace_ops import get_axis_range
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.labels import generate_legend
 from mslice.models.workspacemanager.workspace_algorithms import export_workspace_to_ads
@@ -38,7 +39,7 @@ class CutPlotterPresenter(PresenterUtility):
             self.save_cut_to_workspace(workspace, cut)
             return
         if cut.width is not None:
-            self._plot_with_width(workspace, cut, plot_over)
+            return self._plot_with_width(workspace, cut, plot_over)
         else:
             self._plot_cut(workspace, cut, plot_over)
 
@@ -91,6 +92,13 @@ class CutPlotterPresenter(PresenterUtility):
             # The first plot will respect which button the user pressed. The rest will over plot
             plot_over = True
         cut.reset_integration_axis(cut.start, cut.end)
+
+        cut_axis = cut.cut_axis
+
+        x_step = get_axis_range(workspace, cut_axis.units)[-1]
+        if cut_axis.step < x_step:
+            return f"The {cut_axis.units} step provided ({cut_axis.step:.4f}) is smaller than the data step in " \
+                   f"the workspace ({x_step:.4f}). Please provide a larger {cut_axis.units} step."
 
     def save_cache(self, ax, cut, plot_over=False):
         # If plot over is True you want to save all plotted cuts for use by the cli

--- a/src/mslice/presenters/cut_widget_presenter.py
+++ b/src/mslice/presenters/cut_widget_presenter.py
@@ -63,7 +63,9 @@ class CutWidgetPresenter(PresenterUtility):
                 workspace = get_workspace_handle(workspace)
                 cut = Cut(*(params + (None, workspace.e_fixed)))  # add non-parsed cut params
                 cut.parent_ws_name = workspace.name
-                self._cut_plotter_presenter.run_cut(workspace, cut, plot_over=plot_over, save_only=save_only)
+                message = self._cut_plotter_presenter.run_cut(workspace, cut, plot_over=plot_over, save_only=save_only)
+                if message is not None:
+                    self._cut_view.display_warning(message)
             except RuntimeError as e:
                 self._cut_view.display_error(str(e))
             plot_over = True  # The first plot will respect which button the user pressed. The rest will over plot

--- a/src/mslice/views/interfaces/cut_view.py
+++ b/src/mslice/views/interfaces/cut_view.py
@@ -68,6 +68,9 @@ class CutView:
     def set_energy_units_default(self, unit):
         pass
 
+    def display_warning(self, string):
+        pass
+
     def display_error(self, string):
         pass
 

--- a/src/mslice/widgets/cut/cut.py
+++ b/src/mslice/widgets/cut/cut.py
@@ -24,6 +24,7 @@ from .command import Command
 # -----------------------------------------------------------------------------
 
 class CutWidget(CutView, QWidget):
+    warning_occurred = Signal('QString')
     error_occurred = Signal('QString')
     busy = Signal(bool)
     _name_to_index = {'Rebin': 0, 'Integration': 1}
@@ -90,6 +91,9 @@ class CutWidget(CutView, QWidget):
                 self.populate_integration_params(int_start, int_end)
                 self.lneCutIntegrationWidth.setText(int_width)
         self._en = EnergyUnits(new_unit)
+
+    def display_warning(self, warning_string):
+        self.warning_occurred.emit(warning_string)
 
     def display_error(self, error_string):
         self.error_occurred.emit(error_string)

--- a/tests/cli_helper_functions_test.py
+++ b/tests/cli_helper_functions_test.py
@@ -135,7 +135,7 @@ class CLIHelperFunctionsTest(unittest.TestCase):
         with self._caplog.at_level(logging.WARNING):
             return_value = _process_axis(axis, fallback_index, workspace)
             self.assertEqual(return_value, Axis(units='DeltaE', start=-0.5, end=0.5, step=0.01))
-        self.assertEqual("The DeltaE step provided (0.01) is smaller than the data step in the workspace (1). "
+        self.assertEqual("The DeltaE step provided (0.0100) is smaller than the data step in the workspace (1.0000). "
                          "Please provide a larger DeltaE step.", self._caplog.records[0].message)
 
     def test_that_process_axis_does_not_log_a_warning_for_an_axis_index_of_one(self):

--- a/tests/cut_plotter_presenter_test.py
+++ b/tests/cut_plotter_presenter_test.py
@@ -108,12 +108,14 @@ class CutPlotterPresenterTest(unittest.TestCase):
         self.assertEqual(1 * len(intensity_correction_types), update_main_window_mock.call_count)
         self.assertEqual(2, compute_chi_mock.call_count)
 
+    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_range')
     @mock.patch('mslice.presenters.cut_plotter_presenter.get_workspace_handle')
     @mock.patch('mslice.presenters.cut_plotter_presenter.CutPlotterPresenter._plot_cut')
-    def test_multiple_cuts_with_width(self, plot_cut_mock, get_ws_handle_mock):
+    def test_multiple_cuts_with_width(self, plot_cut_mock, get_ws_handle_mock, get_axis_range_mock):
         mock_ws = mock.MagicMock()
         mock_ws.name = 'workspace'
         get_ws_handle_mock.return_value = mock_ws
+        get_axis_range_mock.return_value = [-5, 5, 0.05]
         cut_cache = self.create_cut_cache()
         cut_cache.width = '25'
 
@@ -299,3 +301,37 @@ class CutPlotterPresenterTest(unittest.TestCase):
         cut_2_call = mock.call(cut_2._cut_ws, cut_2, plot_over=True, intensity_correction='dynamical_susceptibility')
         cut_3_call = mock.call(cut_3._cut_ws, cut_3, plot_over=True, intensity_correction='dynamical_susceptibility')
         mock_plot_cut.assert_has_calls([cut_1_call, cut_2_call, cut_3_call])
+
+    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_range')
+    @mock.patch('mslice.presenters.cut_plotter_presenter.CutPlotterPresenter._plot_cut')
+    def test_plot_with_width_returns_none_if_the_cut_width_is_larger_than_the_data_x_width(self, mock_plot_cut,
+                                                                                           mock_get_axis_range):
+        mock_ws = mock.MagicMock()
+        mock_get_axis_range.return_value = [-10, 10, 0.05]
+        mock_cut = mock.MagicMock()
+        mock_cut.cut_axis.units = 'DeltaE'
+        mock_cut.cut_axis.step = 0.05
+        mock_cut.integration_axis.start = 0.2
+        mock_cut.integration_axis.end = 0.3
+        mock_cut.width = 0.01
+
+        self.assertEqual(None, self.cut_plotter_presenter._plot_with_width(mock_ws, mock_cut, False))
+        mock_plot_cut.assert_called()
+
+    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_range')
+    @mock.patch('mslice.presenters.cut_plotter_presenter.CutPlotterPresenter._plot_cut')
+    def test_plot_with_width_returns_a_warning_if_the_cut_width_is_smaller_than_the_data_x_width(self, mock_plot_cut,
+                                                                                                 mock_get_axis_range):
+        mock_ws = mock.MagicMock()
+        mock_get_axis_range.return_value = [-10, 10, 0.05]
+        mock_cut = mock.MagicMock()
+        mock_cut.cut_axis.units = 'DeltaE'
+        mock_cut.cut_axis.step = 0.04  # Smaller cut step than the x axis data
+        mock_cut.integration_axis.start = 0.2
+        mock_cut.integration_axis.end = 0.3
+        mock_cut.width = 0.01
+
+        self.assertEqual("The DeltaE step provided (0.0400) is smaller than the data step in the workspace (0.0500). "
+                         "Please provide a larger DeltaE step.",
+                         self.cut_plotter_presenter._plot_with_width(mock_ws, mock_cut, False))
+        mock_plot_cut.assert_called()

--- a/tests/cut_plotter_presenter_test.py
+++ b/tests/cut_plotter_presenter_test.py
@@ -108,14 +108,14 @@ class CutPlotterPresenterTest(unittest.TestCase):
         self.assertEqual(1 * len(intensity_correction_types), update_main_window_mock.call_count)
         self.assertEqual(2, compute_chi_mock.call_count)
 
-    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_range')
+    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_step')
     @mock.patch('mslice.presenters.cut_plotter_presenter.get_workspace_handle')
     @mock.patch('mslice.presenters.cut_plotter_presenter.CutPlotterPresenter._plot_cut')
-    def test_multiple_cuts_with_width(self, plot_cut_mock, get_ws_handle_mock, get_axis_range_mock):
+    def test_multiple_cuts_with_width(self, plot_cut_mock, get_ws_handle_mock, get_axis_step_mock):
         mock_ws = mock.MagicMock()
         mock_ws.name = 'workspace'
         get_ws_handle_mock.return_value = mock_ws
-        get_axis_range_mock.return_value = [-5, 5, 0.05]
+        get_axis_step_mock.return_value = 0.05
         cut_cache = self.create_cut_cache()
         cut_cache.width = '25'
 
@@ -302,12 +302,12 @@ class CutPlotterPresenterTest(unittest.TestCase):
         cut_3_call = mock.call(cut_3._cut_ws, cut_3, plot_over=True, intensity_correction='dynamical_susceptibility')
         mock_plot_cut.assert_has_calls([cut_1_call, cut_2_call, cut_3_call])
 
-    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_range')
+    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_step')
     @mock.patch('mslice.presenters.cut_plotter_presenter.CutPlotterPresenter._plot_cut')
     def test_plot_with_width_returns_none_if_the_cut_width_is_larger_than_the_data_x_width(self, mock_plot_cut,
-                                                                                           mock_get_axis_range):
+                                                                                           mock_get_axis_step):
         mock_ws = mock.MagicMock()
-        mock_get_axis_range.return_value = [-10, 10, 0.05]
+        mock_get_axis_step.return_value = 0.05
         mock_cut = mock.MagicMock()
         mock_cut.cut_axis.units = 'DeltaE'
         mock_cut.cut_axis.step = 0.05
@@ -318,12 +318,12 @@ class CutPlotterPresenterTest(unittest.TestCase):
         self.assertEqual(None, self.cut_plotter_presenter._plot_with_width(mock_ws, mock_cut, False))
         mock_plot_cut.assert_called()
 
-    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_range')
+    @mock.patch('mslice.presenters.cut_plotter_presenter.get_axis_step')
     @mock.patch('mslice.presenters.cut_plotter_presenter.CutPlotterPresenter._plot_cut')
     def test_plot_with_width_returns_a_warning_if_the_cut_width_is_smaller_than_the_data_x_width(self, mock_plot_cut,
-                                                                                                 mock_get_axis_range):
+                                                                                                 mock_get_axis_step):
         mock_ws = mock.MagicMock()
-        mock_get_axis_range.return_value = [-10, 10, 0.05]
+        mock_get_axis_step.return_value = 0.05
         mock_cut = mock.MagicMock()
         mock_cut.cut_axis.units = 'DeltaE'
         mock_cut.cut_axis.step = 0.04  # Smaller cut step than the x axis data


### PR DESCRIPTION
**Description of work:**
This PR adds a warning when a step for a cut plot is smaller than the steps in the x axis data of a workspace. This can cause plots to appear to having missing lines. It has been implemented as follows:

- From the cli, a warning message will be output to the log
- From the interface, a warning message will be displayed in the status bar

**To test:**
Follow the instructions in the testing issue
Make sure two warnings are output after running the script, and that they make sense. (two warnings because two of the lines have cut axis steps which are too small)

Repeat the same steps but via the interface. See that a warning is displayed in the status bar.

Fixes #842 
Fixes #728 
