### PR TITLE
Stop storing GDOS cuts in ADS

### DIFF
--- a/src/mslice/models/intensity_correction_algs.py
+++ b/src/mslice/models/intensity_correction_algs.py
@@ -211,11 +211,10 @@ def _reduce_bins_along_int_axis(slice_gdos, algorithm, cut_axis, int_axis, cut_a
     units = f"{x_dim.getUnits()},{y_dim.getUnits()}"
 
     new_ws = CreateMDHistoWorkspace(Dimensionality=2, Extents=extents, SignalInput=signal, ErrorInput=error, NumberOfBins=no_of_bins,
-                                    Names=names, Units=units)
+                                    Names=names, Units=units, StoreInADS=False, OutputWorkspace=output_name)
 
     int_axis.step = 0
     new_ws.axes = (cut_axis, int_axis)
-    new_ws.name = output_name
     return new_ws
 
 


### PR DESCRIPTION
**Description of work:**

Currently, when correcting cuts with `GDOS`, the result is stored in the ADS. This PR corrects that.

**To test:**

1) Load `MAR21335_Ei60meV` dataset
2) Take a cut
3) Correct for GDOS
4) In the console run: `from mantid.api import AnalysisDataService as ADS; ADS.getObjectNames()`
5) See no objects stored in ADS.

