### PR TITLE
Set default save directory

### DIFF
--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -83,7 +83,7 @@ def save_ascii(workspace, path, is_slice):
         _save_slice_to_ascii(workspace, path)
     else:
         if isinstance(workspace, HistogramWorkspace):
-            _save_cut_to_ascii(workspace, workspace.name, path)
+            _save_cut_to_ascii(workspace, path)
         else:
             SaveAscii(InputWorkspace=workspace, Filename=path)
 
@@ -123,7 +123,7 @@ def _save_histogram_workspace(workspace, path, is_slice):
         SaveMD(InputWorkspace=workspace, Filename=path)
 
 
-def _save_cut_to_ascii(workspace, ws_name, output_path):
+def _save_cut_to_ascii(workspace, output_path):
     # get integration ranges from the name
     cut_axis, integration_axis = tuple(workspace.axes)
 

--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import os.path
 from qtpy.QtWidgets import QFileDialog
 from mantid.api import MDNormalization
+from mantid.kernel import ConfigService
 from mslice.util.mantid.mantid_algorithms import CreateMDHistoWorkspace, SaveAscii, SaveMD, SaveNexus, SaveNXSPE
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.models.axis import Axis
@@ -111,7 +112,7 @@ def save_matlab(workspace, path, is_slice):
         y = workspace.raw_ws.extractY()
         e = workspace.raw_ws.extractE()
     mdict = {'x': x, 'y': y, 'e': e, 'labels': labels}
-    savemat(path, mdict=mdict)
+    savemat(_to_absolute_path(path), mdict=mdict)
 
 
 def _save_histogram_workspace(workspace, path, is_slice):
@@ -218,4 +219,11 @@ def _get_slice_mdhisto_xye(histo_ws):
 
 
 def _output_data_to_ascii(output_path, out_data, header):
-    np.savetxt(str(output_path), out_data, fmt='%12.9e', header=header)
+    np.savetxt(_to_absolute_path(str(output_path)), out_data, fmt='%12.9e', header=header)
+
+
+def _to_absolute_path(filepath: str) -> str:
+    """Returns an absolute path in which a file should be saved."""
+    if os.path.isabs(filepath):
+        return filepath
+    return os.path.join(ConfigService.getString("defaultsave.directory"), filepath)

--- a/tests/file_io_test.py
+++ b/tests/file_io_test.py
@@ -6,10 +6,12 @@ from os.path import join
 from tempfile import gettempdir
 import unittest
 from mantid.simpleapi import CreateMDHistoWorkspace
+from mantid.kernel import ConfigService
 
 from mslice.models.axis import Axis
 from mslice.models.cut.cut_functions import output_workspace_name
-from mslice.models.workspacemanager.file_io import _save_cut_to_ascii, _save_slice_to_ascii, get_save_directory
+from mslice.models.workspacemanager.file_io import (_save_cut_to_ascii, _save_slice_to_ascii, get_save_directory,
+                                                    _to_absolute_path)
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 
 
@@ -100,3 +102,14 @@ class FileIOTest(unittest.TestCase):
         self.assertEqual(output_method.call_args[0][0], 'path1')
         np.testing.assert_array_equal(output_method.call_args[0][1], [[-10, -10, 1, 3], [-10, 10, 3, 5],
                                                                       [10, -10, 2, 4], [10, 10, 4, 6]])
+
+    def test_to_absolute_path_returns_the_same_path_if_it_is_already_absolute(self):
+        abs_path = "C:/User/Documents/filename.txt"
+        self.assertEqual(abs_path, _to_absolute_path(abs_path))
+
+    def test_to_absolute_path_returns_a_path_in_the_default_save_dir_if_the_path_provided_is_relative(self):
+        default_save_directory = "D:/User/Documents/default_save_dir/"
+        ConfigService.setString("defaultsave.directory", default_save_directory)
+
+        rel_path = "datadir/filename.txt"
+        self.assertEqual(f"{default_save_directory}{rel_path}", _to_absolute_path(rel_path))

--- a/tests/file_io_test.py
+++ b/tests/file_io_test.py
@@ -104,12 +104,12 @@ class FileIOTest(unittest.TestCase):
                                                                       [10, -10, 2, 4], [10, 10, 4, 6]])
 
     def test_to_absolute_path_returns_the_same_path_if_it_is_already_absolute(self):
-        abs_path = "C:/User/Documents/filename.txt"
+        abs_path = "/c/user/documents/filename.txt"
         self.assertEqual(abs_path, _to_absolute_path(abs_path))
 
     def test_to_absolute_path_returns_a_path_in_the_default_save_dir_if_the_path_provided_is_relative(self):
-        default_save_directory = "D:/User/Documents/default_save_dir/"
+        default_save_directory = "/d/user/documents/default_save_dir"
         ConfigService.setString("defaultsave.directory", default_save_directory)
 
         rel_path = "datadir/filename.txt"
-        self.assertEqual(f"{default_save_directory}{rel_path}", _to_absolute_path(rel_path))
+        self.assertEqual(f"{default_save_directory}/{rel_path}", _to_absolute_path(rel_path))

--- a/tests/file_io_test.py
+++ b/tests/file_io_test.py
@@ -85,7 +85,7 @@ class FileIOTest(unittest.TestCase):
                                         NumberOfBins=2, Names='Dim1', Units="units", OutputWorkspace=ws_name)
         ws = HistogramWorkspace(raw_ws, ws_name)
         ws.axes = [Axis('DeltaE', 0, 1, 0.1), Axis('Q', 0, 2, 0.2)]
-        _save_cut_to_ascii(ws, ws_name, "some_path")
+        _save_cut_to_ascii(ws, "some_path")
         output_method.assert_called_once()
         self.assertEqual(output_method.call_args[0][0], 'some_path')
         np.testing.assert_array_equal(output_method.call_args[0][1], [[-1, 1, 4], [5, 2, 5]])


### PR DESCRIPTION
**Description of work:**
This PR ensures that matlab and ascii files get saved into the default save directory when a relative filepath is provided by the user.

**To test:**
To test this, you will need to make sure your config service returns a default save directory.

Fixes #532
