### PR TITLE
Ensure that correct version of MSlice is started via mslicedevel.bat

### DIFF
--- a/mslicedevel.bat
+++ b/mslicedevel.bat
@@ -44,13 +44,13 @@
 :NoConda
 :: This allows to start MSlice when there is no conda available or activating mantidnightly failed
 @set MANTIDPATH=C:\MantidInstall\bin
-@set PYTHONPATH=%MANTIDPATH%;%THIS_DIR%;%PYTHONPATH%
+@set PYTHONPATH=%MANTIDPATH%;%THIS_DIR%src;%PYTHONPATH%
 @set QT_PLUGIN_PATH=%MANTIDPATH%\..\plugins\qt5
 %MANTIDPATH%\python.exe %THIS_DIR%scripts\start_mslice.py
 @goto End
 
 :Conda
-@set PYTHONPATH=%THIS_DIR%; %CONDA_PREFIX%
+@set PYTHONPATH=%THIS_DIR%src; %CONDA_PREFIX%
 
 python %THIS_DIR%scripts\start_mslice.py
 


### PR DESCRIPTION
**Description of work:**

MSlicedevel.bat needs to append `src` to PYTHONPATH so that the development version of MSlice is started.

**To test:**

Run mslicedevel.bat on windows and observe which MSlice version is started.

Fixes #897 
