### PR TITLE
941 append scaling to ws name

### DIFF
--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -25,6 +25,7 @@ from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace
+from mslice.workspace.helperfunctions import WorkspaceNameAppender
 
 from .file_io import save_ascii, save_matlab, save_nexus, save_nxspe
 
@@ -198,18 +199,18 @@ def combine_workspace(selected_workspaces, new_name):
 
 
 def add_workspace_runs(selected_ws):
-    out_ws_name = selected_ws[0] + '_sum'
-    sum_ws = MergeRuns(OutputWorkspace=out_ws_name, InputWorkspaces=selected_ws)
+    sum_ws = MergeRuns(OutputWorkspace=WorkspaceNameAppender.sum(selected_ws[0]),
+                       InputWorkspaces=selected_ws)
     propagate_properties(get_workspace_handle(selected_ws[0]), sum_ws)
 
 
 def subtract(workspaces, background_ws, ssf):
-    scaled_bg_ws = Scale(OutputWorkspace=str(background_ws) + '_scaled',
+    scaled_bg_ws = Scale(OutputWorkspace=WorkspaceNameAppender.scale(str(background_ws), ssf),
                          InputWorkspace=str(background_ws), Factor=ssf, store=False)
     try:
         for ws_name in workspaces:
-            result = Minus(OutputWorkspace=ws_name + f'_subtracted_by_{ssf:.2f}', LHSWorkspace=ws_name,
-                           RHSWorkspace=scaled_bg_ws)
+            result = Minus(OutputWorkspace=WorkspaceNameAppender.subtract(ws_name, ssf),
+                           LHSWorkspace=ws_name, RHSWorkspace=scaled_bg_ws)
             propagate_properties(get_workspace_handle(ws_name), result)
     except ValueError as e:
         raise ValueError(e)
@@ -217,8 +218,8 @@ def subtract(workspaces, background_ws, ssf):
 
 def rebose_single(ws, from_temp, to_temp):
     ws = get_workspace_handle(ws)
-    results = Rebose(InputWorkspace=ws, CurrentTemperature=from_temp, TargetTemperature=to_temp,
-                     OutputWorkspace=ws.name+'_bosed')
+    results = Rebose(OutputWorkspace=WorkspaceNameAppender.rebose(ws.name),
+                     InputWorkspace=ws, CurrentTemperature=from_temp, TargetTemperature=to_temp)
     propagate_properties(ws, results)
     return results
 
@@ -232,7 +233,8 @@ def scale_workspaces(workspaces, scale_factor=None, from_temp=None, to_temp=None
     else:
         for ws_name in workspaces:
             ws = get_workspace_handle(ws_name)
-            result = Scale(InputWorkspace=ws.raw_ws, Factor=scale_factor, OutputWorkspace=ws_name+'_scaled')
+            result = Scale(OutputWorkspace=WorkspaceNameAppender.scale(ws_name, scale_factor),
+                           InputWorkspace=ws.raw_ws, Factor=scale_factor)
             propagate_properties(ws, result)
 
 

--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -208,7 +208,7 @@ def subtract(workspaces, background_ws, ssf):
                          InputWorkspace=str(background_ws), Factor=ssf, store=False)
     try:
         for ws_name in workspaces:
-            result = Minus(OutputWorkspace=ws_name + '_subtracted', LHSWorkspace=ws_name,
+            result = Minus(OutputWorkspace=ws_name + f'_subtracted_by_{ssf:.2f}', LHSWorkspace=ws_name,
                            RHSWorkspace=scaled_bg_ws)
             propagate_properties(get_workspace_handle(ws_name), result)
     except ValueError as e:

--- a/src/mslice/workspace/helperfunctions.py
+++ b/src/mslice/workspace/helperfunctions.py
@@ -116,3 +116,20 @@ class WrapWorkspaceAttribute(object):
         if self.workspace:
             self.workspace.remove_saved_attributes()
         return True
+
+
+class WorkspaceNameAppender:
+
+    def scale(ws_name: str, scaling_factor: float) -> str:
+        return ws_name + f"_ssf_{scaling_factor:.2f}"
+        # return ws_name + "_scaled"
+
+    def subtract(ws_name: str, scaling_factor: float) -> str:
+        return ws_name + f"_minus_ssf_{scaling_factor:.2f}"
+        # return ws_name + "_subtracted"
+
+    def sum(ws_name: str) -> str:
+        return ws_name + "_sum"
+
+    def rebose(ws_name: str) -> str:
+        return ws_name + "_bosed"

--- a/tests/workspace_provider_test.py
+++ b/tests/workspace_provider_test.py
@@ -13,6 +13,7 @@ from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresen
 from mslice.widgets.workspacemanager.command import Command
 from mantid.simpleapi import AddSampleLog
 from mslice.views.interfaces.workspace_view import WorkspaceView
+from mslice.workspace.helperfunctions import WorkspaceNameAppender
 
 
 class MantidWorkspaceProviderTest(unittest.TestCase):
@@ -44,16 +45,16 @@ class MantidWorkspaceProviderTest(unittest.TestCase):
 
     def test_subtract_workspace(self):
         subtract(['test_ws_2d'], 'test_ws_2d', 0.95)
-        result = get_workspace_handle('test_ws_2d_subtracted')
+        result = get_workspace_handle(WorkspaceNameAppender.subtract('test_ws_2d', 0.95))
         np.testing.assert_array_almost_equal(result.raw_ws.dataY(0), [0.05] * 20)
         np.testing.assert_array_almost_equal(self.test_ws_2d.raw_ws.dataY(0), [1] * 20)
-        self.assertFalse('test_ws_2d_scaled' in get_visible_workspace_names())
+        self.assertFalse(WorkspaceNameAppender.scale('test_ws_2d', 0.95) in get_visible_workspace_names())
         self.assertRaises(ValueError, subtract, ['test_ws_2d'], 'test_ws_md', 1.0)
 
     def test_add_workspace(self):
         original_data = self.test_ws_2d.raw_ws.dataY(0)
         add_workspace_runs(['test_ws_2d', 'test_ws_2d'])
-        result = get_workspace_handle('test_ws_2d_sum')
+        result = get_workspace_handle(WorkspaceNameAppender.sum('test_ws_2d'))
         np.testing.assert_array_almost_equal(result.raw_ws.dataY(0), [2.0] * 20)
         np.testing.assert_array_almost_equal(original_data, [1] * 20)
 


### PR DESCRIPTION
**Summary**
- Created new class that returns name of workspaces for the operations of add, subtract, rebose and scale
- Updated tests with new class, so any changes to naming conventions will not have tests failing

**Description of work:**
- The main observable change is the new format of naming workspaces after subtraction
- Instead of the suffix `_subtracted`, I changed it to include the scaling factor of the background workspace to `_minus_ssf_0.95`, as seen in:
- 
![image](https://github.com/mantidproject/mslice/assets/80104863/151b1a71-e3d5-45d4-a13a-29e72068d210)
- Also altered the scaling suffix to match new naming convention

**Question**
- I altered the tests so that the new class I introduced gets imported into the test and the correct name of the workspace is always used.
- This means that if this class gets changed to include a different naming convention, the tests will continue to pass.
- Is this good practice or should I hard-code the workspace name string into the tests?

**To test:**
- In the workspace manager, load a workspace and try the arithmetic operations:
  - Scale
  - Subtract
  - Rebose
  - Sum
- Give your opinion on whether the naming convention I implemented makes sense
- Look at the new class `WorkspaceNameAppender` and tell me if it's fine (maybe needs an initializer method?)
- Look at the location of the new class (under `workspaces.helperfunctions`), is it the best location or should I move somewhere else?

Fixes #941 .
