### PR TITLE
Fix crash when correcting GDOS intensity of pixel ws

### DIFF
--- a/src/mslice/workspace/histogram_workspace.py
+++ b/src/mslice/workspace/histogram_workspace.py
@@ -40,6 +40,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
         new_ws = HistogramWorkspace(ws, self.name)
         new_ws.is_PSD = self.is_PSD
         new_ws.axes = self.axes
+        new_ws.is_slice = self.is_slice
         return new_ws
 
     def convert_to_matrix(self):


### PR DESCRIPTION
**Description of work:**

As per a similar bug fix, this PR ensures that `is_slice` propagates on binary operations involving histogram workspaces.

This prevents a crash when correcting the intensity of a slice taken from a pixel workspace to `GDOS`.

This bug was introduced through this pr: https://github.com/mantidproject/mslice/pull/908

**To test:**
1) Load `HYS_63373_4pixel.nxspe`
2) Project, and plot as a slice
3) Take an `icut`.
4) Using the slice window, correct the intensity to `GDOS`.
5) Observe no crash.



