### PR TITLE
Remove deleted hidden workspaces from ADS

### DIFF
--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -278,9 +278,8 @@ def export_workspace_to_ads(workspace):
     add_to_ads(workspace)
 
 
-def remove_workspace_from_ads(workspace):
-    workspace = get_workspace_handle(workspace)
-    remove_from_ads('__MSL' + workspace.name)
+def remove_workspace_from_ads(workspacename):
+    remove_from_ads(workspacename)
 
 
 def _save_single_ws(workspace, save_name, save_method, path, extension):

--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -19,7 +19,7 @@ from mantid.api import WorkspaceUnitValidator
 from mantid.api import MatrixWorkspace
 
 from mslice.models.axis import Axis
-from mslice.util.mantid.algorithm_wrapper import add_to_ads
+from mslice.util.mantid.algorithm_wrapper import add_to_ads, remove_from_ads
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, delete_workspace
 from mslice.util.mantid.mantid_algorithms import Load, MergeMD, MergeRuns, Scale, Minus, ConvertUnits, Rebose
 from mslice.workspace.pixel_workspace import PixelWorkspace
@@ -276,6 +276,11 @@ def export_workspace_to_ads(workspace):
     if isinstance(workspace, HistogramWorkspace):
         workspace = workspace.convert_to_matrix()
     add_to_ads(workspace)
+
+
+def remove_workspace_from_ads(workspace):
+    workspace = get_workspace_handle(workspace)
+    remove_from_ads(workspace)
 
 
 def _save_single_ws(workspace, save_name, save_method, path, extension):

--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -280,7 +280,7 @@ def export_workspace_to_ads(workspace):
 
 def remove_workspace_from_ads(workspace):
     workspace = get_workspace_handle(workspace)
-    remove_from_ads(workspace)
+    remove_from_ads('__MSL' + workspace.name)
 
 
 def _save_single_ws(workspace, save_name, save_method, path, extension):

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -7,7 +7,8 @@ from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.models.workspacemanager.file_io import get_save_directory
 from mslice.models.workspacemanager.workspace_algorithms import (save_workspaces, export_workspace_to_ads, subtract,
                                                                  is_pixel_workspace, combine_workspace,
-                                                                 add_workspace_runs, scale_workspaces)
+                                                                 add_workspace_runs, scale_workspaces,
+                                                                 remove_workspace_from_ads)
 from mslice.models.workspacemanager.workspace_provider import (get_workspace_handle, get_visible_workspace_names,
                                                                get_workspace_name, delete_workspace, rename_workspace)
 from .interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
@@ -116,6 +117,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_select_one_or_more_workspaces()
             return
         for workspace in selected_workspaces:
+            remove_workspace_from_ads(workspace)
             delete_workspace(workspace)
             self.update_displayed_workspaces()
 

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -117,6 +117,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_select_one_or_more_workspaces()
             return
         for workspace in selected_workspaces:
+            # Remove hidden workspaces from ADS
             ws = get_workspace_handle(workspace)
             remove_workspace_from_ads('__MSL' + ws.name)
             delete_workspace(workspace)

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -117,10 +117,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_select_one_or_more_workspaces()
             return
         for workspace in selected_workspaces:
-            # Remove hidden workspaces from ADS
             ws = get_workspace_handle(workspace)
-            remove_workspace_from_ads(ws.name)
-            # remove_workspace_from_ads('__MSL' + ws.name)
+            remove_workspace_from_ads(ws)
             delete_workspace(workspace)
             self.update_displayed_workspaces()
 

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -118,7 +118,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             return
         for workspace in selected_workspaces:
             ws = get_workspace_handle(workspace)
-            remove_workspace_from_ads(ws)
+            remove_workspace_from_ads(ws.name)
             delete_workspace(workspace)
             self.update_displayed_workspaces()
 

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -119,7 +119,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         for workspace in selected_workspaces:
             # Remove hidden workspaces from ADS
             ws = get_workspace_handle(workspace)
