### PR TITLE
Create `IgnorePartialOverlaps` interface option and pass to the Cut algorithm

### DIFF
--- a/src/mslice/cli/_mslice_commands.py
+++ b/src/mslice/cli/_mslice_commands.py
@@ -168,7 +168,7 @@ def Slice(InputWorkspace, Axis1=None, Axis2=None, NormToOne=False):
 
 
 def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False, Algorithm='Rebin',
-        IntensityCorrection=False, SampleTemperature=None):
+        IntensityCorrection=False, SampleTemperature=None, IgnorePartialOverlaps=False):
     """
     Cuts workspace.
     :param InputWorkspace: Workspace to cut. The parameter can be either a python
@@ -189,6 +189,7 @@ def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False, Alg
             'dynamical_susceptibility', 'dynamical_susceptibility_magnetic', 'd2sigma', or 'symmetrised'.
     :param SampleTemperature: if a temperature dependant intensity correction is input, a SampleTemperature in Kelvin
            must be provided.
+    :param IgnorePartialOverlaps: If true, ignore the bins where the sum of the weights is not unity (1.0)
     :return:
     """
     from mslice.app.presenters import get_cut_plotter_presenter
@@ -199,7 +200,8 @@ def Cut(InputWorkspace, CutAxis=None, IntegrationAxis=None, NormToOne=False, Alg
     cut_axis = _process_axis(CutAxis, 0, workspace)
     integration_axis = _process_axis(IntegrationAxis, 1 if workspace.is_PSD else 2,
                                      workspace, string_function=_string_to_integration_axis)
-    cut = compute_cut(workspace, cut_axis, integration_axis, NormToOne, Algorithm, store=True)
+    cut = compute_cut(workspace, cut_axis, integration_axis, NormToOne, Algorithm, store=True,
+                      ignore_partial_overlaps=IgnorePartialOverlaps)
 
     rotated = not is_twotheta(cut_axis.units) and not is_momentum(cut_axis.units)
     e_axis = cut_axis if rotated else integration_axis

--- a/src/mslice/models/cut/cut.py
+++ b/src/mslice/models/cut/cut.py
@@ -10,13 +10,14 @@ class Cut(object):
     """Groups parameters needed to cut and validates them, caches intensities"""
 
     def __init__(self, cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one=False, width=None,
-                 algorithm='Rebin', sample_temp=None, e_fixed=None):
+                 algorithm='Rebin', ignore_partial_overlaps=False, sample_temp=None, e_fixed=None):
         self._cut_ws = None
         self.cut_axis = cut_axis
         self.integration_axis = integration_axis
         self.intensity_start = intensity_start
         self.intensity_end = intensity_end
         self.norm_to_one = norm_to_one
+        self.ignore_partial_overlaps = ignore_partial_overlaps
         self.icut = None
         # These are here to save the integration range as the integration axis is
         # changed when a cut with a width is performed

--- a/src/mslice/models/cut/cut_functions.py
+++ b/src/mslice/models/cut/cut_functions.py
@@ -12,12 +12,13 @@ def output_workspace_name(selected_workspace: str, integration_start: float, int
     return f"{selected_workspace}_cut({integration_start:.3f},{integration_end:.3f})"
 
 
-def compute_cut(workspace, cut_axis, integration_axis, is_norm, algo='Rebin', store=True):
+def compute_cut(workspace, cut_axis, integration_axis, is_norm, algo='Rebin', store=True,
+                ignore_partial_overlaps=False):
     out_ws_name = output_workspace_name(workspace.name, integration_axis.start, integration_axis.end)
     cut = mantid_algorithms.Cut(OutputWorkspace=_make_name_unique(out_ws_name), store=store, InputWorkspace=workspace,
                                 CutAxis=cut_axis.to_dict(), IntegrationAxis=integration_axis.to_dict(),
                                 EMode=workspace.e_mode, PSD=workspace.is_PSD, NormToOne=is_norm,
-                                Algorithm=algo)
+                                Algorithm=algo, IgnorePartialOverlaps=ignore_partial_overlaps)
     cut.parent = workspace.name
     return cut
 

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -48,7 +48,8 @@ class CutPlotterPresenter(PresenterUtility):
         cut_axis = cut.cut_axis
         integration_axis = cut.integration_axis
         if not cut.cut_ws:
