### PR TITLE
Fix for crash when saving MDHisto into mantid workbench

### DIFF
--- a/src/mslice/models/intensity_correction_algs.py
+++ b/src/mslice/models/intensity_correction_algs.py
@@ -211,10 +211,11 @@ def _reduce_bins_along_int_axis(slice_gdos, algorithm, cut_axis, int_axis, cut_a
     units = f"{x_dim.getUnits()},{y_dim.getUnits()}"
 
     new_ws = CreateMDHistoWorkspace(Dimensionality=2, Extents=extents, SignalInput=signal, ErrorInput=error, NumberOfBins=no_of_bins,
-                                    Names=names, Units=units, StoreInADS=False, OutputWorkspace=output_name)
+                                    Names=names, Units=units)
 
     int_axis.step = 0
     new_ws.axes = (cut_axis, int_axis)
+    new_ws.name = output_name
     return new_ws
 
 


### PR DESCRIPTION
**Description of work:**

When creating an MDHisto workspace for a different intensity correction algorithm, this workspace needs to be saved in the ADS. We have tried to prevent this in the past (https://github.com/mantidproject/mslice/pull/925), but it causes crashes when the user wants to access the cut workspace in Mantid Workbench.

Reducing the ADS usage by MSlice is an ongoing maintenance project and there will hopefully be a more sophisticated solution available for the next release.

**To test:**

Follow the steps in the original issue and check that Mantid does not crash anymore.


Fixes #972.