-            remove_workspace_from_ads('__MSL' + ws.name)
+            remove_workspace_from_ads(ws.name)
+            # remove_workspace_from_ads('__MSL' + ws.name)
             delete_workspace(workspace)
             self.update_displayed_workspaces()
 

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -117,7 +117,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_select_one_or_more_workspaces()
             return
         for workspace in selected_workspaces:
-            remove_workspace_from_ads(workspace)
+            ws = get_workspace_handle(workspace)
+            remove_workspace_from_ads('__MSL' + ws.name)
             delete_workspace(workspace)
             self.update_displayed_workspaces()
 

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -98,5 +98,9 @@ def add_to_ads(workspaces):
 
 
 def remove_from_ads(workspacename):
+    print(AnalysisDataService.Instance().getObjectNames())
+    if workspacename in AnalysisDataService.Instance().getObjectNames():
+        AnalysisDataService.Instance().remove(workspacename)
+    workspacename = '__MSL' + workspacename
     if workspacename in AnalysisDataService.Instance().getObjectNames():
         AnalysisDataService.Instance().remove(workspacename)

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -97,10 +97,10 @@ def add_to_ads(workspaces):
         AnalysisDataService.Instance().addOrReplace(workspace.name[startid:], workspace.raw_ws)
 
 
-def remove_from_ads(workspacename):
-    print(AnalysisDataService.Instance().getObjectNames())
-    if workspacename in AnalysisDataService.Instance().getObjectNames():
-        AnalysisDataService.Instance().remove(workspacename)
-    workspacename = '__MSL' + workspacename
+def remove_from_ads(workspace):
+    if workspace.name in AnalysisDataService.Instance().getObjectNames():
+        AnalysisDataService.Instance().remove(workspace.name)
+    # Remove hidden workspaces from ADS
+    workspacename = '__MSL' + workspace.name
     if workspacename in AnalysisDataService.Instance().getObjectNames():
         AnalysisDataService.Instance().remove(workspacename)

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -98,7 +98,5 @@ def add_to_ads(workspaces):
 
 
 def remove_from_ads(workspacename):
-    print("ws name:")
-    print(workspacename)
     if workspacename in AnalysisDataService.Instance().getObjectNames():
         AnalysisDataService.Instance().remove(workspacename)

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -97,10 +97,8 @@ def add_to_ads(workspaces):
         AnalysisDataService.Instance().addOrReplace(workspace.name[startid:], workspace.raw_ws)
 
 
-def remove_from_ads(workspaces):
-    try:
-        workspaces = iter(workspaces)
-    except TypeError:
-        workspaces = [workspaces]
-    for workspace in workspaces:
-        AnalysisDataService.Instance().remove('__MSL' + workspace.name)
+def remove_from_ads(workspacename):
+    print("ws name:")
+    print(workspacename)
+    if workspacename in AnalysisDataService.Instance().getObjectNames():
+        AnalysisDataService.Instance().remove(workspacename)

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -95,3 +95,12 @@ def add_to_ads(workspaces):
     for workspace in workspaces:
         startid = (5 if workspace.name.startswith('__mat') else 2) if workspace.name.startswith('__') else 0
         AnalysisDataService.Instance().addOrReplace(workspace.name[startid:], workspace.raw_ws)
+
+
+def remove_from_ads(workspaces):
+    try:
+        workspaces = iter(workspaces)
+    except TypeError:
+        workspaces = [workspaces]
+    for workspace in workspaces:
+        AnalysisDataService.Instance().remove('__MSL' + workspace.name)

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -97,10 +97,10 @@ def add_to_ads(workspaces):
         AnalysisDataService.Instance().addOrReplace(workspace.name[startid:], workspace.raw_ws)
 
 
-def remove_from_ads(workspace):
-    if workspace.name in AnalysisDataService.Instance().getObjectNames():
-        AnalysisDataService.Instance().remove(workspace.name)
+def remove_from_ads(workspacename):
+    if workspacename in AnalysisDataService.Instance().getObjectNames():
+        AnalysisDataService.Instance().remove(workspacename)
     # Remove hidden workspaces from ADS
