### PR TITLE
Fix crash when plotting from workspace list

### DIFF
--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -156,7 +156,7 @@ class CutPlotterPresenter(PresenterUtility):
             self.plot_cut_from_workspace(workspace_name, plot_over)
             plot_over = True  # plot over if multiple workspaces selected
 
-    def plot_cut_from_workspace(self, workspace, plot_over=False, intensity_range=None):
+    def plot_cut_from_workspace(self, workspace, plot_over=False, intensity_range=(None, None)):
         workspace = get_workspace_handle(workspace)
         lines = plot_cut_impl(workspace, intensity_range=intensity_range, plot_over=plot_over)
         self.set_is_icut(False)

--- a/src/mslice/views/cut_plotter.py
+++ b/src/mslice/views/cut_plotter.py
@@ -28,7 +28,7 @@ def draw_interactive_cut(workspace):
 
 
 @plt.set_category(plt.CATEGORY_CUT)
-def plot_cut_impl(workspace, intensity_range=None, plot_over=False, legend=None, en_conversion=True):
+def plot_cut_impl(workspace, intensity_range, plot_over=False, legend=None, en_conversion=True):
     cur_fig = plt.gcf()
     axes = cur_fig.axes
     if len(axes) == 0:


### PR DESCRIPTION
**Description of work:**

#888 Removes a line which changes a `None` `intensity_range` value to `(None, None)`.

This PR effectively readds this functionality, by changing the default value passed as `intensity_range` to `(None, None`) rather than `None`. It does not make sense for the default value to cause a crash when it is not needed for anything else.

**To test:**

<!-- Instructions for testing. -->
Follow steps in #911

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #911
