### PR TITLE
956 data in cut plot distorted after ticking and unticking log scale in x axis

### DIFF
--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -644,7 +644,7 @@ class CutPlot(IPlot):
             current_axis.set_yscale('linear')
 
         if value:
-            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            xdata = [line.get_xdata() for line in current_axis.get_lines()]
             x_axis_min = get_min(xdata, absolute_minimum=0.)
             linthresh_val = pow(10, np.floor(np.log10(x_axis_min)))
 
@@ -672,7 +672,7 @@ class CutPlot(IPlot):
             current_axis.set_xscale('linear')
 
         if value:
-            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
+            ydata = [line.get_ydata() for line in current_axis.get_lines()]
             y_axis_min = get_min(ydata, absolute_minimum=0.)
             linthresh_val = pow(10, np.floor(np.log10(y_axis_min)))
 

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -33,7 +33,7 @@ DEFAULT_FONT_SIZE_STEP = 1
 
 
 def _gca_sym_log_linear_threshold(axis_data):
-    axis_data = np.array(axis_data)
+    axis_data = np.concatenate(axis_data)
     axis_min = np.min(axis_data[axis_data > 0])
     linthresh = pow(10, np.floor(np.log10(axis_min)))
     return linthresh

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -680,7 +680,7 @@ class CutPlot(IPlot):
         else:
             current_axis.set_yscale('linear')
 
-        if value or (value != orig_y_log):
+        if value != orig_y_log:
             self.update_bragg_peaks(refresh=True)
 
     @property

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -764,7 +764,6 @@ class CutPlot(IPlot):
     def x_range_font_size(self, font_size):
         self.manager.x_range_font_size = font_size
 
-
     @property
     def y_range_font_size(self):
         return self.manager.y_range_font_size

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -644,10 +644,7 @@ class CutPlot(IPlot):
             current_axis.set_yscale('linear')
 
         if value:
-            xdata = [line.get_xdata() for line in current_axis.get_lines()]
-            x_axis_min = get_min(xdata, absolute_minimum=0.)
-            linthresh_val = pow(10, np.floor(np.log10(x_axis_min)))
-
+            linthresh_val = self._gca_sym_log_linear_threshold()
             current_axis.set_xscale('symlog', linthresh=linthresh_val)
         else:
             current_axis.set_xscale('linear')
@@ -672,16 +669,20 @@ class CutPlot(IPlot):
             current_axis.set_xscale('linear')
 
         if value:
-            ydata = [line.get_ydata() for line in current_axis.get_lines()]
-            y_axis_min = get_min(ydata, absolute_minimum=0.)
-            linthresh_val = pow(10, np.floor(np.log10(y_axis_min)))
-
+            linthresh_val = self._gca_sym_log_linear_threshold()
             current_axis.set_yscale('symlog', linthresh=linthresh_val)
         else:
             current_axis.set_yscale('linear')
 
         if value != orig_y_log:
             self.update_bragg_peaks(refresh=True)
+
+    def _gca_sym_log_linear_threshold(self):
+        current_axis = self._canvas.figure.gca()
+        data = [line.get_ydata() for line in current_axis.get_lines()]
+        axis_min = get_min(data, absolute_minimum=0.)
+        linthresh = pow(10, np.floor(np.log10(axis_min)))
+        return linthresh
 
     @property
     def y_range(self):

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -201,41 +201,6 @@ class CutPlot(IPlot):
             legend = axes.legend(handles_to_show, labels_to_show, fontsize='medium')  # add new legends
             legend_set_draggable(legend, True)
 
