### PR TITLE
Fix legend remaining turned off when Waterfall is clicked

### DIFF
--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -191,8 +191,10 @@ class CutPlot(IPlot):
                     handles_to_show.append(handles[i])
                     labels_to_show.append(line_data[i]['label'])
                 self._legends_visible[i] = line_data[i]['legend']
-        legend = axes.legend(handles_to_show, labels_to_show, fontsize='medium')  # add new legends
-        legend_set_draggable(legend, True)
+
+        if self._legends_shown:
+            legend = axes.legend(handles_to_show, labels_to_show, fontsize='medium')  # add new legends
+            legend_set_draggable(legend, True)
 
     def change_axis_scale(self, xy_config):
         current_axis = self._canvas.figure.gca()

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -178,19 +178,16 @@ class CutPlot(IPlot):
         handles_to_show = []
         handles, labels = axes.get_legend_handles_labels()
         if line_data is None:
-            i = 0
-            for handle, label in zip(handles, labels):
+            for i, (handle, label) in enumerate(zip(handles, labels)):
                 if self.legend_visible(i):
                     labels_to_show.append(label)
                     handles_to_show.append(handle)
-                i += 1
         else:
-            containers = axes.containers
-            for i in range(len(containers)):
-                if line_data[i]['legend']:
-                    handles_to_show.append(handles[i])
-                    labels_to_show.append(line_data[i]['label'])
-                self._legends_visible[i] = line_data[i]['legend']
+            for line, handle in zip(line_data, handles):
+                if line['legend']:
+                    handles_to_show.append(handle)
+                    labels_to_show.append(line['label'])
+            self._legends_visible = [line['legend'] for line in line_data]
 
         if self._legends_shown:
             legend = axes.legend(handles_to_show, labels_to_show, fontsize='medium')  # add new legends

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -85,7 +85,7 @@ class CutPlotTest(unittest.TestCase):
         self.cut_plot.update_legend.assert_called_once()
         self.cut_plot._canvas.draw.assert_called_once()
 
-    def test_update_legend(self):
+    def test_update_legend_legends_not_shown(self):
         line = Line2D([], [])
         self.axes.get_legend_handles_labels = MagicMock(return_value=([line], ['some_label']))
         self.cut_plot._legends_shown = False
@@ -93,6 +93,9 @@ class CutPlotTest(unittest.TestCase):
         self.assertTrue(self.cut_plot._legends_visible[0])
         self.axes.legend.assert_not_called()
 
+    def test_update_legend_legends_shown(self):
+        line = Line2D([], [])
+        self.axes.get_legend_handles_labels = MagicMock(return_value=([line], ['some_label']))
         self.cut_plot._legends_shown = True
         self.cut_plot.update_legend()
         self.assertTrue(self.cut_plot._legends_visible[0])

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -112,6 +112,8 @@ class CutPlotTest(unittest.TestCase):
         self.axes.get_legend_handles_labels = MagicMock(return_value=(
             [mock_line, another_mock_line], ['mock_label', 'another_mock_label']
         ))
+        self.cut_plot._legends_shown = True
+
         self.cut_plot.update_legend(line_data)
         self.assertEqual(self.cut_plot._legends_visible, [2, 0])
         self.axes.legend.assert_called_with([mock_line], ['visible_line_data_label'], fontsize=ANY)

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -88,6 +88,12 @@ class CutPlotTest(unittest.TestCase):
     def test_update_legend(self):
         line = Line2D([], [])
         self.axes.get_legend_handles_labels = MagicMock(return_value=([line], ['some_label']))