-            cut.cut_ws = compute_cut(workspace, cut_axis, integration_axis, cut.norm_to_one, cut.algorithm, store)
+            cut.cut_ws = compute_cut(workspace, cut_axis, integration_axis, cut.norm_to_one, cut.algorithm, store,
+                                     cut.ignore_partial_overlaps)
             self.prepare_cut_for_cache(cut)
         if intensity_correction == IntensityType.SCATTERING_FUNCTION:
             cut_ws = cut.cut_ws
@@ -146,7 +147,8 @@ class CutPlotterPresenter(PresenterUtility):
         return self._cut_cache_dict[ax] if ax in self._cut_cache_dict.keys() else None
 
     def save_cut_to_workspace(self, workspace, cut):
-        cut_ws = compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one, cut.algorithm)
+        cut_ws = compute_cut(workspace, cut.cut_axis, cut.integration_axis, cut.norm_to_one, cut.algorithm,
+                             ignore_partial_overlaps=cut.ignore_partial_overlaps)
         self._main_presenter.update_displayed_workspaces()
         export_workspace_to_ads(cut_ws)
 

--- a/src/mslice/presenters/cut_widget_presenter.py
+++ b/src/mslice/presenters/cut_widget_presenter.py
@@ -102,9 +102,11 @@ class CutWidgetPresenter(PresenterUtility):
         intensity_end = self._cut_view.get_intensity_end()
 
         norm_to_one = bool(self._cut_view.get_intensity_is_norm_to_one())
+        ignore_partial_overlaps = bool(self._cut_view.get_ignore_partial_overlaps())
+
         width = self._cut_view.get_integration_width()
         algo = ['Rebin', 'Integration'][self._cut_view.get_cut_algorithm()]
-        return cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width, algo
+        return cut_axis, integration_axis, intensity_start, intensity_end, norm_to_one, width, algo, ignore_partial_overlaps
 
     def _set_minimum_step(self, workspace, axis):
         """Gets axes limits and then sets the minimumStep dictionary with those values"""

--- a/src/mslice/views/interfaces/cut_view.py
+++ b/src/mslice/views/interfaces/cut_view.py
@@ -98,9 +98,6 @@ class CutView:
     def disable(self):
         pass
 
-    def plotting_params_only(self):
-        pass
-
     def force_normalization(self):
         pass
 

--- a/src/mslice/views/interfaces/cut_view.py
+++ b/src/mslice/views/interfaces/cut_view.py
@@ -38,6 +38,9 @@ class CutView:
     def get_intensity_is_norm_to_one(self):
         pass
 
+    def get_ignore_partial_overlaps(self):
+        pass
+
     def get_presenter(self):
         pass
 

--- a/src/mslice/widgets/cut/cut.py
+++ b/src/mslice/widgets/cut/cut.py
@@ -154,6 +154,9 @@ class CutWidget(CutView, QWidget):
     def get_intensity_is_norm_to_one(self):
         return self.rdoCutNormToOne.isChecked()
 
+    def get_ignore_partial_overlaps(self):
+        return self.rdoIgnorePartialOverlaps.isChecked()
+
     def get_energy_units(self):
         return self.cmbCutEUnits.currentText()
 

--- a/src/mslice/widgets/cut/cut.py
+++ b/src/mslice/widgets/cut/cut.py
@@ -100,6 +100,7 @@ class CutWidget(CutView, QWidget):
 
     def cut_algorithm_changed(self, _changed_index):
         self.get_input_fields()
+        self.rdoIgnorePartialOverlaps.setChecked(_changed_index == 1)
 
     def axis_changed(self, _changed_index):
         self._presenter.notify(Command.AxisChanged)
