### PR TITLE
Suppress returned warning from ADS.clear()

### DIFF
--- a/tests/cut_algorithm_test.py
+++ b/tests/cut_algorithm_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
+import warnings
 
 from mantid.api import AnalysisDataService
 from mantid.dataobjects import MDHistoWorkspace
@@ -27,7 +28,9 @@ class CutAlgorithmTest(TestCase):
         self.theta_axis = Axis("2Theta", -10, 15, 1)
 
     def tearDown(self) -> None:
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     def xtest_that_compute_cut_returns_a_result_with_the_expected_size_for_normalized_psd_rebin_data(self):
         normalized = True

--- a/tests/cut_functions_test.py
+++ b/tests/cut_functions_test.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from mock import patch
 from unittest import TestCase
+import warnings
 
 from mantid.api import AlgorithmFactory, AnalysisDataService
 from mantid.simpleapi import AddSampleLog, _create_algorithm_function
@@ -41,7 +42,9 @@ class CutFunctionsTest(TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     def test_that_output_workspace_name_returns_the_expected_result(self):
         self.assertEqual(output_workspace_name(self.workspace_name, self.integration_start, self.integration_end),

--- a/tests/cut_normalisation_test.py
+++ b/tests/cut_normalisation_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 from unittest import TestCase
+import warnings
 
 from mantid.api import AnalysisDataService
 
@@ -14,7 +15,9 @@ class CutNormalisationTest(TestCase):
         self.md_histo_ws = create_md_histo_workspace(2, "md_histo_ws")
 
     def tearDown(self) -> None:
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     def test_that_normalize_workspace_fails_for_a_non_IMDHistoWorkspace(self):
         try:

--- a/tests/projection_calculator_test.py
+++ b/tests/projection_calculator_test.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import warnings
 
 from mantid.api import AnalysisDataService
 
@@ -20,7 +21,9 @@ class ProjectionCalculatorTest(TestCase):
         self.projection_calculator = MantidProjectionCalculator()
 
     def tearDown(self) -> None:
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     def test_available_axes(self):
         self.assertEqual(self.projection_calculator.available_axes(), ['|Q|', '2Theta', 'DeltaE'])

--- a/tests/rebose_algorithm_test.py
+++ b/tests/rebose_algorithm_test.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from mantid.api import AnalysisDataService
 from tests.testhelpers.workspace_creator import create_workspace
@@ -13,7 +14,9 @@ class RebinAlgorithmTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     def test_rebose_algorithm(self):
         results = Rebose(self.test_workspace)

--- a/tests/slice_algorithm_test.py
+++ b/tests/slice_algorithm_test.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 from mock import patch, MagicMock, call, ANY
 import numpy as np
 import unittest
+import warnings
 
 from mantid.simpleapi import AddSampleLog, AnalysisDataService
 from mantid.kernel import PropertyManager
@@ -55,7 +56,9 @@ class SliceAlgorithmTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.test_objects = None  # reset test objects
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     @staticmethod
     def _create_tst_objects(sim_scattering_data, x_dict, y_dict, norm_to_one=False, PSD=False, e_mode='Direct'):

--- a/tests/slice_functions_test.py
+++ b/tests/slice_functions_test.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 from mock import patch, MagicMock
 import numpy as np
 import unittest
+import warnings
 
 from mantid.api import AlgorithmFactory
 from mantid.simpleapi import AddSampleLog, _create_algorithm_function, AnalysisDataService
@@ -34,7 +35,9 @@ class SliceFunctionsTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     @patch('mslice.models.slice.slice_functions.mantid_algorithms')
     def test_slice(self, alg_mock):

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
+import warnings
 
 from mslice.models.axis import Axis
 from mslice.models.workspacemanager.workspace_algorithms import (process_limits, process_limits_event, scale_workspaces,
@@ -44,7 +45,9 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        AnalysisDataService.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            AnalysisDataService.clear()
 
     def test_process_limits_does_not_fail_for_direct_data(self):
         process_limits(self.direct_workspace)


### PR DESCRIPTION
**Description of work:**

ADS.clear() now returns a warning. This causes an exception in `tearDown` and `tearDownClass` methods in tests. I have added code to ignore the warning instead.

**To test:**

Check if the unit tests for this branch are passing.
