### PR TITLE
Fix for deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = ["error", "ignore::DeprecationWarning"]
 
 [tool.coverage.report]
 include = [

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -248,5 +248,5 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
         AddSampleLog(workspace=self.test_ws.raw_ws, LogName='ListTemp', LogText='3.', LogType='Number Series',
                      StoreInADS=False)
         print("listtemp")
-        print(['ListTemp'])
+        print(sample_temperature(self.test_ws.name, ['ListTemp']))
         self.assertEqual(sample_temperature(self.test_ws.name, ['ListTemp']), [3.0])

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -1,8 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mock import patch, MagicMock, call
-import warnings
-
+import numpy as np
 import unittest
 from copy import copy
 
@@ -14,12 +13,6 @@ from mslice.models.intensity_correction_algs import (compute_boltzmann_dist, com
 from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace, CreateMDHistoWorkspace
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mantid.simpleapi import AddSampleLog
-
-
-warnings.filterwarnings('ignore', category=DeprecationWarning)
-
-
-import numpy as np  # noqa: E402
 
 
 def _invert_axes(matrix):
@@ -254,4 +247,6 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
     def test_sample_temperature_list(self):
         AddSampleLog(workspace=self.test_ws.raw_ws, LogName='ListTemp', LogText='3.', LogType='Number Series',
                      StoreInADS=False)
+        print("listtemp")
+        print(['ListTemp'])
         self.assertEqual(sample_temperature(self.test_ws.name, ['ListTemp']), [3.0])

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mock import patch, MagicMock, call
+import warnings
+
 import numpy as np
 import unittest
 from copy import copy
@@ -13,6 +15,7 @@ from mslice.models.intensity_correction_algs import (compute_boltzmann_dist, com
 from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace, CreateMDHistoWorkspace
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mantid.simpleapi import AddSampleLog
+warnings.filterwarnings('ignore', category=DeprecationWarning)
 
 
 def _invert_axes(matrix):

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function)
 from mock import patch, MagicMock, call
 import warnings
 
-import numpy as np
 import unittest
 from copy import copy
 
@@ -15,7 +14,12 @@ from mslice.models.intensity_correction_algs import (compute_boltzmann_dist, com
 from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace, CreateMDHistoWorkspace
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mantid.simpleapi import AddSampleLog
+
+
 warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+
+import numpy as np  # noqa: E402
 
 
 def _invert_axes(matrix):

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -245,8 +245,6 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
         self.assertEqual(sample_temperature(self.test_ws.name, ['StrTemp']), '3.')
 
     def test_sample_temperature_list(self):
-        AddSampleLog(workspace=self.test_ws.raw_ws, LogName='ListTemp', LogText='3.', LogType='Number Series',
+        AddSampleLog(workspace=self.test_ws.raw_ws, LogName='ListTemp', LogText='3., 3.', LogType='Number Series',
                      StoreInADS=False)
-        print("listtemp")
-        print(sample_temperature(self.test_ws.name, ['ListTemp']))
         self.assertEqual(sample_temperature(self.test_ws.name, ['ListTemp']), [3.0])

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -245,6 +245,6 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
         self.assertEqual(sample_temperature(self.test_ws.name, ['StrTemp']), '3.')
 
     def test_sample_temperature_list(self):
-        AddSampleLog(workspace=self.test_ws.raw_ws, LogName='ListTemp', LogText='3., 3.', LogType='Number Series',
+        AddSampleLog(workspace=self.test_ws.raw_ws, LogName='ListTemp', LogText='3.', LogType='Number Series',
                      StoreInADS=False)
         self.assertEqual(sample_temperature(self.test_ws.name, ['ListTemp']), [3.0])


### PR DESCRIPTION
**Description of work:**

Recently a unit test failed, caused by a deprecation warning. This problem is described in https://github.com/mantidproject/mslice/issues/975 and will be fixed soon. Since testing for the upcoming MSlice release has already finished, the fix needs to be added after the release. Therefore, this deprecation warning is temporarily suppressed in the project configuration.

**To test:**

Check if the corresponding workflow was running successfully: https://github.com/mantidproject/mslice/actions/runs/8046107930

