### PR TITLE
Fix out of bounds intensity range issue when plotting from cli

### DIFF
--- a/src/mslice/cli/_mslice_commands.py
+++ b/src/mslice/cli/_mslice_commands.py
@@ -275,7 +275,7 @@ def PlotCut(InputWorkspace, IntensityStart=0, IntensityEnd=0, PlotOver=False):
         raise RuntimeError("Incorrect workspace type.")
 
     if IntensityStart == 0 and IntensityEnd == 0:
-        intensity_range = None
+        intensity_range = (None, None)
     else:
         intensity_range = (IntensityStart, IntensityEnd)
     from mslice.app.presenters import cli_cut_plotter_presenter

--- a/tests/command_line_test.py
+++ b/tests/command_line_test.py
@@ -224,7 +224,7 @@ class CommandLineTest(unittest.TestCase):
         workspace = self.create_pixel_workspace('test_plot_cut_cli')
         cut = Cut(workspace)
         PlotCut(cut)
-        cpp.plot_cut_from_workspace.assert_called_once_with(cut, intensity_range=None, plot_over=False)
+        cpp.plot_cut_from_workspace.assert_called_once_with(cut, intensity_range=(None, None), plot_over=False)
 
     @mock.patch('mslice.cli._mslice_commands.is_gui')
     @mock.patch('mslice.app.presenters.cli_cut_plotter_presenter')
@@ -233,7 +233,7 @@ class CommandLineTest(unittest.TestCase):
         workspace = self.create_workspace('test_plot_cut_non_psd_cli')
         cut = Cut(workspace)
         PlotCut(cut)
-        cpp.plot_cut_from_workspace.assert_called_once_with(cut, intensity_range=None, plot_over=False)
+        cpp.plot_cut_from_workspace.assert_called_once_with(cut, intensity_range=(None, None), plot_over=False)
 
     @mock.patch('mantid.plots.axesfunctions.errorbar')
     @mock.patch('mslice.cli._mslice_commands.is_gui')


### PR DESCRIPTION
**Description of work:**

Intensity range should default as a tuple, but this was missed it one place. This PR fixes this.

**To test:**

Run this script: https://developer.mantidproject.org/Testing/DirectInelastic/MSliceTestGuide.html#the-command-line-interface

Fixes #933
