### PR TITLE
Permanent fix for deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
-filterwarnings = ["error", "ignore::DeprecationWarning"]
+filterwarnings = ["error"]
 
 [tool.coverage.report]
 include = [

--- a/src/mslice/models/intensity_correction_algs.py
+++ b/src/mslice/models/intensity_correction_algs.py
@@ -266,16 +266,12 @@ def sample_temperature(ws_name, sample_temp_fields):
             pass
         except AttributeError:
             sample_temp = ws.getExperimentInfo(0).run().getLogData(field_name).value
-    try:
-        float(sample_temp)
-    except (ValueError, TypeError):
-        pass
-    else:
-        return sample_temp
     if isinstance(sample_temp, string_types):
         sample_temp = get_sample_temperature_from_string(sample_temp)
-    if isinstance(sample_temp, np.ndarray) or isinstance(sample_temp, list):
+    elif isinstance(sample_temp, np.ndarray) or isinstance(sample_temp, list):
         sample_temp = np.mean(sample_temp)
+    else:
+        float(sample_temp)
     return sample_temp
 
 

--- a/tests/intensity_correction_algs_test.py
+++ b/tests/intensity_correction_algs_test.py
@@ -242,7 +242,7 @@ class IntensityCorrectionAlgsTest(unittest.TestCase):
 
     def test_sample_temperature_string(self):
         AddSampleLog(workspace=self.test_ws.raw_ws, LogName='StrTemp', LogText='3.', LogType='String', StoreInADS=False)
-        self.assertEqual(sample_temperature(self.test_ws.name, ['StrTemp']), '3.')
+        self.assertEqual(sample_temperature(self.test_ws.name, ['StrTemp']), 3.0)
 
     def test_sample_temperature_list(self):
         AddSampleLog(workspace=self.test_ws.raw_ws, LogName='ListTemp', LogText='3.', LogType='Number Series',


### PR DESCRIPTION
**Description of work:**

This is a permanent fix for a deprecation warning that occurred in the unit tests. Conversion of an array to a scalar is deprecated in NumPy 1.25. In the function sample_temperature in the intensity correction algorithms, we attempted to convert a one-dimensional array into a float. This triggers now the deprecation warning. The solution is to first check for lists and arrays before attempting to convert a single value to a float.

**To test:**

1. Load `MAR21335_Ei60meV` dataset 
2. Display slice
3. On the intensity dropdown select `Chi''(Q,E)`
4. Enter `80` in combo box and click ok
5. On the intensity dropdown select `GDOS`
6. There should be no pop up window asking for the sample temperature

Also, check that the unit tests were running without failure for this branch: https://github.com/mantidproject/mslice/actions/runs/8047878035

Fixes #975.