-    workspacename = '__MSL' + workspace.name
+    workspacename = '__MSL' + workspacename
     if workspacename in AnalysisDataService.Instance().getObjectNames():
         AnalysisDataService.Instance().remove(workspacename)

--- a/src/mslice/workspace/helperfunctions.py
+++ b/src/mslice/workspace/helperfunctions.py
@@ -85,7 +85,8 @@ def attribute_to_log(attrdict, raw_ws, append=False):
 
 def delete_workspace(workspace, ws):
     try:
-        if hasattr(workspace, str(ws)) and ws is not None and ws.name().endswith('_HIDDEN'):
+        if hasattr(workspace, str(ws)) and ws is not None \
+           and (ws.name().endswith('_HIDDEN') or ws.name().startswith('__MSL')):
             DeleteWorkspace(ws)
             ws = None
     except RuntimeError:

--- a/src/mslice/workspace/helperfunctions.py
+++ b/src/mslice/workspace/helperfunctions.py
@@ -85,8 +85,7 @@ def attribute_to_log(attrdict, raw_ws, append=False):
 
 def delete_workspace(workspace, ws):
     try:
-        if hasattr(workspace, str(ws)) and ws is not None \
-           and (ws.name().endswith('_HIDDEN') or ws.name().startswith('__MSL')):
+        if hasattr(workspace, str(ws)) and ws is not None and ws.name().endswith('_HIDDEN'):
             DeleteWorkspace(ws)
             ws = None
     except RuntimeError:

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -86,8 +86,10 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
         self.assertEqual(get_comment(self.test_workspace), "")
 
     def test_remove_workspace_from_ads(self):
-        test_workspace2 = CloneWorkspace(OutputWorkspace='__MSLtest_workspace2', InputWorkspace=self.test_workspace)
-        export_workspace_to_ads(test_workspace2)
+        test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
+        AnalysisDataService.addOrReplace('__MSLtest_workspace2', test_workspace2)
+        print(AnalysisDataService.getObjectNames())
         current_len = len(AnalysisDataService)
         remove_workspace_from_ads("test_workspace2")
+        print(AnalysisDataService.getObjectNames())
         self.assertEqual(len(AnalysisDataService), current_len - 1)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -86,8 +86,11 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
         self.assertEqual(get_comment(self.test_workspace), "")
 
     def test_remove_workspace_from_ads(self):
-        current_len = len(AnalysisDataService)
         test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
         export_workspace_to_ads(test_workspace2)
+        print(AnalysisDataService.getObjectNames())
+        print("~~~~~~~~~~")
+        current_len = len(AnalysisDataService)
         remove_workspace_from_ads(test_workspace2)
