### PR TITLE
Correct error propagation in GDOS intensity correction

### DIFF
--- a/src/mslice/models/intensity_correction_algs.py
+++ b/src/mslice/models/intensity_correction_algs.py
@@ -234,7 +234,7 @@ def _reduce_bins_and_return_signal_error(slice_gdos, algorithm, cut_axis, int_ax
 def _reduce_bins_and_return_signal_error_PSD(slice_gdos, algorithm, int_axis, cut_axis_id, cut_slice_alignment):
     # PSD type workspace, just sum all the bins
     signal = np.nansum(slice_gdos.get_signal(), axis=cut_axis_id, keepdims=True)
-    error = np.nansum(np.sqrt(slice_gdos.get_variance()), cut_axis_id, keepdims=True)
+    error = np.sqrt(np.nansum(slice_gdos.get_variance(), cut_axis_id, keepdims=True))
     if not cut_slice_alignment:
         signal = signal.transpose()
         error = error.transpose()

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -228,7 +228,7 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
         if use_psd:
             integration_factor = int_axis.step if algorithm == 'Integration' else 1
             signal_result = np.nansum(selected_test_ws.get_signal(), int(rotated), keepdims=True) * integration_factor
-            error_result = np.nansum(selected_test_ws.get_error(), int(rotated), keepdims=True) * integration_factor
+            error_result = np.sqrt(np.nansum(selected_test_ws.get_variance(), int(rotated), keepdims=True)) * integration_factor
             shape_string = f'{signal_result.shape[1]},{signal_result.shape[0]}' if rotated else f'{signal_result.shape[0]},' \
                                                                                                 f'{signal_result.shape[1]}'
             self.assertEqual(shape_string, createMDHistoWorkspace_mock.call_args[1]['NumberOfBins'])


### PR DESCRIPTION
**Description of work:**

This corrects a bug where errors were simply being summed as if they were absolute. This is not the case, and they need to be added in quadrature.

https://docs.mantidproject.org/v3.7.2/concepts/ErrorPropagation.html

**To test:**

1). Plot a slice, take a cut where appropriate
2) Correct to GDOS
3) See smaller error bars.


