### PR TITLE
Fix for failing unit test workflows

### DIFF
--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Miniconda
         if: ${{ env.recentCommits == 'true'}}
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          mamba install -c mantid/label/nightly mantid mantidqt
+          conda install -c mantid/label/nightly mantid mantidqt
 
       - name: Run Tests and Coverage
         run: |

--- a/.github/workflows/unit_tests_nightly.yml
+++ b/.github/workflows/unit_tests_nightly.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.2.0
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           miniforge-variant: Mambaforge
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install Mantid
         run: |
-          mamba install -c mantid/label/nightly mantid mantidqt
+          conda install -c mantid/label/nightly mantid mantidqt
 
       - name: Run Tests and Coverage
         run: |


### PR DESCRIPTION
**Description of work:**

All unit test workflows fell over for MSlice, although there were no changes made to the MSlice main branch (which is used for the nightly unit test workflow). Switching from `mamba install` to `conda install` can prevent this. 

I have also upgraded the conda-incubator from version 2.2.0 to version 3.

**To test:**

Check that the GitHub workflow for the unit tests does not fail for this branch: https://github.com/mantidproject/mslice/actions/runs/8433683620