@@ -238,7 +239,8 @@ class CutWidget(CutView, QWidget):
                           'integration_range': ['', ''],
                           'integration_width': '',
                           'normtounity': False,
-                          'cut_algorithm_index': ''}
+                          'cut_algorithm_index': '',
+                          'ignorepartialoverlaps': False}
         for k in cleared_fields:
             if current_fields[k] != cleared_fields[k]:
                 return False
@@ -253,6 +255,7 @@ class CutWidget(CutView, QWidget):
         self.cmbCutAlg.setCurrentIndex(saved_input['cut_algorithm_index'])
         self.cmbCutEUnits.setCurrentIndex(EnergyUnits.get_index(saved_input['energy_unit']))
         self._en = EnergyUnits(saved_input['energy_unit'])
+        self.rdoIgnorePartialOverlaps.setChecked(saved_input['ignorepartialoverlaps'])
         self.cmbCutEUnits.blockSignals(False)
 
     def get_input_fields(self):
@@ -266,6 +269,7 @@ class CutWidget(CutView, QWidget):
         saved_input['normtounity'] = self.get_intensity_is_norm_to_one()
         saved_input['cut_algorithm_index'] = self.get_cut_algorithm()
         saved_input['energy_unit'] = self.get_energy_units()
+        saved_input['ignorepartialoverlaps'] = self.get_ignore_partial_overlaps()
         return saved_input
 
     def enable(self):
@@ -275,6 +279,7 @@ class CutWidget(CutView, QWidget):
         self.cmbCutAxis.setEnabled(True)
         self.cmbCutEUnits.setEnabled(True)
         self.cmbCutAlg.setEnabled(True)
+        self.rdoIgnorePartialOverlaps.setEnabled(True)
 
         self.lneCutIntegrationStart.setEnabled(True)
         self.lneCutIntegrationEnd.setEnabled(True)
@@ -302,6 +307,7 @@ class CutWidget(CutView, QWidget):
         self.cmbCutAxis.setEnabled(False)
         self.cmbCutEUnits.setEnabled(False)
         self.cmbCutAlg.setEnabled(False)
+        self.rdoIgnorePartialOverlaps.setEnabled(False)
 
         self.lneCutIntegrationStart.setEnabled(False)
         self.lneCutIntegrationEnd.setEnabled(False)
@@ -314,15 +320,6 @@ class CutWidget(CutView, QWidget):
         self.btnCutSaveToWorkbench.setEnabled(False)
         self.btnCutPlot.setEnabled(False)
         self.btnCutPlotOver.setEnabled(False)
-
-    def plotting_params_only(self):
-        self.disable()
-        self.lneEditCutIntensityStart.setEnabled(True)
-        self.lneCutIntensityEnd.setEnabled(True)
-        self.rdoCutNormToOne.setEnabled(True)
-
-        self.btnCutPlot.setEnabled(True)
-        self.btnCutPlotOver.setEnabled(True)
 
     def set_validators(self):
         line_edits = [self.lneCutStart, self.lneCutEnd, self.lneCutIntegrationStart,

--- a/src/mslice/widgets/cut/cut.ui
+++ b/src/mslice/widgets/cut/cut.ui
@@ -214,6 +214,13 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="5">
+      <widget class="QCheckBox" name="rdoIgnorePartialOverlaps">
+       <property name="text">
+        <string>Ignore partial overlaps</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/tests/cut_algorithm_test.py
+++ b/tests/cut_algorithm_test.py
@@ -84,7 +84,7 @@ class CutAlgorithmTest(TestCase):
     def test_that_compute_cut_returns_the_expected_size_for_a_rebin_cut_axis_in_units_of_2theta(self):
         non_psd_workspace = create_simulation_workspace("Direct", "non_psd_ws", psd=False)
 
-        cut = compute_cut(non_psd_workspace.raw_ws, self.theta_axis, self.e_axis, "Direct", False, False, "Rebin")
+        cut = compute_cut(non_psd_workspace.raw_ws, self.theta_axis, self.e_axis, "Direct", False, False, False, "Rebin")
 
         self.assertTrue(isinstance(cut, MDHistoWorkspace))
         self.assertEqual(cut.getSignalArray().shape, (25, ))
@@ -95,7 +95,7 @@ class CutAlgorithmTest(TestCase):
         cut_algo = Cut()
         cut_algo.PyInit()
 
-        self.assertEqual(mock_declare_property.call_count, 8)
+        self.assertEqual(mock_declare_property.call_count, 9)
 
     @patch('mslice.models.cut.cut_algorithm.PythonAlgorithm.setProperty')
     @patch('mslice.models.cut.cut_algorithm.PythonAlgorithm.getProperty')
@@ -108,7 +108,8 @@ class CutAlgorithmTest(TestCase):
                   "step": MockProperty(1), "e_unit": MockProperty("DeltaE")}
         mock_get_property.side_effect = [MockProperty("md_ws"), MockProperty(q_axis),
                                          MockProperty(e_axis), MockProperty("Direct"),
-                                         MockProperty(True), MockProperty(False), MockProperty("Rebin")]
+                                         MockProperty(True), MockProperty(False), MockProperty("Rebin"),
+                                         MockProperty(False)]
         mock_compute_cut.return_value = MagicMock()
 
         cut_algo = Cut()
