### PR TITLE
Pin Openssl to ensure Mantid is installed without conflicts

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,9 @@ dependencies:
   - coverage
   - ipython
   - mock
+  - openssl=1.1.*
   - pip
+  - pytest
   - pyqt
   - qtconsole
   - qtpy
-  - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - coverage
   - ipython
   - mock
-  - openssl=1.1.*
+  - openssl=1.1.*  # Pinned to the same version as Mantid
   - pip
   - pytest
   - pyqt


### PR DESCRIPTION
**Description of work:**
This PR pins Openssl to `1.1.*` in order to ensure that Mantid can be installed without conflicts. Previously, the "Setup Miniconda" step would install openssl version 3.1.0 . This was not compatible with the install of Mantid which pins openssl to `1.1.*`. I think the large jump in ssl version meant that it could not resolve the conflict automatically.

We should keep note to update our openssl pinning when Mantid updates it.

I also moved pytest up to be in alphabetical order in the dependency list.

**To test:**
Check the unit test job on this PR passes
