### PR TITLE
Fix SaveAscii index out of range error

### DIFF
--- a/src/mslice/cli/__init__.py
+++ b/src/mslice/cli/__init__.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 from mslice.plotting.pyplot import *  # noqa: F401, F403
 from matplotlib.axes import Axes
 from matplotlib.projections import register_projection
-from mslice.cli.helperfunctions import is_slice, is_cut, is_hs_workspace
+from mslice.cli.helperfunctions import is_cut, is_hs_workspace
 from ._mslice_commands import *  # noqa: F401, F403
 from mslice.app import is_gui
 from mslice.cli.helperfunctions import (_check_workspace_name, _check_workspace_type, _get_workspace_type, _get_overplot_key,
@@ -31,7 +31,7 @@ class MSliceAxes(Axes):
 
     def pcolormesh(self, *args, **kwargs):
         from mslice.cli.plotfunctions import pcolormesh
-        if is_slice(*args):
+        if hasattr(args[0], "is_slice") and args[0].is_slice:
             return pcolormesh(self, *args, **kwargs)
         else:
             return Axes.pcolormesh(self, *args, **kwargs)

--- a/src/mslice/cli/_mslice_commands.py
+++ b/src/mslice/cli/_mslice_commands.py
@@ -14,7 +14,7 @@ import mslice.app as app
 from mslice.app import is_gui
 from mslice.plotting.globalfiguremanager import GlobalFigureManager
 from mslice.cli.helperfunctions import (_string_to_integration_axis, _process_axis, _check_workspace_name,
-                                        _check_workspace_type, is_slice, _correct_intensity)
+                                        _check_workspace_type, _correct_intensity)
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.util.qt.qapp import QAppThreadCall, mainloop
 from six import string_types
@@ -100,7 +100,7 @@ def SaveData(InputWorkspace, Path, format='ascii'):
     else:
         workspace = InputWorkspace
     save_fun = {'ascii': save_ascii, 'matlab': save_matlab, 'nexus': save_nexus}
-    save_fun[format](workspace, Path, is_slice(workspace))
+    save_fun[format](workspace, Path)
 
 
 def SaveAscii(InputWorkspace, Path):

--- a/src/mslice/cli/helperfunctions.py
+++ b/src/mslice/cli/helperfunctions.py
@@ -131,15 +131,6 @@ def _rescale_energy_cut_plot(presenter, cuts, new_e_unit):
 
 
 # Arguments Validation
