### PR TITLE
Temporary fix for failing MSlice nightly builds

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -31,9 +31,7 @@ runs:
   - name: Build package
     shell: bash -l {0}
     run: |
-      #mamba install conda=23.5.2
       conda activate build-env
-      #conda config --set anaconda_upload yes
-      conda config --set anaconda_upload no
+      conda config --set anaconda_upload yes
       conda build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       grep "Upload complete" upload.log

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -32,6 +32,7 @@ runs:
     shell: bash -l {0}
     run: |
       conda activate build-env
-      conda config --set anaconda_upload yes
+      #conda config --set anaconda_upload yes
+      conda config --set anaconda_upload no
       mamba build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       grep "Upload complete" upload.log

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,7 +24,7 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       conda create -n build-env python=3.8
       conda activate build-env
-      #mamba install conda=23.5.2#debug
+      mamba install conda=23.5.2#debug
       mamba install -c conda-forge mamba conda-build anaconda-client conda-verify
       conda config --add channels mantid
       conda config --add channels mantid/label/nightly

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,7 +24,6 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       conda create -n build-env python=3.8
       conda activate build-env
-      mamba install conda=23.5.2#debug
       mamba install -c conda-forge mamba conda-build anaconda-client conda-verify
       conda config --add channels mantid
       conda config --add channels mantid/label/nightly
@@ -32,9 +31,9 @@ runs:
   - name: Build package
     shell: bash -l {0}
     run: |
-      mamba install conda=23.5.2
+      #mamba install conda=23.5.2
       conda activate build-env
       #conda config --set anaconda_upload yes
       conda config --set anaconda_upload no
-      mamba build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
+      conda build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       grep "Upload complete" upload.log

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,6 +24,7 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       conda create -n build-env python=3.8
       conda activate build-env
+      mamba install conda=23.5.2
       mamba install -c conda-forge mamba conda-build anaconda-client conda-verify
       conda config --add channels mantid
       conda config --add channels mantid/label/nightly

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,7 +24,7 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       conda create -n build-env python=3.8
       conda activate build-env
-      mamba install conda=23.5.2
+      #mamba install conda=23.5.2#debug
       mamba install -c conda-forge mamba conda-build anaconda-client conda-verify
       conda config --add channels mantid
       conda config --add channels mantid/label/nightly
@@ -32,6 +32,7 @@ runs:
   - name: Build package
     shell: bash -l {0}
     run: |
+      mamba install conda=23.5.2
       conda activate build-env
       #conda config --set anaconda_upload yes
       conda config --set anaconda_upload no

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,11 +1,12 @@
 name: Deploy MSlice nightly
 
 on:
-  workflow_run:
-    workflows: ["MSlice nightly build"]
-    branches: [main]
-    types:
-      - completed
+  push
+#  workflow_run:
+#    workflows: ["MSlice nightly build"]
+##    branches: [main]
+#    types:
+#      - completed
 
 jobs:
   build_conda_and_upload:
@@ -19,14 +20,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+#          ref: main
 
       - name: Check for changes since last build
         run: |
           echo "recentCommits=$(test -z $(git log --since="yesterday" -1 --format=%h) && echo false || echo true)" >> $GITHUB_ENV
 
       - name: Setup Miniconda
-        if: ${{ env.recentCommits == 'true'}}
+        #if: ${{ env.recentCommits == 'true'}}
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
@@ -37,7 +38,7 @@ jobs:
           auto-activate-base: false
 
       - name: Build MSlice nightly conda package
-        if: ${{ env.recentCommits == 'true'}}
+        #if: ${{ env.recentCommits == 'true'}}
         uses: ./.github/actions/publish-package
         with:
           label: nightly

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,12 +1,11 @@
 name: Deploy MSlice nightly
 
 on:
-  push
-#  workflow_run:
-#    workflows: ["MSlice nightly build"]
-##    branches: [main]
-#    types:
-#      - completed
+  workflow_run:
+    workflows: ["MSlice nightly build"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build_conda_and_upload:
@@ -20,14 +19,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-#          ref: main
+          ref: main
 
       - name: Check for changes since last build
         run: |
           echo "recentCommits=$(test -z $(git log --since="yesterday" -1 --format=%h) && echo false || echo true)" >> $GITHUB_ENV
 
       - name: Setup Miniconda
-        #if: ${{ env.recentCommits == 'true'}}
+        if: ${{ env.recentCommits == 'true'}}
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
           miniforge-version: latest
@@ -38,7 +37,7 @@ jobs:
           auto-activate-base: false
 
       - name: Build MSlice nightly conda package
-        #if: ${{ env.recentCommits == 'true'}}
+        if: ${{ env.recentCommits == 'true'}}
         uses: ./.github/actions/publish-package
         with:
           label: nightly


### PR DESCRIPTION
**Description of work:**

Caused by a known bug in mamba the MSlice nightly builds started to fail recently: https://stackoverflow.com/questions/76847652/mamba-env-throws-attributeerror-namespace-object-has-no-attribute-func)

While we are waiting for a new mamba version with a fix for this I have replaced `mamba build` with `conda build`.

**To test:**

Check that there are no other changes than the one described above and observe that the last run of `Deploy MSlice nightly` with this branch was successful.

It would be useful to check `Deploy MSlice nightly` again the day after this PR was merged into main. 
