### PR TITLE
Ensure filepath in generated script is raw string

### DIFF
--- a/src/mslice/scripting/__init__.py
+++ b/src/mslice/scripting/__init__.py
@@ -98,7 +98,7 @@ def get_algorithm_kwargs(algorithm, existing_ws_refs):
                 continue
             if algorithm.name() == "Load":
                 if prop.name() == "Filename":
-                    arguments += [f"{prop.name()}='{pval}'"]
+                    arguments += [f"{prop.name()}=r'{pval}'"]
                     continue
                 elif prop.name() == "LoaderName" or prop.name() == "LoaderVersion":
                     continue

--- a/tests/scripting_tests.py
+++ b/tests/scripting_tests.py
@@ -253,3 +253,18 @@ class ScriptingTest(unittest.TestCase):
         mock_clipboard.assert_called_once()
 
         self.assertEqual(fake_clipboard.text, fake_file.text)
+
+    def test_that_get_algorithm_kwargs_produces_raw_string_for_loaded_filename(self):
+        some_alg = mock.MagicMock()
+        some_alg.name.return_value = 'Load'
+
+        some_alg_prop = mock.MagicMock()
+        some_alg_prop.name.return_value = "Filename"
+        some_alg_prop.isDefault.return_value = False
+        some_alg_prop.value.return_value = "test_filename"
+
+        some_alg.getProperties.return_value = [some_alg_prop]
+
+        args, _ = get_algorithm_kwargs(some_alg, 'workspace_name')
+
+        self.assertEqual("Filename=r'test_filename'", args)


### PR DESCRIPTION
**Description of work:**

This prepends an `r` to the filepath string in generated scripts to ensure `\U` is not interpreted as unicode.

**To test:**

I've struggled to directly test this, as I cannot directly replicate the script that caused the issue. In my case, the generated filepath is separated by `/` not `\`.

Regardless, generated a few scripts of cut/slices from clipboard and test.


Fixes #932