### PR TITLE
Fix crash when changing intensity

### DIFF
--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -376,7 +376,7 @@ def _get_exp_info_using(raw_ws, get_exp_info):
 
 def propagate_properties(old_workspace, new_workspace):
     """Propagates MSlice only properties of workspaces, e.g. limits"""
-    properties = ['is_PSD', 'parent', 'intensity_corrected', 'axes', 'ef_defined', 'e_mode', 'limits', 'e_fixed']
+    properties = ['is_PSD', 'parent', 'intensity_corrected', 'axes', 'ef_defined', 'e_mode', 'limits', 'e_fixed', 'is_slice']
     for prop in properties:
         old_prop = getattr(old_workspace, prop)
         if old_prop:

--- a/src/mslice/workspace/workspace.py
+++ b/src/mslice/workspace/workspace.py
@@ -43,6 +43,7 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase, CommonWor
         new_ws.ef_defined = self.ef_defined
         new_ws.limits = self.limits
         new_ws.axes = self.axes
+        new_ws.is_slice = self.is_slice
         attribute_from_log(new_ws, mantid_ws)
         return new_ws
 


### PR DESCRIPTION
**Description of work:**

#908 adds a property `is_slice` to workspaces to differentiate between slices and cuts. When you perform a binary operation on an `mslice` workspace, this property was not passed onto the new resultant workspace and therefore lost.

This ultimately caused a crash when setting the intensity of a slice.

**To test:**
1) Plot a slice.
2) Change intensity to `chi`
3) Observe no crash

Fixes #916
