### PR TITLE
Fix save plot saving underlying ws rather than derived ws

### DIFF
--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -236,13 +236,12 @@ def scale_workspaces(workspaces, scale_factor=None, from_temp=None, to_temp=None
             propagate_properties(ws, result)
 
 
-def save_workspaces(workspaces, path, save_name, extension, slice_nonpsd=False):
+def save_workspaces(workspaces, path, save_name, extension):
     """
     :param workspaces: list of workspaces to save
     :param path: directory to save to
     :param save_name: name to save the file as (plus file extension). Pass none to use workspace name
     :param extension: file extension (such as .txt)
-    :param slice_nonpsd: whether the selection is in non_psd mode
     """
     if extension == '.nxs':
         save_method = save_nexus
@@ -265,7 +264,7 @@ def save_workspaces(workspaces, path, save_name, extension, slice_nonpsd=False):
         if len(save_names) != len(workspaces):
             save_names = [None] * len(workspaces)
     for workspace, save_name_single in zip(workspaces, save_names):
-        _save_single_ws(workspace, save_name_single, save_method, path, extension, slice_nonpsd)
+        _save_single_ws(workspace, save_name_single, save_method, path, extension)
 
 
 def export_workspace_to_ads(workspace):
@@ -279,11 +278,12 @@ def export_workspace_to_ads(workspace):
     add_to_ads(workspace)
 
 
-def _save_single_ws(workspace, save_name, save_method, path, extension, slice_nonpsd):
+def _save_single_ws(workspace, save_name, save_method, path, extension):
     save_as = save_name if save_name is not None else str(workspace) + extension
     full_path = os.path.join(str(path), save_as)
     workspace = get_workspace_handle(workspace)
-    if workspace.is_slice:
+    non_psd_slice = isinstance(workspace, Workspace) and not workspace.is_PSD
+    if is_pixel_workspace(workspace) or non_psd_slice:
         workspace = _get_slice_mdhisto(workspace, get_workspace_name(workspace))
     save_method(workspace, full_path)
 

--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -222,8 +222,7 @@ class PlotFigureManagerQT(QtCore.QObject):
             save_workspaces(workspaces,
                             file_path,
                             save_name,
-                            ext,
-                            slice_nonpsd=True)
+                            ext)
         except RuntimeError as e:
             if str(e) == "unrecognised file extension":
                 supported_image_types = list(

--- a/tests/file_io_test.py
+++ b/tests/file_io_test.py
@@ -112,4 +112,4 @@ class FileIOTest(unittest.TestCase):
         ConfigService.setString("defaultsave.directory", default_save_directory)
 
         rel_path = "datadir/filename.txt"
-        self.assertEqual(f"{default_save_directory}/{rel_path}", _to_absolute_path(rel_path))
+        self.assertEqual(join(default_save_directory, rel_path), _to_absolute_path(rel_path))


### PR DESCRIPTION
**Description of work:**

This rolls back some changes in #908.

The change of the if conditional to `is_slice` misses the fact that the workspace provided is actually the underlying workspace, which then needs to be converted to a derived workspace before saving.

I've removed the `slice_nonpsd` argument from `save_workspaces` and  `_save_single_ws` as in the only use in the current code it is fed a hardcoded argument as `True` (even though the default was `False`). It was also confusing for two reasons:
-  The workspace being saved could also be a `cut`
- In the `_save_single_ws` function there is the statement `non_psd_slice = slice_nonpsd and isinstance(workspace, Workspace) and not workspace.is_PSD`, which seems to imply inequivalence between `non_psd_slice` and `slice_nonpsd`.

I don't understand what this if statement is trying to check. So I've just rolled it back to what it was previously minus the redundant `slice_nonpsd` variable. Prehaps @mducle can advise so we can change it to something clearer: https://github.com/mantidproject/mslice/commit/b87a65235d98d1f765ca4c2ca78f2c05c95154e9

**Additionally**: I've snuck in a fix for a unit test that was failing on windows, but not our linux github runners.


**To test:**

- Load an initial dataset
- Plot any slice
- Using the save button on the slice plot, save the plot as ACII.
- Using `workbench`, load the initial dataset again, save this dataset as ASCII using the `SaveASCII` alg.
- Compare the two files to see that they are not the same anymore.


Fixes #927 
