### PR TITLE
Update tests with True flag for ADS.clear()

### DIFF
--- a/tests/cut_algorithm_test.py
+++ b/tests/cut_algorithm_test.py
@@ -1,7 +1,6 @@
 import numpy as np
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
-import warnings
 
 from mantid.api import AnalysisDataService
 from mantid.dataobjects import MDHistoWorkspace
@@ -28,9 +27,7 @@ class CutAlgorithmTest(TestCase):
         self.theta_axis = Axis("2Theta", -10, 15, 1)
 
     def tearDown(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     def xtest_that_compute_cut_returns_a_result_with_the_expected_size_for_normalized_psd_rebin_data(self):
         normalized = True

--- a/tests/cut_functions_test.py
+++ b/tests/cut_functions_test.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from mock import patch
 from unittest import TestCase
-import warnings
 
 from mantid.api import AlgorithmFactory, AnalysisDataService
 from mantid.simpleapi import AddSampleLog, _create_algorithm_function
@@ -42,9 +41,7 @@ class CutFunctionsTest(TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     def test_that_output_workspace_name_returns_the_expected_result(self):
         self.assertEqual(output_workspace_name(self.workspace_name, self.integration_start, self.integration_end),

--- a/tests/cut_normalisation_test.py
+++ b/tests/cut_normalisation_test.py
@@ -1,6 +1,5 @@
 import numpy as np
 from unittest import TestCase
-import warnings
 
 from mantid.api import AnalysisDataService
 
@@ -15,9 +14,7 @@ class CutNormalisationTest(TestCase):
         self.md_histo_ws = create_md_histo_workspace(2, "md_histo_ws")
 
     def tearDown(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     def test_that_normalize_workspace_fails_for_a_non_IMDHistoWorkspace(self):
         try:

--- a/tests/projection_calculator_test.py
+++ b/tests/projection_calculator_test.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-import warnings
 
 from mantid.api import AnalysisDataService
 
@@ -21,9 +20,7 @@ class ProjectionCalculatorTest(TestCase):
         self.projection_calculator = MantidProjectionCalculator()
 
     def tearDown(self) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     def test_available_axes(self):
         self.assertEqual(self.projection_calculator.available_axes(), ['|Q|', '2Theta', 'DeltaE'])

--- a/tests/rebose_algorithm_test.py
+++ b/tests/rebose_algorithm_test.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 from mantid.api import AnalysisDataService
 from tests.testhelpers.workspace_creator import create_workspace
@@ -14,9 +13,7 @@ class RebinAlgorithmTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     def test_rebose_algorithm(self):
         results = Rebose(self.test_workspace)

--- a/tests/slice_algorithm_test.py
+++ b/tests/slice_algorithm_test.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function)
 from mock import patch, MagicMock, call, ANY
 import numpy as np
 import unittest
-import warnings
 
 from mantid.simpleapi import AddSampleLog, AnalysisDataService
 from mantid.kernel import PropertyManager
@@ -56,9 +55,7 @@ class SliceAlgorithmTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.test_objects = None  # reset test objects
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     @staticmethod
     def _create_tst_objects(sim_scattering_data, x_dict, y_dict, norm_to_one=False, PSD=False, e_mode='Direct'):

--- a/tests/slice_functions_test.py
+++ b/tests/slice_functions_test.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function)
 from mock import patch, MagicMock
 import numpy as np
 import unittest
-import warnings
 
 from mantid.api import AlgorithmFactory
 from mantid.simpleapi import AddSampleLog, _create_algorithm_function, AnalysisDataService
@@ -35,9 +34,7 @@ class SliceFunctionsTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     @patch('mslice.models.slice.slice_functions.mantid_algorithms')
     def test_slice(self, alg_mock):

--- a/tests/workspace_algorithms_test.py
+++ b/tests/workspace_algorithms_test.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-import warnings
 
 from mslice.models.axis import Axis
 from mslice.models.workspacemanager.workspace_algorithms import (process_limits, process_limits_event, scale_workspaces,
@@ -45,9 +44,7 @@ class WorkspaceAlgorithmsTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
     def test_process_limits_does_not_fail_for_direct_data(self):
         process_limits(self.direct_workspace)


### PR DESCRIPTION
**Description of work:**

ADS.clear() now has a silent flag to suppress the warning message (https://github.com/mantidproject/mantid/issues/36690) thrown when running this function. It is useful to set this flag when clearing the ADS after unit tests, as it simplifies the clean-up process.

**To test:**

Check that the unit tests were running without problems for this branch: https://github.com/mantidproject/mslice/actions/runs/7757957015