@@ -130,7 +131,7 @@ class CutAlgorithmTest(TestCase):
     def _test_non_psd_cut(self, normalized: bool, algorithm: str):
         non_psd_workspace = create_simulation_workspace("Direct", "non_psd_ws", psd=False)
 
-        cut = compute_cut(non_psd_workspace.raw_ws, self.q_axis, self.e_axis, "Direct", False, normalized, algorithm)
+        cut = compute_cut(non_psd_workspace.raw_ws, self.q_axis, self.e_axis, "Direct", False, normalized, True, algorithm)
 
         self.assertTrue(isinstance(cut, MDHistoWorkspace))
         self.assertEqual(cut.getSignalArray().shape, (30, ))

--- a/tests/cut_plotter_presenter_test.py
+++ b/tests/cut_plotter_presenter_test.py
@@ -100,7 +100,7 @@ class CutPlotterPresenterTest(unittest.TestCase):
             get_current_plot_intensity_mock.return_value = intensity
             self.cut_plotter_presenter._plot_cut(mock_ws, cut_cache, False, intensity_correction=intensity)
             compute_cut_mock.assert_called_with(mock_ws, cut_cache.cut_axis, cut_cache.integration_axis,
-                                                cut_cache.norm_to_one, cut_cache.algorithm, True)
+                                                cut_cache.norm_to_one, cut_cache.algorithm, True, False)
             cut_cache._cut_ws = None
 
         self.assertEqual(1 * len(intensity_correction_types), plot_cut_impl_mock.call_count)

--- a/tests/cut_widget_presenter_test.py
+++ b/tests/cut_widget_presenter_test.py
@@ -302,4 +302,4 @@ class CutWidgetPresenterTest(unittest.TestCase):
         cut_widget_presenter.notify(Command.Plot)
         self.view.display_error.assert_not_called()
         mock_cut_obj.assert_called_once_with(axis, integration_axis, intensity_start, intensity_end,
-                                             is_norm, width, 'Integration', None, 1)
+                                             is_norm, width, 'Integration', True, None, 1)


### PR DESCRIPTION
**Description of work:**
This PR creates an `IgnorePartialOverlaps` check box on the Cut interface, and its value gets passed through to the Cut algorithm. The ability to provide a `IgnorePartialOverlaps` option via the command line is also available.

It is not yet possible to provide this option for an interactive cut. This functionality will be added in a later PR. Remind me to create an issue for this.

This PR is currently waiting on a PR in the main mantid repo to be finished and merged.

**To test:**
When switching between the Rebin and Integration algorithms, check that `IgnorePartialOverlaps` is default off for Rebin and default on for Integration.

Fixes #835
