### PR TITLE
Modify sequence of channels in GitHub publish

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -25,8 +25,8 @@ runs:
       conda create -n build-env python=3.10
       conda activate build-env
       mamba install -c conda-forge mamba conda-build anaconda-client conda-verify boa
-      conda config --add channels mantid
       conda config --add channels mantid/label/nightly
+      conda config --add channels mantid
 
   - name: Build package
     shell: bash -l {0}

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,11 +1,11 @@
 name: Deploy MSlice nightly
 
-on: push
-#  workflow_run:
-#    workflows: ["MSlice nightly build"]
-#    branches: [main]
-#    types:
-#      - completed
+on:
+  workflow_run:
+    workflows: ["MSlice nightly build"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build_conda_and_upload:
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-#          ref: main
+          ref: main
 
       - name: Check for changes since last build
         run: |
@@ -39,5 +39,5 @@ jobs:
         if: ${{ env.recentCommits == 'true'}}
         uses: ./.github/actions/publish-package
         with:
-          label: test # nightly
+          label: nightly
           token: ${{ secrets.ANACONDA_API_TOKEN }}

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,11 +1,11 @@
 name: Deploy MSlice nightly
 
-on:
-  workflow_run:
-    workflows: ["MSlice nightly build"]
-    branches: [main]
-    types:
-      - completed
+on: push
+#  workflow_run:
+#    workflows: ["MSlice nightly build"]
+#    branches: [main]
+#    types:
+#      - completed
 
 jobs:
   build_conda_and_upload:
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: main
+#          ref: main
 
       - name: Check for changes since last build
         run: |
@@ -39,5 +39,5 @@ jobs:
         if: ${{ env.recentCommits == 'true'}}
         uses: ./.github/actions/publish-package
         with:
-          label: nightly
+          label: test # nightly
           token: ${{ secrets.ANACONDA_API_TOKEN }}


### PR DESCRIPTION
**Description of work:**

When adding channels for Conda, the last added channel moves to the top. Therefore, it makes more sense to add channel `mantid/label/nightly` before channel `mantid` so that released Conda packages for `mantid` and `mantidqt` are preferred over the nightly versions.

**To test:**

Code review only.

