### PR TITLE
Propagate recoil and bragg line colors to script

### DIFF
--- a/src/mslice/cli/__init__.py
+++ b/src/mslice/cli/__init__.py
@@ -53,7 +53,7 @@ class MSliceAxes(Axes):
         _update_overplot_checklist(key)
         _update_legend()
 
-    def bragg(self, workspace, element=None, cif=None):
+    def bragg(self, workspace, element=None, cif=None, **kwargs):
         from mslice.app.presenters import get_cut_plotter_presenter, get_slice_plotter_presenter
         _check_workspace_name(workspace)
         workspace = get_workspace_handle(workspace)
@@ -62,9 +62,9 @@ class MSliceAxes(Axes):
 
         ws_type = _get_workspace_type(workspace)
         if ws_type == 'HistogramWorkspace':
-            get_cut_plotter_presenter().add_overplot_line(workspace.name, key, recoil=True, cif=None)
+            get_cut_plotter_presenter().add_overplot_line(workspace.name, key, recoil=True, cif=None, **kwargs)
         elif ws_type == 'MatrixWorkspace':
-            get_slice_plotter_presenter().add_overplot_line(workspace.name, key, recoil=False, cif=cif)
+            get_slice_plotter_presenter().add_overplot_line(workspace.name, key, recoil=False, cif=cif, **kwargs)
 
         _update_overplot_checklist(key)
         _update_legend()

--- a/src/mslice/cli/__init__.py
+++ b/src/mslice/cli/__init__.py
@@ -36,7 +36,7 @@ class MSliceAxes(Axes):
         else:
             return Axes.pcolormesh(self, *args, **kwargs)
 
-    def recoil(self, workspace, element=None, rmm=None):
+    def recoil(self, workspace, element=None, rmm=None, **kwargs):
         from mslice.app.presenters import get_slice_plotter_presenter
         _check_workspace_name(workspace)
         workspace = get_workspace_handle(workspace)
@@ -48,7 +48,7 @@ class MSliceAxes(Axes):
             plot_handler = GlobalFigureManager.get_active_figure().plot_handler
             plot_handler._arb_nuclei_rmm = rmm
 
-        get_slice_plotter_presenter().add_overplot_line(workspace.name, key, recoil=True, cif=None)
+        get_slice_plotter_presenter().add_overplot_line(workspace.name, key, recoil=True, cif=None, **kwargs)
 
         _update_overplot_checklist(key)
         _update_legend()

--- a/src/mslice/plotting/plot_window/overplot_interface.py
+++ b/src/mslice/plotting/plot_window/overplot_interface.py
@@ -71,8 +71,8 @@ def remove_line(line):
     plt.gca().lines.remove(line)
 
 
-def plot_overplot_line(x, y, key, recoil, cache):
-    color = OVERPLOT_COLORS[key] if key in OVERPLOT_COLORS else 'c'
+def plot_overplot_line(x, y, key, recoil, cache, **kwargs):
+    color = kwargs.get('color', OVERPLOT_COLORS.get(key, 'c'))
     if recoil:
         return overplot_line(x, y, color, get_recoil_label(key), cache.rotated)
     else:

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -186,7 +186,7 @@ class CutPlotterPresenter(PresenterUtility):
         return np.resize(np.array([10 ** adj_factor, 10 ** (-adj_factor), np.nan]), size) * datum
 
     def add_overplot_line(self, workspace_name, key, recoil, cif=None, e_is_logarithmic=None, datum=0,
-                          intensity_correction=IntensityType.SCATTERING_FUNCTION):
+                          intensity_correction=IntensityType.SCATTERING_FUNCTION, **kwargs):
         cache = self._cut_cache_dict[plt.gca()][0]
         if cache.rotated:
             warnings.warn("No Bragg peak found as cut has no |Q| dimension.")
@@ -209,7 +209,7 @@ class CutPlotterPresenter(PresenterUtility):
             else:
                 y = self._get_log_bragg_y_coords(len(y), BRAGG_SIZE_ON_AXES, datum)
 
-            self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache)
+            self._overplot_cache[key] = plot_overplot_line(x, y, key, recoil, cache, **kwargs)
         except (ValueError, IndexError):
             warnings.warn("No Bragg peak found.")
 

--- a/src/mslice/presenters/slice_plotter_presenter.py
+++ b/src/mslice/presenters/slice_plotter_presenter.py
@@ -93,14 +93,14 @@ class SlicePlotterPresenter(PresenterUtility):
             remove_line(line)
 
     def add_overplot_line(self, workspace_name, key, recoil, cif=None, y_has_logarithmic=None, datum=None,
-                          intensity_correction=None):
+                          intensity_correction=None, **kwargs):
         cache = self._slice_cache[workspace_name]
         if recoil:
             x, y = compute_recoil_line(workspace_name, cache.momentum_axis, key)
         else:
             x, y = compute_powder_line(workspace_name, cache.momentum_axis, key, cif_file=cif)
         y = convert_energy_to_meV(y, cache.energy_axis.e_unit)