-    def change_axis_scale(self, xy_config):
-        current_axis = self._canvas.figure.gca()
-        orig_y_scale_log = self.y_log
-        if xy_config['x_log']:
-            xmin = xy_config['x_range'][0]
-            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
-            self.x_axis_min = get_min(xdata, absolute_minimum=0.)
-            linthresh_val = pow(10, np.floor(np.log10(self.x_axis_min)))
-
-            kwargs = {'linthresh': linthresh_val}
-            current_axis.set_xscale('symlog', **kwargs)
-
-            if xmin > 0:
-                xy_config['x_range'] = (xmin, xy_config['x_range'][1])
-        else:
-            current_axis.set_xscale('linear')
-        if xy_config['y_log']:
-            ymin = xy_config['y_range'][0]
-            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
-            self.y_axis_min = get_min(ydata, absolute_minimum=0.)
-            linthresh_val = pow(10, np.floor(np.log10(self.y_axis_min)))
-
-            kwargs = {'linthresh': linthresh_val}
-            current_axis.set_yscale('symlog', **kwargs)
-
-            if ymin > 0:
-                xy_config['y_range'] = (ymin, xy_config['y_range'][1])
-        else:
-            current_axis.set_yscale('linear')
-        self.x_range = xy_config['x_range']
-        self.y_range = xy_config['y_range']
-
-        if xy_config['y_log'] or (xy_config['y_log'] != orig_y_scale_log):
-            self.update_bragg_peaks(refresh=True)
-
     def get_line_options(self, line):
         index = self._get_line_index(line)
         if index >= 0:
@@ -676,10 +641,27 @@ class CutPlot(IPlot):
 
     @x_log.setter
     def x_log(self, value):
-        config = self.xy_config()
-        config['x_log'] = value
-        self.change_axis_scale(config)
-        self._canvas.draw()
+        current_axis = self._canvas.figure.gca()
+        if not self.y_log:
+            # Fixes bug where setting xscale from log to linear distorts plot data
+            current_axis.set_yscale('linear')
+
+        if value:
+            xdata = [ll.get_xdata() for ll in current_axis.get_lines()]
+            x_axis_min = get_min(xdata, absolute_minimum=0.)
+            linthresh_val = pow(10, np.floor(np.log10(x_axis_min)))
+
+            current_axis.set_xscale('symlog', linthresh=linthresh_val)
+        else:
+            current_axis.set_xscale('linear')
+
+    @property
+    def x_range(self):
+        return self.manager.x_range
+
+    @x_range.setter
+    def x_range(self, value):
+        self.manager.x_range = value
 
     @property
     def y_log(self):
@@ -687,10 +669,30 @@ class CutPlot(IPlot):
 
     @y_log.setter
     def y_log(self, value):
-        config = self.xy_config()
-        config['y_log'] = value
-        self.change_axis_scale(config)
-        self._canvas.draw()
+        orig_y_scale_log = self.y_log
+        current_axis = self._canvas.figure.gca()
+        if not self.x_log:
+            current_axis.set_xscale('linear')
+
+        if value:
+            ydata = [ll.get_ydata() for ll in current_axis.get_lines()]
+            y_axis_min = get_min(ydata, absolute_minimum=0.)
+            linthresh_val = pow(10, np.floor(np.log10(y_axis_min)))
+
+            current_axis.set_yscale('symlog', linthresh=linthresh_val)
+        else:
+            current_axis.set_yscale('linear')
+
+        if value or (value != orig_y_scale_log):
+            self.update_bragg_peaks(refresh=True)
+
+    @property
+    def y_range(self):
+        return self.manager.y_range
+
+    @y_range.setter
+    def y_range(self, value):
+        self.manager.y_range = value
 
     @property
     def show_legends(self):
@@ -758,14 +760,6 @@ class CutPlot(IPlot):
         self.manager.y_label_size = value
 
     @property
-    def x_range(self):
-        return self.manager.x_range
-
-    @x_range.setter
-    def x_range(self, value):
-        self.manager.x_range = value
-
-    @property
     def x_range_font_size(self):
         return self.manager.x_range_font_size
 
@@ -773,13 +767,6 @@ class CutPlot(IPlot):
     def x_range_font_size(self, font_size):
         self.manager.x_range_font_size = font_size
 
-    @property
-    def y_range(self):
-        return self.manager.y_range
-
-    @y_range.setter
-    def y_range(self, value):
-        self.manager.y_range = value
 
     @property
     def y_range_font_size(self):

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -410,9 +410,6 @@ class CutPlot(IPlot):
         bounds['x_label'] = fig_y * 0.05
         return bounds
 
-    def xy_config(self):
-        return {'x_log': self.x_log, 'y_log': self.y_log, 'x_range': self.x_range, 'y_range': self.y_range}
-
     def legend_visible(self, index: int) -> bool:
         try:
             v = self._legends_visible[index]
