### PR TITLE
Remove square bracket in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mantid MSlice
 
 ## Build status
-[![Build Status](https://github.com/mantidproject/mslice/actions/workflows/unit_tests_nightly.yml/badge.svg)
+![Build Status](https://github.com/mantidproject/mslice/actions/workflows/unit_tests_nightly.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/mantidproject/mslice/badge.svg?branch=main)](https://coveralls.io/github/mantidproject/mslice?branch=main)
 
 ## Overview


### PR DESCRIPTION
**Description of work:**
This PR removes a square bracket that is not needed in the README. It can be seen on the README page:
![image](https://user-images.githubusercontent.com/40830825/237059917-154d7cb8-4ac6-4f36-818d-b43907fc02f3.png)


Note that the coverage badge should update after the next successful nightly run.

