### PR TITLE
Support saving of NXSPE files 

### DIFF
--- a/src/mslice/app/mainwindow.py
+++ b/src/mslice/app/mainwindow.py
@@ -90,6 +90,7 @@ class MainWindow(MainView, QMainWindow):
         self.ws_tab_changed(0)
 
         self.wgtCut.warning_occurred.connect(self.show_warning)
+        self.wgtWorkspacemanager.warning_occurred.connect(self.show_warning)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)
@@ -121,6 +122,7 @@ class MainWindow(MainView, QMainWindow):
     def setup_save(self):
         menu = QMenu()
         menu.addAction("Nexus (*.nxs)", lambda: self.button_save('Nexus'))
+        menu.addAction("NXSPE (*.nxspe)", lambda: self.button_save('NXSPE'))
         menu.addAction("ASCII (*.txt)", lambda: self.button_save('Ascii'))
         menu.addAction("Matlab (*.mat)", lambda: self.button_save('Matlab'))
         self.btnSave.setMenu(menu)

--- a/src/mslice/app/mainwindow.py
+++ b/src/mslice/app/mainwindow.py
@@ -90,7 +90,6 @@ class MainWindow(MainView, QMainWindow):
         self.ws_tab_changed(0)
 
         self.wgtCut.warning_occurred.connect(self.show_warning)
-        self.wgtWorkspacemanager.warning_occurred.connect(self.show_warning)
 
         self.wgtCut.error_occurred.connect(self.show_error)
         self.wgtSlice.error_occurred.connect(self.show_error)

--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import os.path
 from qtpy.QtWidgets import QFileDialog
 from mantid.api import MDNormalization
-from mslice.util.mantid.mantid_algorithms import CreateMDHistoWorkspace, SaveAscii, SaveMD, SaveNexus
+from mslice.util.mantid.mantid_algorithms import CreateMDHistoWorkspace, SaveAscii, SaveMD, SaveNexus, SaveNXSPE
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.models.axis import Axis
 from mslice.models.labels import get_display_name
@@ -57,7 +57,15 @@ def save_nexus(workspace, path, is_slice):
             workspace = get_workspace_handle(workspace.name[2:])
         save_alg = SaveMD
     else:
-        save_alg = SaveNexus
+        loader_name = get_workspace_handle(workspace).loader_name()
+        if loader_name == "LoadNXSPE":
+            # If the loaded workspace uses the old SPE format, save it in SPE format to prevent loss of metadata
+            save_alg = SaveNXSPE
+            # Make sure the extension uses *.nxspe
+            path.replace(".nxs", ".nxspe")
+        else:
+            save_alg = SaveNexus
+
     with WrapWorkspaceAttribute(workspace):
         save_alg(InputWorkspace=workspace, Filename=path)
 

--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -56,11 +56,12 @@ def save_nexus(workspace, path, is_slice):
         _save_histogram_workspace(workspace, path, is_slice)
         return
 
+    loader_name = get_workspace_handle(workspace).loader_name()
+    if loader_name is not None and loader_name == "LoadNXSPE":
+        raise RuntimeError("An NXSPE file cannot be saved as a Nexus - metadata may be lost.")
+
     with WrapWorkspaceAttribute(workspace):
         SaveNexus(InputWorkspace=workspace, Filename=path)
-
-    loader_name = get_workspace_handle(workspace).loader_name()
-    assert loader_name != "LoadNXSPE", "An NXSPE file was saved as a Nexus - metadata may be lost."
 
 
 def save_nxspe(workspace, path, is_slice):
@@ -68,11 +69,12 @@ def save_nxspe(workspace, path, is_slice):
         _save_histogram_workspace(workspace, path, is_slice)
         return
 
+    loader_name = get_workspace_handle(workspace).loader_name()
+    if loader_name is not None and loader_name != "LoadNXSPE":
+        raise RuntimeError("A Nexus cannot be saved as an NXSPE file - metadata may be lost.")
+
     with WrapWorkspaceAttribute(workspace):
         SaveNXSPE(InputWorkspace=workspace, Filename=path)
