### PR TITLE
Use LineEditDoubleValidator to prevent broken e notation

### DIFF
--- a/src/mslice/plotting/plot_window/plot_window.py
+++ b/src/mslice/plotting/plot_window/plot_window.py
@@ -4,9 +4,9 @@ from qtpy import QtCore, QtWidgets
 
 from matplotlib.figure import Figure
 from mantidqt.icons import get_icon
+from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
 
 from mslice.plotting.backend import get_canvas_and_toolbar_cls
-from mslice.util.qt.validator_helper import double_validator_without_separator
 from mslice.util.intensity_correction import IntensityType, IntensityCache
 
 FigureCanvas, NavigationToolbar2QT = get_canvas_and_toolbar_cls()
@@ -183,9 +183,10 @@ class PlotWindow(QtWidgets.QMainWindow):
         sz.setWidth(60)
         self.waterfall_x_edt.setMaximumSize(sz)
         self.waterfall_y_edt.setMaximumSize(sz)
-        validator = double_validator_without_separator()
-        self.waterfall_x_edt.setValidator(validator)
-        self.waterfall_y_edt.setValidator(validator)
+        self.waterfall_x_edt_validator = LineEditDoubleValidator(self.waterfall_x_edt, 0.0)
+        self.waterfall_x_edt.setValidator(self.waterfall_x_edt_validator)
+        self.waterfall_y_edt_validator = LineEditDoubleValidator(self.waterfall_y_edt, 0.0)
+        self.waterfall_y_edt.setValidator(self.waterfall_y_edt_validator)
         self.waterfall_x_lbl_act = parent.addWidget(self.waterfall_x_lbl)
         self.waterfall_x_edt_act = parent.addWidget(self.waterfall_x_edt)
         self.waterfall_y_lbl_act = parent.addWidget(self.waterfall_y_lbl)


### PR DESCRIPTION
**Description of work:**
This PR ensures we use a `LineEditDoubleValidator` for the waterfall x and y options so that providing a number in broken e notation will not cause a crash. Instead, the value will get reset to the original value.

**To test:**
Create a waterfall plot
Enter '2e' into the x box, and then click on the y box
The x box should switch back to its original value of 0
Try entering valid values and make sure they still work for x and y

Part of  #854