+        self.cut_plot._legends_shown = False
+        self.cut_plot.update_legend()
+        self.assertTrue(self.cut_plot._legends_visible[0])
+        self.axes.legend.assert_not_called()
+
+        self.cut_plot._legends_shown = True
         self.cut_plot.update_legend()
         self.assertTrue(self.cut_plot._legends_visible[0])
         self.axes.legend.assert_called_with([line], ['some_label'], fontsize=ANY)

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -103,13 +103,15 @@ class CutPlotTest(unittest.TestCase):
 
     def test_update_legend_with_line_data(self):
         line_data = [
-            {'shown': True, 'color': 'blue', 'style': '--', 'width': 1.5, 'marker': 'o', 'legend': 2, 'label': 'visible_line_data_label', 'error_bar': True},
-            {'shown': True, 'color': 'cyan', 'style': ':', 'width': 1.5, 'marker': 'o', 'legend': 0, 'label': 'non_visible_line_data_label', 'error_bar': True}
+            {'shown': True, 'legend': 2, 'label': 'visible_line_data_label'},
+            {'shown': True, 'legend': 0, 'label': 'non_visible_line_data_label'}
         ]
         mock_line = Line2D([], [])
         another_mock_line = Line2D([], [])
-        self.axes.get_legend_handles_labels = MagicMock(return_value=([mock_line, another_mock_line], ['mock_label', 'another_mock_label']))
 
+        self.axes.get_legend_handles_labels = MagicMock(return_value=(
+            [mock_line, another_mock_line], ['mock_label', 'another_mock_label']
+        ))
         self.cut_plot.update_legend(line_data)
         self.assertEqual(self.cut_plot._legends_visible, [2, 0])
         self.axes.legend.assert_called_with([mock_line], ['visible_line_data_label'], fontsize=ANY)

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -101,6 +101,19 @@ class CutPlotTest(unittest.TestCase):
         self.assertTrue(self.cut_plot._legends_visible[0])
         self.axes.legend.assert_called_with([line], ['some_label'], fontsize=ANY)
 
+    def test_update_legend_with_line_data(self):
+        line_data = [
+            {'shown': True, 'color': 'blue', 'style': '--', 'width': 1.5, 'marker': 'o', 'legend': 2, 'label': 'visible_line_data_label', 'error_bar': True},
+            {'shown': True, 'color': 'cyan', 'style': ':', 'width': 1.5, 'marker': 'o', 'legend': 0, 'label': 'non_visible_line_data_label', 'error_bar': True}
+        ]
+        mock_line = Line2D([], [])
+        another_mock_line = Line2D([], [])
+        self.axes.get_legend_handles_labels = MagicMock(return_value=([mock_line, another_mock_line], ['mock_label', 'another_mock_label']))
+
+        self.cut_plot.update_legend(line_data)
+        self.assertEqual(self.cut_plot._legends_visible, [2, 0])
+        self.axes.legend.assert_called_with([mock_line], ['visible_line_data_label'], fontsize=ANY)
+
     def test_waterfall(self):
         self.cut_plot._apply_offset = MagicMock()
         self.cut_plot.update_bragg_peaks = MagicMock()


### PR DESCRIPTION
### Summary of changes
- Introduced an if statement that checks a boolean flag on whether the legend is supposed to be shown or not.
- Edited the unit test of the changed function to include testing of both options, i.e. when legend is not shown and when legend is shown

## Description of Work
#### Finding the problem
- When the legends box is clicked, a `_toggle_legend` function is activated which sets the boolean attribute `_legends_shown` to its opposite
- The attribute `_legends_shown` of `CutPlot` is thus supposed to control whether or not the legend is visible in the plot.
- The `update_legend` function does not make use of the attribute `_legends_shown` in its scope, which leads to legends being shown even when `_legends_shown` is set to False.
- This behaviour is present in 3 scenarios on cut viewer, as all these instances call the function `update_legend`:
  - When Waterfall is clicked
  - When the Intensity is changed
  - When any line in the plot is clicked

#### Fixing the problem
- Introduced an `if` statement inside `update_legend`
- Same `if` statement is used in the analogous slice viewer

#### Edited unit test
- Introduced the new scenario of making sure `axes.legend()` is not called when `_legends_shown` is set to `False`.

## To test
- Open cut viewer in mslice and run over the 3 scenarios that were previously making the legend visible:
   - Click **Legend** so legends become invisible
   - Click **Waterfall** and check legends remain invisible
   - Click any plot line > cancel, and check legends remain invisible
   - Click **Intensity** > any intensity that works, and check legends remain invisible
 
- Comment out `if`` statement and run test `cut_plot_test.py`. It should fail the test `test_update_legend`. Restore `if` statement and check the test passes.

Fixes #863 .
