### PR TITLE
Clean up Jupyter QtConsole when closing MSlice interface in Mantid

### DIFF
--- a/src/mslice/app/mainwindow.py
+++ b/src/mslice/app/mainwindow.py
@@ -287,3 +287,6 @@ class MainWindow(MainView, QMainWindow):
         for item in print_list:
             for strn in item.split('\n'):
                 self._console.execute(f'print("{strn}")', hidden=True)
+
+    def closeEvent(self, event):
+        self._console.cleanup()

--- a/src/mslice/widgets/ipythonconsole/ipython_widget.py
+++ b/src/mslice/widgets/ipythonconsole/ipython_widget.py
@@ -43,3 +43,8 @@ class IPythonWidget(RichIPythonWidget):
             self.execute('from mslice.cli import *', hidden=True)
         else:
             self.execute('import mslice.cli as mc')
+
+    def cleanup(self):
+        if in_mantid():
+            self.execute('cls')
+            self.execute('import mslice.cli as mc')


### PR DESCRIPTION
**Description of work:**
In the past, commands run in the Jupyter console were still visible after closing and re-opening the MSlice interface in Mantid. Now the Jupyter console is cleaned up and opens with `import mslice.cli as mc` just as on the first startup of the interface.

This fixes one part of the bugs described in https://github.com/mantidproject/mslice/issues/737. The second part will be dealt with in changes for https://github.com/mantidproject/mslice/issues/839 and https://github.com/mantidproject/mslice/issues/924.

**To test:**

Copy the `mslice` directory within `src` into `scripts\ExternalInterfaces` for a Mantid 6.8 installation. Open the MSlice interface in this Mantid workbench and use the Jupyter console, for instance by running the following script:
`ws = mc.Load('C:\\MAR21335_Ei60meV.nxs')
wsq = mc.Cut(ws, '|Q|', 'DeltaE, -1, 1')
mc.PlotCut(wsq)

ws2d = mc.Slice(ws, '|Q|, 0, 10, 0.01', 'DeltaE, -5, 55, 0.5')
mc.PlotSlice(ws2d)`

Please note that in the standalone version of MSlice the Jupyter console is cleaned up automatically, so this fix can only be tested for the MSlice interface in Mantid.

Fixes [#737](https://github.com/mantidproject/mslice/issues/737)