+        print(AnalysisDataService.getObjectNames())
         self.assertEqual(len(AnalysisDataService), current_len - 1)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -9,7 +9,7 @@ from mslice.models.workspacemanager.workspace_algorithms import (process_limits,
 from mslice.models.workspacemanager.workspace_provider import add_workspace
 from tests.testhelpers.workspace_creator import (create_md_histo_workspace, create_workspace,
                                                  create_simulation_workspace)
-from mslice.util.mantid.mantid_algorithms import (AppendSpectra, CreateSimulationWorkspace,
+from mslice.util.mantid.mantid_algorithms import (AppendSpectra, CloneWorkspace, CreateSimulationWorkspace,
                                                   CreateWorkspace, ConvertToMD, AddSampleLog)
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mantid.api import AnalysisDataService
@@ -87,5 +87,7 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
 
     def test_remove_workspace_from_ads(self):
         current_len = len(AnalysisDataService)
-        remove_workspace_from_ads(self.test_workspace)
+        test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
+        export_workspace_to_ads(test_workspace2)
+        remove_workspace_from_ads(test_workspace2)
         self.assertEqual(len(AnalysisDataService), current_len - 1)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -86,7 +86,7 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
         self.assertEqual(get_comment(self.test_workspace), "")
 
     def test_remove_workspace_from_ads(self):
-        test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
+        test_workspace2 = CloneWorkspace(OutputWorkspace='__MSLtest_workspace2', InputWorkspace=self.test_workspace)
         export_workspace_to_ads(test_workspace2)
         print(AnalysisDataService.getObjectNames())
         current_len = len(AnalysisDataService)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -86,11 +86,8 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
         self.assertEqual(get_comment(self.test_workspace), "")
 
     def test_remove_workspace_from_ads(self):
-        test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
+        test_workspace2 = CloneWorkspace(OutputWorkspace='__MSLtest_workspace2', InputWorkspace=self.test_workspace)
         export_workspace_to_ads(test_workspace2)
-        print(AnalysisDataService.getObjectNames())
-        print("~~~~~~~~~~")
         current_len = len(AnalysisDataService)
-        remove_workspace_from_ads(test_workspace2)
-        print(AnalysisDataService.getObjectNames())
+        remove_workspace_from_ads("test_workspace2")
         self.assertEqual(len(AnalysisDataService), current_len - 1)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -88,8 +88,6 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
     def test_remove_workspace_from_ads(self):
         test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
         export_workspace_to_ads(test_workspace2)
-        print(AnalysisDataService.getObjectNames())
         current_len = len(AnalysisDataService)
         remove_workspace_from_ads("test_workspace2")
-        print(AnalysisDataService.getObjectNames())
         self.assertEqual(len(AnalysisDataService), current_len - 1)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -86,7 +86,7 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
         self.assertEqual(get_comment(self.test_workspace), "")
 
     def test_remove_workspace_from_ads(self):
-        test_workspace2 = CloneWorkspace(OutputWorkspace='__MSLtest_workspace2', InputWorkspace=self.test_workspace)
+        test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
         export_workspace_to_ads(test_workspace2)
         print(AnalysisDataService.getObjectNames())
         current_len = len(AnalysisDataService)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -87,7 +87,7 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
 
     def test_remove_workspace_from_ads(self):
         test_workspace2 = CloneWorkspace(OutputWorkspace='test_workspace2', InputWorkspace=self.test_workspace)
-        AnalysisDataService.addOrReplace('__MSLtest_workspace2', test_workspace2)
+        export_workspace_to_ads(test_workspace2)
         print(AnalysisDataService.getObjectNames())
         current_len = len(AnalysisDataService)
         remove_workspace_from_ads("test_workspace2")

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -5,7 +5,7 @@ import unittest
 from mslice.models.axis import Axis
 from mslice.models.workspacemanager.workspace_algorithms import (process_limits, process_limits_event, scale_workspaces,
                                                                  export_workspace_to_ads, is_pixel_workspace,
-                                                                 get_axis_from_dimension, get_comment)
+                                                                 get_axis_from_dimension, get_comment, remove_workspace_from_ads)
 from mslice.models.workspacemanager.workspace_provider import add_workspace
 from tests.testhelpers.workspace_creator import (create_md_histo_workspace, create_workspace,
                                                  create_simulation_workspace)
@@ -84,3 +84,9 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
 
     def test_get_comment(self):
         self.assertEqual(get_comment(self.test_workspace), "")
+
+    def test_remove_workspace_from_ads(self):
+        export_workspace_to_ads(self.test_workspace)
+        current_len = len(AnalysisDataService)
+        remove_workspace_from_ads(self.test_workspace)
+        self.assertEqual(len(AnalysisDataService), current_len - 1)

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -86,7 +86,6 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
         self.assertEqual(get_comment(self.test_workspace), "")
 
     def test_remove_workspace_from_ads(self):
-        export_workspace_to_ads(self.test_workspace)
         current_len = len(AnalysisDataService)
         remove_workspace_from_ads(self.test_workspace)
         self.assertEqual(len(AnalysisDataService), current_len - 1)


### PR DESCRIPTION
**Description of work:**

The cut algorithm creates hidden workspaces specific to a cut that are now also removed from the ADS once this cut is deleted to avoid memory issues when working with many cuts.

**To test:**

Follow instructions in https://github.com/mantidproject/mslice/issues/924 for testing. At the moment, only hidden workspaces linked to a specific cut are removed, not all hidden workspaces.

Fixes #924 
