### PR TITLE
Fixed matplotlib error by avoiding call to ArtistList

### DIFF
--- a/src/mslice/plotting/plot_window/overplot_interface.py
+++ b/src/mslice/plotting/plot_window/overplot_interface.py
@@ -68,7 +68,7 @@ def cif_file_powder_line(plot_handler, plotter_presenter, checked):
 
 
 def remove_line(line):
-    plt.gca().lines.remove(line)
+    line.remove()
 
 
 def plot_overplot_line(x, y, key, recoil, cache, **kwargs):


### PR DESCRIPTION
Fixed error by deleting line object directly.
There is no need to call an ArtistList when can just delete the artist directly.

**Description of work:**
Fixed a bug where removing Bragg peak lines caused an unhanded error. This happened due to matplotib having been updated, and the object ArtistList no longer supporting a remove() method.

**To test:**
Open a slice plot > Information > Bragg peaks > select some bragg peaks
Then try to deselect any bragg peak
The Bragg peak lines should be removed from the plot.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #967 .