-        cache.overplot_lines[key] = plot_overplot_line(x, y, key, recoil, cache)
+        cache.overplot_lines[key] = plot_overplot_line(x, y, key, recoil, cache, **kwargs)
 
     def validate_intensity(self, intensity_start, intensity_end):
         intensity_start = self._to_float(intensity_start)

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -97,6 +97,7 @@ def add_overplot_statements(script_lines, plot_handler):
     line_artists = ax.lines
 
     for line in line_artists:
+        color = line._color
         label = line._label
         if "nolegend" in label:
             continue
@@ -108,15 +109,15 @@ def add_overplot_statements(script_lines, plot_handler):
 
         if recoil:
             if element is None:
-                script_lines.append("ax.recoil(workspace='{}', rmm={})\n".format(plot_handler.ws_name, rmm))
+                script_lines.append(f"ax.recoil(workspace='{plot_handler.ws_name}', rmm={rmm}, color='{color}')\n")
             else:
-                script_lines.append("ax.recoil(workspace='{}', element='{}')\n".format(plot_handler.ws_name, element))
+                script_lines.append(f"ax.recoil(workspace='{plot_handler.ws_name}', element='{element}', color='{color}')\n")
         else:
             if cif is None:
-                script_lines.append("ax.bragg(workspace='{}', element='{}')\n".format(plot_handler.ws_name, element))
+                script_lines.append(f"ax.bragg(workspace='{plot_handler.ws_name}', element='{element}', color='{color}')\n")
 
             else:
-                script_lines.append("ax.bragg(workspace='{}', cif='{}')\n".format(plot_handler.ws_name, cif))
+                script_lines.append(f"ax.bragg(workspace='{plot_handler.ws_name}', cif='{cif}', color='{color}')\n")
 
 
 def add_cut_plot_statements(script_lines, plot_handler, ax):

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -179,32 +179,32 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
 
         add_overplot_statements(script_lines, plot_handler)
 
-        self.assertIn("ax.recoil(workspace='{}', element='{}')\n".format(workspace_name, "Hydrogen"), script_lines)
+        self.assertIn(f"ax.recoil(workspace='{workspace_name}', element='Hydrogen', color='C0')\n", script_lines)
 
     @mock.patch('mslice.cli._mslice_commands.GlobalFigureManager')
     def test_that_add_overplot_statements_works_as_expected_with_arbitrary_nuclei(self, gfm):
         plot_handler = gfm.get_active_figure().plot_handler
         plot_handler.add_mock_spec(SlicePlot)
         self.assign_slice_parameters(plot_handler)
-        plot_handler._canvas.figure.gca().lines = [Line2D([1, 2], [1, 2], label="Relative Mass 55")]
+        plot_handler._canvas.figure.gca().lines = [Line2D([1, 2], [1, 2], label="Relative Mass 55", color="red")]
         workspace_name = plot_handler.ws_name
         script_lines = []
 
         add_overplot_statements(script_lines, plot_handler)
 
-        self.assertIn("ax.recoil(workspace='{}', rmm={})\n".format(workspace_name, 55), script_lines)
+        self.assertIn(f"ax.recoil(workspace='{workspace_name}', rmm=55, color='red')\n", script_lines)
 
     @mock.patch('mslice.cli._mslice_commands.GlobalFigureManager')
     def test_that_add_overplot_statements_works_as_expected_with_bragg_peaks_elements(self, gfm):
         plot_handler = gfm.get_active_figure().plot_handler
         plot_handler.add_mock_spec(SlicePlot)
-        plot_handler._canvas.figure.gca().lines = [Line2D([1, 2], [1, 2], label="Tantalum")]
+        plot_handler._canvas.figure.gca().lines = [Line2D([1, 2], [1, 2], label="Tantalum", color="green")]
         workspace_name = plot_handler.ws_name
         script_lines = []
 
         add_overplot_statements(script_lines, plot_handler)
 
-        self.assertIn("ax.bragg(workspace='{}', element='{}')\n".format(workspace_name, "Tantalum"), script_lines)
+        self.assertIn(f"ax.bragg(workspace='{workspace_name}', element='Tantalum', color='green')\n", script_lines)
 
     @mock.patch('mslice.scripting.helperfunctions.add_plot_options')
     @mock.patch('mslice.scripting.helperfunctions.add_cut_lines')


### PR DESCRIPTION
**Description of work:**
This PR ensures the line colors of the bragg and recoil lines on a Cut and Slice plot get propagated to a generated plotting script.

**To test:**
Load data into mslice
Do a slice
Add a bragg peak and recoil line, and change the color
Generate a script to clipboard
Run the script in mantid
The colors should be propagated

Fixes #931