@@ -669,7 +666,7 @@ class CutPlot(IPlot):
 
     @y_log.setter
     def y_log(self, value):
-        orig_y_scale_log = self.y_log
+        orig_y_log = self.y_log
         current_axis = self._canvas.figure.gca()
         if not self.x_log:
             current_axis.set_xscale('linear')
@@ -683,7 +680,7 @@ class CutPlot(IPlot):
         else:
             current_axis.set_yscale('linear')
 
-        if value or (value != orig_y_scale_log):
+        if value or (value != orig_y_log):
             self.update_bragg_peaks(refresh=True)
 
     @property

--- a/src/mslice/presenters/plot_options_presenter.py
+++ b/src/mslice/presenters/plot_options_presenter.py
@@ -8,18 +8,18 @@ class PlotOptionsPresenter(object):
         self._model = plot_handler
         self._view = plot_options_dialog
         self._modified_values = {}
-        self._xy_config = {'x_range': self._model.x_range, 'y_range': self._model.y_range, 'modified': False}
         self._default_font_sizes_config = {}
 
-        self.set_properties()  # propagate dialog with existing data
+        self.set_properties()  # Propagate dialog with existing data
 
         self._view.titleEdited.connect(partial(self._value_modified, 'title'))
         self._view.xLabelEdited.connect(partial(self._value_modified, 'x_label'))
         self._view.yLabelEdited.connect(partial(self._value_modified, 'y_label'))
-        self._view.xRangeEdited.connect(partial(self._xy_config_modified, 'x_range'))
-        self._view.yRangeEdited.connect(partial(self._xy_config_modified, 'y_range'))
+        self._view.xRangeEdited.connect(partial(self._value_modified, 'x_range'))
+        self._view.yRangeEdited.connect(partial(self._value_modified, 'y_range'))
         self._view.xGridEdited.connect(partial(self._value_modified, 'x_grid'))
         self._view.yGridEdited.connect(partial(self._value_modified, 'y_grid'))
+
         self._view.allFontSizeFromEmptyToValue.connect(self._update_font_sizes_buffer)
         self._view.allFontSizeEdited.connect(self._set_all_plot_fonts)
         self._view.fontSizeUpClicked.connect(self._model.increase_all_fonts)
@@ -29,10 +29,6 @@ class PlotOptionsPresenter(object):
 
     def _value_modified(self, value_name):
         self._modified_values[value_name] = getattr(self._view, value_name)
-
-    def _xy_config_modified(self, key):
-        getattr(self, '_xy_config')[key] = getattr(self._view, key)
-        self._xy_config['modified'] = True
 
     def _update_font_sizes_buffer(self):
         self._default_font_sizes_config = self._model.all_fonts_size.copy()
@@ -84,8 +80,6 @@ class SlicePlotOptionsPresenter(PlotOptionsPresenter):
             self._model.change_axis_scale(self._color_config['c_range'], self._color_config['log'])
         for key, value in list(self._modified_values.items()):
             setattr(self._model, key, value)
-        self._model.x_range = self._xy_config['x_range']
-        self._model.y_range = self._xy_config['y_range']
 
     def _set_c_range(self):
         self._color_config['c_range'] = self._view.colorbar_range
@@ -100,11 +94,10 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
 
     def __init__(self, plot_options_dialog, cut_handler):
         super(CutPlotOptionsPresenter, self).__init__(plot_options_dialog, cut_handler)
-        self._xy_config.update({'x_log': self._model.x_log, 'y_log': self._model.y_log})
 
         self._view.showLegendsEdited.connect(partial(self._value_modified, 'show_legends'))
-        self._view.xLogEdited.connect(partial(self._xy_config_modified, 'x_log'))
-        self._view.yLogEdited.connect(partial(self._xy_config_modified, 'y_log'))
+        self._view.xLogEdited.connect(partial(self._value_modified, 'x_log'))
+        self._view.yLogEdited.connect(partial(self._value_modified, 'y_log'))
         self._view.removed_line.connect(self.remove_container)
 
         line_options = self._model.get_all_line_options()
@@ -126,8 +119,6 @@ class CutPlotOptionsPresenter(PlotOptionsPresenter):
         current_show_legends = getattr(self._model, 'show_legends')
         new_show_legends = current_show_legends
 
