### PR TITLE
Escape special characters in workspace name when renaming

### DIFF
--- a/src/mslice/workspace/histogram_workspace.py
+++ b/src/mslice/workspace/histogram_workspace.py
@@ -32,7 +32,7 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
     @WorkspaceMixin.name.setter
     def name(self, new_name: str):
         raw_name = str(self.raw_ws)
-        rename_workspace(raw_name, re.sub(rf"{self.name}\w*", new_name, raw_name))
+        rename_workspace(raw_name, re.sub(rf"{re.escape(self.name)}\w*", new_name, raw_name))
 
         self._name = new_name
 

--- a/src/mslice/workspace/pixel_workspace.py
+++ b/src/mslice/workspace/pixel_workspace.py
@@ -40,10 +40,10 @@ class PixelWorkspace(PixelMixin, WorkspaceOperatorMixin, WorkspaceMixin, Workspa
     def name(self, new_name: str):
         if self.raw_ws is not None:
             raw_name = str(self.raw_ws)
-            rename_workspace(raw_name, re.sub(rf"{self.name}\w*", new_name, raw_name))
+            rename_workspace(raw_name, re.sub(rf"{re.escape(self.name)}\w*", new_name, raw_name))
         elif self._histo_ws is not None:
             histo_name = str(self._histo_ws)
-            rename_workspace(histo_name, re.sub(rf"{self.name}\w*", new_name, histo_name))
+            rename_workspace(histo_name, re.sub(rf"{re.escape(self.name)}\w*", new_name, histo_name))
 
         self._name = new_name
 

--- a/src/mslice/workspace/workspace.py
+++ b/src/mslice/workspace/workspace.py
@@ -31,7 +31,7 @@ class Workspace(WorkspaceOperatorMixin, WorkspaceMixin, WorkspaceBase, CommonWor
     @WorkspaceMixin.name.setter
     def name(self, new_name: str):
         raw_name = str(self.raw_ws)
-        rename_workspace(raw_name, re.sub(rf"{self.name}\w*", new_name, raw_name))
+        rename_workspace(raw_name, re.sub(rf"{re.escape(self.name)}\w*", new_name, raw_name))
 
         self._name = new_name
 

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -35,6 +35,10 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
             # remove mslice tracking
             remove_workspace(self.workspace)
 
+    def test_rename_workspace_which_contains_special_character(self):
+        self.workspace.name = "specialcharacter)"
+        self.workspace.name = "secondname"
+
     def test_get_coordinates(self):
         expected = np.linspace(0, 100, 10)
         self.assertTrue((self.workspace.get_coordinates()['Dim1'] == expected).all())

--- a/tests/pixel_workspace_test.py
+++ b/tests/pixel_workspace_test.py
@@ -24,6 +24,10 @@ class PixelWorkspaceTest(unittest.TestCase):
         self.assertRaisesRegex(TypeError, "PixelWorkspace expected IMDEventWorkspace or HistogramWorkspace, got int",
                                lambda: PixelWorkspace(4, "WorkspaceName"))
 
+    def test_rename_workspace_which_contains_special_character(self):
+        self.workspace.name = "specialcharacter)"
+        self.workspace.name = "secondname"
+
     def test_get_coordinates(self):
         coords = self.workspace.get_coordinates()
         self.assertEqual(set(coords), {'|Q|', 'DeltaE'})

--- a/tests/workspace_test.py
+++ b/tests/workspace_test.py
@@ -101,6 +101,10 @@ class WorkspaceTest(BaseWorkspaceTest):
     def test_neg_workspace(self):
         self.check_neg_workspace()
 
+    def test_rename_workspace_which_contains_special_character(self):
+        self.workspace.name = "specialcharacter)"
+        self.workspace.name = "secondname"
+
     def test_add_list(self):
         list_to_add = np.linspace(0, 99, 100)
         result = self.workspace + list_to_add


### PR DESCRIPTION
**Description of work:**
This PR ensures we escape special characters when renaming workspaces. Previously, renaming a workspace containing a special character would cause an exception.

**To test:**
Load data
Rename the workspace to contain a `)` character
Attempt to rename the workspace a second time
There should be no exception and renaming the workspace should work.

Fixes #934 