-
-    loader_name = get_workspace_handle(workspace).loader_name()
-    assert loader_name == "LoadNXSPE", "A Nexus was saved as an NXSPE file - metadata may be lost."
 
 
 def save_ascii(workspace, path, is_slice):

--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -27,7 +27,7 @@ from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace
 
-from .file_io import save_ascii, save_matlab, save_nexus
+from .file_io import save_ascii, save_matlab, save_nexus, save_nxspe
 
 # -----------------------------------------------------------------------------
 # Classes and functions
@@ -247,6 +247,8 @@ def save_workspaces(workspaces, path, save_name, extension, slice_nonpsd=False):
     """
     if extension == '.nxs':
         save_method = save_nexus
+    elif extension == '.nxspe':
+        save_method = save_nxspe
     elif extension == '.txt':
         save_method = save_ascii
     elif extension == '.mat':

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -23,6 +23,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         self._psd = True
         self._command_map = {
             Command.SaveSelectedWorkspaceNexus: lambda: self._save_selected_workspace('.nxs'),
+            Command.SaveSelectedWorkspaceNXSPE: lambda: self._save_selected_workspace('.nxspe'),
             Command.SaveSelectedWorkspaceAscii: lambda: self._save_selected_workspace('.txt'),
             Command.SaveSelectedWorkspaceMatlab: lambda: self._save_selected_workspace('.mat'),
             Command.RemoveSelectedWorkspaces: self._remove_selected_workspaces,
@@ -98,6 +99,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         try:
             save_workspaces(selected_workspaces, save_directory, save_name, extension)
+        except AssertionError as ex:
+            self._workspace_manager_view.display_warning(str(ex))
         except RuntimeError:
             self._workspace_manager_view.error_unable_to_save()
 

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -99,10 +99,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         try:
             save_workspaces(selected_workspaces, save_directory, save_name, extension)
-        except AssertionError as ex:
-            self._workspace_manager_view.display_warning(str(ex))
-        except RuntimeError:
-            self._workspace_manager_view.error_unable_to_save()
+        except RuntimeError as e:
+            self._workspace_manager_view._display_error(str(e))
 
     def _save_to_ads(self):
         selected_workspaces = self._workspace_manager_view.get_workspace_selected()

--- a/src/mslice/widgets/workspacemanager/command.py
+++ b/src/mslice/widgets/workspacemanager/command.py
@@ -19,6 +19,7 @@ class Command(object):
     SaveSelectedWorkspaceAscii = 7
     SaveSelectedWorkspaceMatlab = 8
     SaveToADS = 9
+    SaveSelectedWorkspaceNXSPE = 10
     RenameWorkspace = 1000
     CombineWorkspace = 1010
     SelectionChanged = -1799

--- a/src/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/src/mslice/widgets/workspacemanager/workspacemanager.py
@@ -19,6 +19,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
     """A Widget that allows user to perform basic workspace save/load/rename/delete operations on workspaces"""
 
     error_occurred = Signal('QString')
+    warning_occurred = Signal('QString')
     tab_changed = Signal(int)
     busy = Signal(bool)
 
@@ -40,6 +41,9 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
+
+    def display_warning(self, warning_string):
+        self.warning_occurred.emit(warning_string)
 
     def tab_changed_method(self, tab_index):
         self.clear_selection()

--- a/src/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/src/mslice/widgets/workspacemanager/workspacemanager.py
@@ -19,7 +19,6 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
     """A Widget that allows user to perform basic workspace save/load/rename/delete operations on workspaces"""
 
     error_occurred = Signal('QString')
-    warning_occurred = Signal('QString')
     tab_changed = Signal(int)
     busy = Signal(bool)
 
@@ -41,9 +40,6 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def _display_error(self, error_string):
         self.error_occurred.emit(error_string)
-
-    def display_warning(self, warning_string):
-        self.warning_occurred.emit(warning_string)
 
     def tab_changed_method(self, tab_index):
         self.clear_selection()

--- a/src/mslice/workspace/workspace_mixin.py
+++ b/src/mslice/workspace/workspace_mixin.py
@@ -82,6 +82,26 @@ class WorkspaceMixin(object):
     def is_axis_saved(self, axis):
         return True if axis in self._cut_params else False
 
+    def loader_name(self) -> str:
+        """
+        Searches the algorithm history for the name of the Load algorithm used to load the workspace.
+        If the Load algorithm is not found to be the first algorithm in the history, then return None.
+        """
+        history = self._raw_ws.getHistory()
+        if history.empty():
+            return None
+
+        alg_histories = history.getAlgorithmHistories()
+        if len(alg_histories) == 0:
+            return None
+
+        # Assume the first algorithm in the history is Load
+        first_alg_history = alg_histories[0]
+        if first_alg_history.name() != "Load":
+            return None
+
+        return first_alg_history.getPropertyValue("LoaderName")
+
     @property
     def name(self):
         return self._name

--- a/tests/file_io_test.py
+++ b/tests/file_io_test.py
@@ -27,7 +27,7 @@ class FileIOTest(unittest.TestCase):
         self.mock_dialog.selectedFilter.return_value = 'Nexus (*.nxs)'
 
         directory, file_name, extension = get_save_directory(default_ext='.nxs')
-        self.mock_dialog.setNameFilter.assert_called_once_with("Nexus (*.nxs);; Ascii (*.txt);; Matlab (*.mat)")
+        self.mock_dialog.setNameFilter.assert_called_once_with("Nexus (*.nxs);; NXSPE (*.nxspe);; Ascii (*.txt);; Matlab (*.mat)")
         self.mock_dialog.selectNameFilter.assert_called_once_with("Nexus (*.nxs)")
         self.mock_dialog.exec_.assert_called_once()
         self.assertEqual(directory, self.tempdir)
@@ -41,7 +41,7 @@ class FileIOTest(unittest.TestCase):
 
         directory, file_name, extension = get_save_directory(save_as_image=True)
         self.mock_dialog.setNameFilter.assert_called_once_with(
-            "Image (*.png);; PDF (*.pdf);; Nexus (*.nxs);; Ascii (*.txt);; Matlab (*.mat)")
+            "Image (*.png);; PDF (*.pdf);; Nexus (*.nxs);; NXSPE (*.nxspe);; Ascii (*.txt);; Matlab (*.mat)")
         self.mock_dialog.exec_.assert_called_once()
         self.assertEqual(directory, self.tempdir)
         self.assertEqual(file_name, 'some_file.png')

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -67,9 +67,9 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
         # Test save failure
         save_ws_mock.side_effect = RuntimeError()
-        self.view.error_unable_to_save = mock.Mock()
+        self.view._display_error = mock.Mock()
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
-        self.view.error_unable_to_save.assert_called_once_with()
+        self.view._display_error.assert_called_once()
 
         # Test user cancellation
         save_dir_mock.reset_mock()
@@ -232,7 +232,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_call_presenter_with_unknown_command(self):
         self.presenter = WorkspaceManagerPresenter(self.view)
-        unknown_command = 10
+        unknown_command = 55
         self.assertRaises(ValueError, self.presenter.notify, unknown_command)
 
     def test_notify_presenter_clears_error(self):


### PR DESCRIPTION
**Description of work:**
This PR fixes an issue where the metadata for a workspace based off the NXSPE file format was not being saved correctly. Previously, we were using the `SaveNexus` file to save the NXSPE workspace, however we should have been using `SaveNXSPE` to ensure all the correct metadata gets saved.

It was decided that we would not add an explicit option to save NXSPE files via the interface. Instead, I added a check to see if the algorithm history says the file was loaded in from a .nxspe file or .nxs file. If it finds the file was loaded using the `LoadNXSPE` algorithm, then the corresponding save algorithm would be used to save it. Otherwise, the `SaveNexus` algorithm gets used.

This ensures the saved nxspe workspace can be loaded back into the MSlice interface without any problems.

**To test:**
Load `MARI28540_80meV.nxspe`
Scale the workspace
Save the file as Nexus to a different name such as `MARI28540_80meV_scaled`
There should be an error message displayed at the bottom suggesting that metadata will not be saved.
Save the file as NXSPE to a different name such as `MARI28540_80meV_scaled`
Load the `MARI28540_80meV_scaled` workspace back into MSlice
There should be no error

Fixes #834
Fixes #540
