### PR TITLE
Fix for crash when saving into incorrect format

### DIFF
--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -247,6 +247,8 @@ class PlotFigureManagerQT(QtCore.QObject):
                     self.save_image(os.path.join(file_path, save_name))
             elif str(e) == "dialog cancelled":
                 pass
+            elif "metadata may be lost" in str(e):
+                self.error_box(str(e))
             else:
                 raise RuntimeError(e)
         except KeyError:  # Could be case of interactive cuts when the workspace has not been saved yet


### PR DESCRIPTION
**Description of work:**

When trying to save an `.nxs` file as `.nxspe`  or vice versa from a slice plot, MSlice crashed, as this is not supported. Now a box with an error message opens instead.

**To test:**

Follow the instructions on the original issue. In addition, attempt to save an `.nxspe` file as `.nxs`.

Fixes #984.
