### PR TITLE
Use closest whole step number if within a small tolerance

### DIFF
--- a/src/mslice/models/alg_workspace_ops.py
+++ b/src/mslice/models/alg_workspace_ops.py
@@ -5,14 +5,13 @@ from mslice.models.workspacemanager.workspace_provider import get_workspace_hand
 def get_number_of_steps(axis):
     if axis.step == 0:
         return 1
-    else:
-        step_num = max(1, (axis.end - axis.start) / axis.step)
-        step_num_round = np.around(step_num)
-        step_num_ceil = np.ceil(step_num)
-        if np.isclose(step_num_round, step_num, atol=0):
-            return int(step_num_round)
-        else:
-            return int(step_num_ceil)
+
+    step_num = max(1, (axis.end - axis.start) / axis.step)
+    step_num_round = np.around(step_num)
+    if np.isclose(step_num_round, step_num, atol=0.05):
+        return int(step_num_round)
+
+    return int(np.ceil(step_num))
 
 
 def get_axis_range(workspace, dimension_name):

--- a/tests/alg_workspace_ops_test.py
+++ b/tests/alg_workspace_ops_test.py
@@ -1,0 +1,31 @@
+import unittest
+
+from mslice.models.alg_workspace_ops import get_number_of_steps
+from mslice.models.axis import Axis
+
+
+class AlgWorkspaceOpsTest(unittest.TestCase):
+
+    def test_get_number_of_steps_returns_one_when_step_equals_zero(self):
+        axis = Axis('DeltaE', 3, 33, 0)
+
+        n_steps = get_number_of_steps(axis)
+        self.assertEqual(1, n_steps)
+
+    def test_get_number_of_steps_for_simple_division(self):
+        axis = Axis('DeltaE', 3, 33, 2)
+
+        n_steps = get_number_of_steps(axis)
+        self.assertEqual(15, n_steps)
+
+    def test_get_number_of_steps_for_remainder_division_to_floor(self):
+        axis = Axis('DeltaE', 3, 33.03, 2)
+
+        n_steps = get_number_of_steps(axis)
+        self.assertEqual(15, n_steps)
+
+    def test_get_number_of_steps_for_remainder_division_to_ceiling(self):
+        axis = Axis('DeltaE', 3, 34, 2)
+
+        n_steps = get_number_of_steps(axis)
+        self.assertEqual(16, n_steps)


### PR DESCRIPTION
**Description of work:**
This PR ensures that the number of steps in an axis gets rounded to the closest whole number if `(axis.end - axis.start)/axis.step` is close to a whole number. We might want to adjust the absolute tolerance in the future if 0.05 is too small.

**To test:**
Follow the instructions in the attached issue

Fixes #899
