### PR TITLE
Check intensity is a real number

### DIFF
--- a/src/mslice/cli/plotfunctions.py
+++ b/src/mslice/cli/plotfunctions.py
@@ -8,6 +8,7 @@ from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.app import is_gui
 from mslice.util.compat import legend_set_draggable
 from mslice.util.mantid.mantid_algorithms import Transpose
+from mslice.util.numpy_helper import is_real_number
 from mslice.util.intensity_correction import IntensityType, IntensityCache
 from mslice.models.labels import get_display_name, CUT_INTENSITY_LABEL
 from mslice.models.cut.cut import Cut
@@ -37,8 +38,8 @@ def errorbar(axes, workspace, *args, **kwargs):
 
     plot_over = kwargs.pop('plot_over', True)
     intensity_min, intensity_max = kwargs.pop('intensity_range', (None, None))
-    intensity_min = intensity_min if intensity_min and intensity_min != '' else None
-    intensity_max = intensity_max if intensity_max and intensity_max != '' else None
+    intensity_min = intensity_min if is_real_number(intensity_min) else None
+    intensity_max = intensity_max if is_real_number(intensity_max) else None
     label = kwargs.pop('label', None)
     label = workspace.name if label is None else label
     en_conversion_allowed = kwargs.pop('en_conversion', True)

--- a/src/mslice/util/numpy_helper.py
+++ b/src/mslice/util/numpy_helper.py
@@ -55,3 +55,15 @@ def clean_array(arr):
         except ValueError:
             pass
     return arr_clean
+
+
+def is_real_number(value) -> bool:
+    """
+    Checks that the value provided is a real number. i.e. that it can be converted to a float and is not NaN or Inf
+    :param value: The value to check. It can have a type of None, string or float.
+    """
+    try:
+        num = float(value)
+        return not np.isnan(num) and not np.isinf(num)
+    except (TypeError, ValueError):
+        return False

--- a/tests/numpy_helper_test.py
+++ b/tests/numpy_helper_test.py
@@ -1,0 +1,25 @@
+import unittest
+import numpy as np
+
+from mslice.util.numpy_helper import is_real_number
+
+
+class NumpyHelperTest(unittest.TestCase):
+
+    def test_is_real_number_returns_false_when_provided_none(self):
+        self.assertFalse(is_real_number(None))
+
+    def test_is_real_number_returns_false_when_provided_a_string_that_cannot_be_converted_to_float(self):
+        self.assertFalse(is_real_number("34eta"))
+
+    def test_is_real_number_returns_false_when_provided_an_inf_or_nan(self):
+        self.assertFalse(is_real_number(np.inf))
+        self.assertFalse(is_real_number(np.nan))
+
+    def test_is_real_number_returns_true_for_a_valid_real_number(self):
+        self.assertTrue(is_real_number("1.234"))
+        self.assertTrue(is_real_number(5.678))
+
+    def test_is_real_number_returns_true_for_a_valid_real_number_in_scientific_notation(self):
+        self.assertTrue(is_real_number("1e5"))
+        self.assertTrue(is_real_number(2e6))


### PR DESCRIPTION
**Description of work:**
This PR fixes an unhandled exception that causes MSlice to crash when the intensity min or max is a nan or inf value. The Intensity min or max should be set to None if this is the case, thereby avoiding a crash.

**To test:**
Follow the instructions in the attached issue.
There should be no crash. The plot generated will be empty and there may be warnings in the console, but this is still an improvement on the previous behaviour.

Fixes #905