-        if self._xy_config['modified']:
-            self._model.change_axis_scale(self._xy_config)
         for key, value in list(self._modified_values.items()):
             if key == 'show_legends':
                 new_show_legends = value

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import unittest
 
 from matplotlib.lines import Line2D
-from mslice.plotting.plot_window.cut_plot import CutPlot, get_min
+from mslice.plotting.plot_window.cut_plot import CutPlot, _gca_sym_log_linear_threshold
 
 
 class CutPlotTest(unittest.TestCase):
@@ -29,10 +29,11 @@ class CutPlotTest(unittest.TestCase):
         self.assertEqual(self.cut_plot.is_changed('y_grid'), False)
         self.assertEqual(self.cut_plot.is_changed('x_grid'), True)
 
-    def test_get_min(self):
-        data = [np.array([3, 6, 10]), np.array([3, 2, 7])]
-        self.assertEqual(get_min(data), 2)
-        self.assertEqual(get_min(data, 4), 6)
+    def tests_gca_sym_log_linear_threshold(self):
+        self.assertEqual(_gca_sym_log_linear_threshold([np.array([20, 60, 12])]), 10)
+        self.assertEqual(_gca_sym_log_linear_threshold([np.array([1, 5, 10])]), 1)
+        self.assertEqual(_gca_sym_log_linear_threshold([np.array([-1, 5, -10])]), 1)
+        self.assertEqual(_gca_sym_log_linear_threshold([np.array([300, 500, 1000])]), 100)
 
     @patch.object(CutPlot, 'y_log', PropertyMock(return_value=False))
     def test_change_x_scale_linear(self):
@@ -59,6 +60,7 @@ class CutPlotTest(unittest.TestCase):
         self.axes.get_lines = MagicMock(return_value=[line])
         self.cut_plot.x_log = True
         self.axes.set_yscale.assert_called_with('linear')
+        self.axes.set_xscale.assert_called_once()
         self.axes.set_xscale.assert_called_once_with('symlog', linthresh=10.0)
 
     @patch.object(CutPlot, 'x_log', PropertyMock(return_value=False))

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -34,41 +34,45 @@ class CutPlotTest(unittest.TestCase):
         self.assertEqual(get_min(data), 2)
         self.assertEqual(get_min(data, 4), 6)
 
-    def test_change_scale_linear(self):
+    @patch.object(CutPlot, 'y_log', PropertyMock(return_value=False))
+    def test_change_x_scale_linear(self):
         self.axes.set_xscale = MagicMock()
         self.axes.set_yscale = MagicMock()
-        type(self.cut_plot).y_log = PropertyMock(return_value=False)
         self.cut_plot.x_log = False
         self.axes.set_xscale.assert_called_with('linear')
         self.axes.set_yscale.assert_called_with('linear')
 
+    @patch.object(CutPlot, 'x_log', PropertyMock(return_value=False))
+    def test_change_y_scale_linear(self):
+        self.axes.set_xscale = MagicMock()
+        self.axes.set_yscale = MagicMock()
+        self.cut_plot.y_log = False
+        self.axes.set_xscale.assert_called_with('linear')
+        self.axes.set_yscale.assert_called_with('linear')
+
+    @patch.object(CutPlot, 'y_log', PropertyMock(return_value=False))
     def test_change_x_scale_log(self):
         self.axes.set_xscale = MagicMock()
         self.axes.set_yscale = MagicMock()
-        type(self.cut_plot).y_log = PropertyMock(return_value=False)
         line = MagicMock()
         line.get_xdata = MagicMock(return_value=np.array([20, 60, 12]))
         self.axes.get_lines = MagicMock(return_value=[line])
         self.cut_plot.x_log = True
-
         self.axes.set_yscale.assert_called_with('linear')
         self.axes.set_xscale.assert_called_once_with('symlog', linthresh=10.0)
 
