### PR TITLE
Fix Bragg peak too large on interactive cuts

### DIFF
--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -192,11 +192,12 @@ class CutPlotterPresenter(PresenterUtility):
         try:
             ws_handle = get_workspace_handle(workspace_name)
             workspace_name = ws_handle.parent
-            scale_fac = self._get_overall_max_signal(intensity_correction) / 10
         except KeyError:
             # Workspace is interactively generated and is not in the workspace list
-            scale_fac = 90
             workspace_name = workspace_name.split('(')[0][:-4]
+
+        # Get 10% of the maximum signal
+        scale_fac = self._get_overall_max_signal(intensity_correction) / 10
 
         q_axis = self._get_overall_q_axis()
         x, y = compute_powder_line(workspace_name, q_axis, key, cif_file=cif)

--- a/tests/cut_plotter_presenter_test.py
+++ b/tests/cut_plotter_presenter_test.py
@@ -1,5 +1,6 @@
 import unittest
 import mock
+import numpy as np
 from mslice.models.axis import Axis
 from mslice.models.cut.cut import Cut
 from mslice.presenters.cut_plotter_presenter import CutPlotterPresenter
@@ -285,6 +286,30 @@ class CutPlotterPresenterTest(unittest.TestCase):
 
         max_signal = self.cut_plotter_presenter._get_overall_max_signal(IntensityType.SCATTERING_FUNCTION)
         self.assertEqual(max_signal, 100)
+
+    @mock.patch("mslice.presenters.cut_plotter_presenter.compute_powder_line")
+    @mock.patch("mslice.presenters.cut_plotter_presenter.plot_overplot_line")
+    def test_add_overplot_line_will_use_ten_percent_of_max_signal(self, mock_plot_overplot_line, mock_compute_powder_list):
+        cache = mock.MagicMock()
+        cache.rotated = False
+        self.cut_plotter_presenter._cut_cache_dict = mock.MagicMock()
+        self.cut_plotter_presenter._cut_cache_dict.__getitem__.return_value = [cache]
+
+        self.cut_plotter_presenter._get_overall_max_signal = mock.MagicMock()
+        self.cut_plotter_presenter._get_overall_max_signal.return_value = 4.0
+
+        self.cut_plotter_presenter._get_overall_q_axis = mock.MagicMock()
+        self.cut_plotter_presenter._get_overall_q_axis.return_value = Axis("A-1", "1.0", "2.0", "0.1")
+
+        x, y = np.array([1.0, 2.0]), np.array([3.0, 4.0])
+        key, recoil = "Copper", False
+        mock_compute_powder_list.return_value = (x, y)
+
+        self.cut_plotter_presenter.add_overplot_line("test_ws (-5.5,5.5)", key, recoil)
+
+        args = mock_plot_overplot_line.call_args.args
+        np.testing.assert_allclose(args[0], x)
+        np.testing.assert_allclose(args[1], y / 10)
 
     @mock.patch('mslice.presenters.cut_plotter_presenter.get_workspace_handle')
     @mock.patch('mslice.presenters.cut_plotter_presenter.CutPlotterPresenter._plot_cut')


### PR DESCRIPTION
**Description of work:**
This PR fixes a bug where the Bragg Peak lines displayed on an interactive cut are too large. They default to having 90% the length of the y axis. Instead, we want the bragg peaks to be 10% of the maximum signal - as is done for a direct cut.

<!-- Instructions for testing. -->
Follow the testing instructions in the issue. You should get bragg peaks similar in size to this:
![image](https://user-images.githubusercontent.com/40830825/231136850-99e1263e-1b66-447a-abaa-a4b089c77760.png)



Fixes #853 
