### PR TITLE
Add tolerance to axis step validation

### DIFF
--- a/src/mslice/cli/helperfunctions.py
+++ b/src/mslice/cli/helperfunctions.py
@@ -4,7 +4,7 @@ import logging
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.base import WorkspaceBase as Workspace
 from mslice.workspace.workspace import Workspace as MatrixWorkspace
-from mslice.models.alg_workspace_ops import get_axis_range, get_axis_step, get_available_axes
+from mslice.models.alg_workspace_ops import get_axis_range, get_available_axes
 from mslice.models.axis import Axis
 from mslice.models.workspacemanager.workspace_provider import workspace_exists
 from mslice.models.intensity_correction_algs import (compute_chi, compute_d2sigma,
@@ -78,10 +78,9 @@ def _process_axis(axis, fallback_index, input_workspace, string_function=_string
         axis = string_function(axis)
         if fallback_index != 0:
             return axis
-        x_step = get_axis_step(input_workspace, axis.units)
-        if axis.step < x_step:
-            logging.warning(f"The {axis.units} step provided ({axis.step:.4f}) is smaller than the data step in "
-                            f"the workspace ({x_step:.4f}). Please provide a larger {axis.units} step.")
+        validation_error = axis.validate_step_against_workspace(input_workspace)
+        if validation_error:
+            logging.warning(validation_error)
     elif axis in available_axes:
         range = get_axis_range(input_workspace, axis)
         range = list(map(float, range))

--- a/src/mslice/models/axis.py
+++ b/src/mslice/models/axis.py
@@ -1,4 +1,7 @@
 from mslice.models.units import EnergyUnits
+from mslice.models.alg_workspace_ops import get_axis_step
+
+STEP_TOLERANCE = 1e-5
 
 
 class Axis(object):
@@ -104,3 +107,9 @@ class Axis(object):
         if old_e_unit is not None and 'DeltaE' in self.units and old_e_unit != self._e_unit:
             # This means the axes had a different previous e_unit set so (start, end, step) should be rescaled
             self.start, self.step, self.end = new_e_unit.convert_from(old_e_unit, self.start, self.step, self.end)
+
+    def validate_step_against_workspace(self, workspace) -> str:
+        x_step = get_axis_step(workspace, self.units)
+        if self.step < x_step - STEP_TOLERANCE:
+            return f"The {self.units} step provided ({self.step:.4f}) is smaller than the data step in " \
+                   f"the workspace ({x_step:.4f}). Please provide a larger {self.units} step."

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from mslice.views.cut_plotter import plot_cut_impl, draw_interactive_cut, cut_figure_exists, get_current_plot
-from mslice.models.alg_workspace_ops import get_axis_step
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.labels import generate_legend
 from mslice.models.workspacemanager.workspace_algorithms import export_workspace_to_ads
@@ -93,12 +92,7 @@ class CutPlotterPresenter(PresenterUtility):
             plot_over = True
         cut.reset_integration_axis(cut.start, cut.end)
 
-        cut_axis = cut.cut_axis
-
-        x_step = get_axis_step(workspace, cut_axis.units)
-        if cut_axis.step < x_step:
-            return f"The {cut_axis.units} step provided ({cut_axis.step:.4f}) is smaller than the data step in " \
-                   f"the workspace ({x_step:.4f}). Please provide a larger {cut_axis.units} step."
+        return cut.cut_axis.validate_step_against_workspace(workspace)
 
     def save_cache(self, ax, cut, plot_over=False):
         # If plot over is True you want to save all plotted cuts for use by the cli


### PR DESCRIPTION
**Description of work:**

This PR adds a tolerance to axis step validation, preventing a warning bring triggered by precision errors.

I've taken the validation code inside of axis so I only have to define this tolerance in one place. Tests edited/moved to suit.

**To test:**

Run script in #912 

Fixes #912