-    # Currently failing, although it's the mirror version of the above
-    # def test_change_y_scale_log(self):
-    #     self.axes.set_xscale = MagicMock()
-    #     self.axes.set_yscale = MagicMock()
-    #     type(self.cut_plot).x_log = PropertyMock(return_value=False)
-    #     line = MagicMock()
-    #     line.get_ydata = MagicMock(return_value=np.array([1, 5, 10]))
-    #     self.axes.get_lines = MagicMock(return_value=[line])
-    #     self.cut_plot.update_bragg_peaks = MagicMock()
-    #
-    #     self.cut_plot.y_log = True
-    #
-    #     self.axes.set_xscale.assert_called_with('linear')
-    #     self.axes.set_yscale.assert_called_once_with('symlog', linthresh=1.0)
-    #     self.cut_plot.update_bragg_peaks.assert_called_once_with(refresh=True)
+    @patch.object(CutPlot, 'x_log', PropertyMock(return_value=False))
+    def test_change_y_scale_log(self):
+        self.axes.set_xscale = MagicMock()
+        self.axes.set_yscale = MagicMock()
+        line = MagicMock()
+        line.get_ydata = MagicMock(return_value=np.array([1, 5, 10]))
+        self.axes.get_lines = MagicMock(return_value=[line])
+        self.cut_plot.update_bragg_peaks = MagicMock()
+        self.cut_plot.y_log = True
+        self.axes.set_xscale.assert_called_with('linear')
+        self.axes.set_yscale.assert_called_once_with('symlog', linthresh=1.0)
+        self.cut_plot.update_bragg_peaks.assert_called_once_with(refresh=True)
 
     @patch('mslice.plotting.plot_window.cut_plot.quick_options')
     def test_line_clicked(self, quick_options_mock):

--- a/tests/cut_plot_test.py
+++ b/tests/cut_plot_test.py
@@ -1,4 +1,4 @@
-from mock import MagicMock, patch, ANY
+from mock import MagicMock, PropertyMock, patch, ANY
 import numpy as np
 import unittest
 
@@ -37,33 +37,38 @@ class CutPlotTest(unittest.TestCase):
     def test_change_scale_linear(self):
         self.axes.set_xscale = MagicMock()
         self.axes.set_yscale = MagicMock()
-        xy_config = {'x_log': False, 'y_log': False, 'x_range': (0, 10), 'y_range': (1, 7)}
+        type(self.cut_plot).y_log = PropertyMock(return_value=False)
+        self.cut_plot.x_log = False
+        self.axes.set_xscale.assert_called_with('linear')
+        self.axes.set_yscale.assert_called_with('linear')
 
-        self.cut_plot.change_axis_scale(xy_config)
-        self.axes.set_xscale.assert_called_once_with('linear')
-        self.axes.set_yscale.assert_called_once_with('linear')
-        self.assertEqual(self.cut_plot.x_range, (0, 10))
-        self.assertEqual(self.cut_plot.y_range, (1, 7))
-
-    def test_change_scale_log(self):
-        self.cut_plot.save_default_options()
+    def test_change_x_scale_log(self):
         self.axes.set_xscale = MagicMock()
         self.axes.set_yscale = MagicMock()
+        type(self.cut_plot).y_log = PropertyMock(return_value=False)
         line = MagicMock()
-        line.get_ydata = MagicMock(return_value=np.array([1, 5, 10]))
         line.get_xdata = MagicMock(return_value=np.array([20, 60, 12]))
         self.axes.get_lines = MagicMock(return_value=[line])
-        self.canvas.figure.gca = MagicMock(return_value=self.axes)
-        xy_config = {'x_log': True, 'y_log': True, 'x_range': (0, 20), 'y_range': (1, 7)}
-        self.cut_plot.update_bragg_peaks = MagicMock()
-        self.cut_plot.change_axis_scale(xy_config)
+        self.cut_plot.x_log = True
 
+        self.axes.set_yscale.assert_called_with('linear')
         self.axes.set_xscale.assert_called_once_with('symlog', linthresh=10.0)
-        self.axes.set_yscale.assert_called_once_with('symlog', linthresh=1.0)
 
