### PR TITLE
Added import for Mantid algorithm wrappers back into CLI

### DIFF
--- a/src/mslice/cli/_mslice_commands.py
+++ b/src/mslice/cli/_mslice_commands.py
@@ -20,7 +20,7 @@ from mslice.util.qt.qapp import QAppThreadCall, mainloop
 from six import string_types
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace as MSliceWorkspace
-
+from mslice.util.mantid.mantid_algorithms import *  # noqa: F401, F403
 
 # -----------------------------------------------------------------------------
 # Command functions


### PR DESCRIPTION
**Description of work:**

The import for Mantid algorithm wrappers was removed by accident earlier this year. It has now been added back.

**To test:**

Follow instructions in original issue.

Fixes #961.