-def is_slice(*args):
-    """
-    Checks if args[0] is a WorkspaceBase or HistogramWorkspace
-    """
-    if not isinstance(args[0], Workspace) or is_cut(*args):
-        return False
-    if isinstance(args[0], Workspace) or args[0]._raw_ws.getNumDims() == 2:
-        return True
-
 
 def is_cut(*args):
     """

--- a/src/mslice/models/slice/slice_functions.py
+++ b/src/mslice/models/slice/slice_functions.py
@@ -21,6 +21,7 @@ def compute_slice(selected_workspace, x_axis, y_axis, norm_to_one, store_in_ADS=
     propagate_properties(workspace, slice)
     if norm_to_one:
         slice = _norm_to_one(slice)
+    slice.is_slice = True
     return slice
 
 

--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -51,9 +51,9 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
             return None, None, None
 
 
-def save_nexus(workspace, path, is_slice):
+def save_nexus(workspace, path):
     if isinstance(workspace, HistogramWorkspace):
-        _save_histogram_workspace(workspace, path, is_slice)
+        _save_histogram_workspace(workspace, path)
         return
 
     loader_name = get_workspace_handle(workspace).loader_name()
@@ -64,9 +64,9 @@ def save_nexus(workspace, path, is_slice):
         SaveNexus(InputWorkspace=workspace, Filename=path)
 
 
-def save_nxspe(workspace, path, is_slice):
+def save_nxspe(workspace, path):
     if isinstance(workspace, HistogramWorkspace):
-        _save_histogram_workspace(workspace, path, is_slice)
+        _save_histogram_workspace(workspace, path)
         return
 
     loader_name = get_workspace_handle(workspace).loader_name()
@@ -77,27 +77,27 @@ def save_nxspe(workspace, path, is_slice):
         SaveNXSPE(InputWorkspace=workspace, Filename=path)
 
 
-def save_ascii(workspace, path, is_slice):
-    if is_slice:
+def save_ascii(workspace, path):
+    if workspace.is_slice:
         _save_slice_to_ascii(workspace, path)
     else:
         if isinstance(workspace, HistogramWorkspace):
-            _save_cut_to_ascii(workspace, workspace.name, path)
+            _save_cut_to_ascii(workspace, path)
         else:
             SaveAscii(InputWorkspace=workspace, Filename=path)
 
 
-def save_matlab(workspace, path, is_slice):
+def save_matlab(workspace, path):
     labels = {}
     if isinstance(workspace, HistogramWorkspace):
-        if is_slice:
+        if workspace.is_slice:
             x, y, e = _get_slice_mdhisto_xye(workspace.raw_ws)
             labels = {'x': get_display_name(workspace.axes[0]), 'y': get_display_name(workspace.axes[1])}
         else:
             x, y, e = _get_md_histo_xye(workspace.raw_ws)
             labels = {'x': get_display_name(workspace.axes[0])}
     else:
-        if is_slice:
+        if workspace.is_slice:
             x = []
             for dim in [workspace.raw_ws.getDimension(i) for i in range(2)]:
                 x.append(np.linspace(dim.getMinimum(), dim.getMaximum(), dim.getNBins()))
@@ -114,15 +114,15 @@ def save_matlab(workspace, path, is_slice):
     savemat(path, mdict=mdict)
 
 
-def _save_histogram_workspace(workspace, path, is_slice):
-    if is_slice:
+def _save_histogram_workspace(workspace, path):
+    if workspace.is_slice:
         workspace = get_workspace_handle(workspace.name[2:])
 
     with WrapWorkspaceAttribute(workspace):
         SaveMD(InputWorkspace=workspace, Filename=path)
 
 
-def _save_cut_to_ascii(workspace, ws_name, output_path):
+def _save_cut_to_ascii(workspace, output_path):
     # get integration ranges from the name
     cut_axis, integration_axis = tuple(workspace.axes)
 

--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -146,7 +146,9 @@ def _save_slice_to_ascii(workspace, output_path):
         x[1] = x[1].T
         y = workspace.raw_ws.extractY()
         e = workspace.raw_ws.extractE()
-        ix = [i for i, ax in enumerate(workspace.axes) if 'DeltaE' in ax.units][0]
+        e_axes = [i for i, ax in enumerate(workspace.axes) if 'DeltaE' in ax.units]
+        assert len(e_axes) > 0
+        ix = e_axes[0]
         iy = 0 if ix == 1 else 1
     dim_sz = [workspace.raw_ws.getDimension(i).getNBins() for i in range(workspace.raw_ws.getNumDims())]
     nbins = np.prod(dim_sz)

--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -19,7 +19,6 @@ from mantid.api import WorkspaceUnitValidator
 from mantid.api import MatrixWorkspace
 
 from mslice.models.axis import Axis
-
 from mslice.util.mantid.algorithm_wrapper import add_to_ads
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, get_workspace_name, delete_workspace
 from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus, ConvertUnits, Rebose
@@ -281,15 +280,12 @@ def export_workspace_to_ads(workspace):
 
 
 def _save_single_ws(workspace, save_name, save_method, path, extension, slice_nonpsd):
-    slice = False
     save_as = save_name if save_name is not None else str(workspace) + extension
     full_path = os.path.join(str(path), save_as)
     workspace = get_workspace_handle(workspace)
-    non_psd_slice = slice_nonpsd and isinstance(workspace, Workspace) and not workspace.is_PSD
-    if is_pixel_workspace(workspace) or non_psd_slice:
-        slice = True
+    if workspace.is_slice:
         workspace = _get_slice_mdhisto(workspace, get_workspace_name(workspace))
-    save_method(workspace, full_path, slice)
+    save_method(workspace, full_path)
 
 
 def _get_slice_mdhisto(workspace, ws_name):
@@ -297,13 +293,13 @@ def _get_slice_mdhisto(workspace, ws_name):
     try:
         return get_workspace_handle('__' + ws_name)
     except KeyError:
-        x_axis = get_axis_from_dimension(workspace, ws_name, 0)
-        y_axis = get_axis_from_dimension(workspace, ws_name, 1)
+        x_axis = get_axis_from_dimension(workspace, 0)
+        y_axis = get_axis_from_dimension(workspace, 1)
         compute_slice(ws_name, x_axis, y_axis, False)
         return get_workspace_handle('__' + ws_name)
 
 
-def get_axis_from_dimension(workspace, ws_name, id):
+def get_axis_from_dimension(workspace, id):
     dim = workspace.raw_ws.getDimension(id).name
     min, max, step = workspace.limits[dim]
     return Axis(dim, min, max, step)

--- a/src/mslice/workspace/common_workspace_properties.py
+++ b/src/mslice/workspace/common_workspace_properties.py
@@ -12,3 +12,4 @@ class CommonWorkspaceProperties:
         self.e_mode = None
         self.limits = None
         self.e_fixed = None
+        self.is_slice: bool = False

--- a/tests/cli_helper_functions_test.py
+++ b/tests/cli_helper_functions_test.py
@@ -7,9 +7,9 @@ from mantid.simpleapi import (AddSampleLog, CreateSampleWorkspace, CreateMDHisto
 from unittest import mock
 from mslice.workspace import wrap_workspace
 from mslice.cli.helperfunctions import _string_to_axis, _string_to_integration_axis, _process_axis,\
-    _check_workspace_name, _check_workspace_type, _get_workspace_type, is_slice, is_cut, _get_overplot_key, _update_overplot_checklist, \
+    _check_workspace_name, _check_workspace_type, _get_workspace_type, is_cut, _get_overplot_key, _update_overplot_checklist, \
     _update_legend
-from mslice.cli._mslice_commands import Cut, Slice
+from mslice.cli._mslice_commands import Cut
 from mslice.models.axis import Axis
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
@@ -179,17 +179,6 @@ class CLIHelperFunctionsTest(unittest.TestCase):
 
         return_value = _get_workspace_type(workspace_histo)
         self.assertEqual(return_value, "HistogramWorkspace")
-
-    def test_that_is_slice_works_as_expected(self):
-        workspace = self.create_workspace('workspace')
-        slice_ws = Slice(workspace)
-        hist_ws = self.create_histo_workspace('hist_workspace')
-
-        return_value = is_slice(slice_ws)
-        self.assertEqual(return_value, True)
-
-        return_value = is_slice(hist_ws)
-        self.assertEqual(return_value, True)
 
     @mock.patch('mslice.cli._mslice_commands.is_gui')
     def test_that_is_cut_works_as_expected(self, is_gui):

--- a/tests/file_io_test.py
+++ b/tests/file_io_test.py
@@ -83,7 +83,7 @@ class FileIOTest(unittest.TestCase):
                                         NumberOfBins=2, Names='Dim1', Units="units", OutputWorkspace=ws_name)
         ws = HistogramWorkspace(raw_ws, ws_name)
         ws.axes = [Axis('DeltaE', 0, 1, 0.1), Axis('Q', 0, 2, 0.2)]
-        _save_cut_to_ascii(ws, ws_name, "some_path")
+        _save_cut_to_ascii(ws, "some_path")
         output_method.assert_called_once()
         self.assertEqual(output_method.call_args[0][0], 'some_path')
         np.testing.assert_array_equal(output_method.call_args[0][1], [[-1, 1, 4], [5, 2, 5]])

--- a/tests/slice_functions_test.py
+++ b/tests/slice_functions_test.py
@@ -43,6 +43,7 @@ class SliceFunctionsTest(unittest.TestCase):
         alg_mock.Slice = wrap_algorithm(_create_algorithm_function('Slice', 1, Slice()))
         plot = compute_slice('slice_functions_test_ws', self.q_axis, self.e_axis, False)
         self.assertEqual(plot.get_signal().shape, (30, 25))
+        self.assertTrue(plot.is_slice)
 
     @patch('mslice.models.slice.slice_functions.get_workspace_handle')
     def test_recoil_line(self, ws_handle_mock):

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -61,9 +61,9 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
             process_limits_event(self.pixel_workspace)
 
     def test_get_axis_from_dimension(self):
-        return_value = get_axis_from_dimension(self.pixel_workspace, self.pixel_workspace.name, 0)
+        return_value = get_axis_from_dimension(self.pixel_workspace, 0)
         self.assertEqual(return_value, Axis('|Q|', '0.1', '3.1', '0.1'))
-        return_value = get_axis_from_dimension(self.pixel_workspace, self.pixel_workspace.name, 1)
+        return_value = get_axis_from_dimension(self.pixel_workspace, 1)
         self.assertEqual(return_value, Axis('DeltaE', '-10.0', '15.0', '1.0'))
 
     def test_scale_workspaces_without_parameters(self):


### PR DESCRIPTION
**Description of work:**
This PR adds a flag `is_slice` to the common workspace properties class. This will provide us with a unified way for determining whether a workspace is a slice or not. Previously, the GUI and CLI used a different method for determining whether a workspace was a slice. I believe the CLI implementation was incorrect and therefore caused the error in the attached issue.

**To test:**
Follow the steps in the attached issue. There should be no error. The file should be saved as expected.

Fixes #907