-        self.cut_plot.update_bragg_peaks.assert_called_once_with(refresh=True)
-        self.assertEqual(self.cut_plot.x_range, (0, 20))
-        self.assertEqual(self.cut_plot.y_range, (1, 7))
+    # Currently failing, although it's the mirror version of the above
+    # def test_change_y_scale_log(self):
+    #     self.axes.set_xscale = MagicMock()
+    #     self.axes.set_yscale = MagicMock()
+    #     type(self.cut_plot).x_log = PropertyMock(return_value=False)
+    #     line = MagicMock()
+    #     line.get_ydata = MagicMock(return_value=np.array([1, 5, 10]))
+    #     self.axes.get_lines = MagicMock(return_value=[line])
+    #     self.cut_plot.update_bragg_peaks = MagicMock()
+    #
+    #     self.cut_plot.y_log = True
+    #
+    #     self.axes.set_xscale.assert_called_with('linear')
+    #     self.axes.set_yscale.assert_called_once_with('symlog', linthresh=1.0)
+    #     self.cut_plot.update_bragg_peaks.assert_called_once_with(refresh=True)
 
     @patch('mslice.plotting.plot_window.cut_plot.quick_options')
     def test_line_clicked(self, quick_options_mock):

--- a/tests/plot_options_presenter_test.py
+++ b/tests/plot_options_presenter_test.py
@@ -122,15 +122,17 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         # passed view -> model through slice presenter
         model_x_range_mock.reset_mock()
         view_x_range_mock.return_value = (2, 10)
-        self.presenter1._xy_config_modified('x_range')
+        self.presenter1._value_modified('x_range')
         self.presenter1.get_new_config()
         model_x_range_mock.assert_called_once_with((2, 10))
 
         # passed view -> model through cut presenter
+        model_x_range_mock.reset_mock()
+        view_x_range_mock.return_value = (3, 11)
         self.presenter2 = CutPlotOptionsPresenter(self.view, self.model)
-        self.presenter2._xy_config_modified('x_range')
+        self.presenter2._value_modified('x_range')
         self.presenter2.get_new_config()
-        self.model.change_axis_scale.assert_called_once()
+        model_x_range_mock.assert_called_with((3, 11))
 
     def test_change_colorbar_config(self):
         view_colorbar_range_mock = PropertyMock()
@@ -164,14 +166,10 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         view_y_log_mock = PropertyMock()
         model_x_log_mock = PropertyMock(return_value=True)
         model_y_log_mock = PropertyMock(return_value=False)
-        model_x_range_mock = PropertyMock(return_value=(1, 2))
-        model_y_range_mock = PropertyMock(return_value=(3, 4))
         type(self.view).x_log = view_x_log_mock
         type(self.view).y_log = view_y_log_mock
         type(self.model).x_log = model_x_log_mock
         type(self.model).y_log = model_y_log_mock
-        type(self.model).x_range = model_x_range_mock
-        type(self.model).y_range = model_y_range_mock
 
         # model -> view
         self.presenter = CutPlotOptionsPresenter(self.view, self.model)
@@ -181,11 +179,11 @@ class PlotOptionsPresenterTest(unittest.TestCase):
         # view -> model
         view_x_log_mock.return_value = False
         view_y_log_mock.return_value = True
-        self.presenter._xy_config_modified('x_log')
-        self.presenter._xy_config_modified('y_log')
+        self.presenter._value_modified('x_log')
+        self.presenter._value_modified('y_log')
         self.presenter.get_new_config()
-        self.model.change_axis_scale.assert_called_once_with({'x_range': (1, 2), 'y_range': (3, 4), 'modified': True,
-                                                              'x_log': False, 'y_log': True})
+        model_x_log_mock.assert_called_with(False)
+        model_y_log_mock.assert_called_with(True)
 
     def test_line_options(self):
         #  model -> view


### PR DESCRIPTION
**Description of work:**
- Fixed bug where data gets distorted from setting log scale to x axis and then setting it to linear again
- Restructured section of the code dealing with updating the log scales on the axes.

**To test:**
- Open cut plot with some example data
- Open plot options > tick Logarithm for x axis > 'OK'
- Check log scale is applied to x axis
- Open plot options again > untick Logarithm for x axis > 'OK'
- Check plot is back to original format
- Repeat the same steps for y axis
- Now put both axis on a linear scale
- Go to Information > Bragg Peaks > check Aluminium
- Change y axis to log scale
- The lines for the Aluminium bragg peaks should stay symmetrical around zero
- Change y axis to linear
- The lines for the Aluminium bragg peaks should stay symmetrical around zero


Fixes #956 
