### PR TITLE
Fix for empty mdhisto lines

### DIFF
--- a/src/mslice/models/intensity_correction_algs.py
+++ b/src/mslice/models/intensity_correction_algs.py
@@ -210,12 +210,11 @@ def _reduce_bins_along_int_axis(slice_gdos, algorithm, cut_axis, int_axis, cut_a
     names = f"{x_dim.name},{y_dim.name}"
     units = f"{x_dim.getUnits()},{y_dim.getUnits()}"
 
-    new_ws = CreateMDHistoWorkspace(Dimensionality=2, Extents=extents, SignalInput=signal, ErrorInput=error, NumberOfBins=no_of_bins,
-                                    Names=names, Units=units)
+    new_ws = CreateMDHistoWorkspace(OutputWorkspace=output_name, Dimensionality=2, Extents=extents, SignalInput=signal,
+                                    ErrorInput=error, NumberOfBins=no_of_bins, Names=names, Units=units, StoreInADS=False)
 
     int_axis.step = 0
     new_ws.axes = (cut_axis, int_axis)
-    new_ws.name = output_name
     return new_ws
 
 

--- a/src/mslice/workspace/histogram_workspace.py
+++ b/src/mslice/workspace/histogram_workspace.py
@@ -48,8 +48,17 @@ class HistogramWorkspace(HistoMixin, WorkspaceOperatorMixin, WorkspaceMixin, Wor
         ws_conv = ConvertMDHistoToMatrixWorkspace(self.name, Normalization='NumEventsNormalization',
                                                   FindXAxis=False, OutputWorkspace='__mat'+self.name)
         coord = self.get_coordinates()
-        first_dim = coord[self.raw_ws.getDimension(0).name]
-        bin_size = first_dim[1] - first_dim[0]
+        bin_size = 1
+        if self.raw_ws.getNumDims() == 2:
+            # for a 2 dimensional workspace use the second dimension to determine bin size
+            # this is the case after changing the intensity to GDOS for a cut
+            first_dim = coord[self.raw_ws.getDimension(1).name]
+        elif self.raw_ws.getNumDims() == 1:
+            first_dim = coord[self.raw_ws.getDimension(0).name]
+        if len(first_dim) > 1:
+            bin_size = first_dim[1] - first_dim[0]
+        else:
+            raise TypeError('Workspace has only one bin.')
         ws_conv = Scale(ws_conv, bin_size, OutputWorkspace='__mat'+self.name)
         ConvertToDistribution(ws_conv)
         return ws_conv

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -19,7 +19,7 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   NumberOfBins='10,10', Names='Dim1,Dim2',
                                                                   Units='U,U', OutputWorkspace='testHistoWorkspace',
                                                                   ), 'testHistoWorkspace')
-        cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=1, Extents=[1, 5],
+        cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=1, Extents=[1],
                                                                       SignalInput=[1], ErrorInput=[4],
                                                                       NumberOfBins=1, Names='Dim1',
                                                                       Units='U', OutputWorkspace='testHistoWorkspace1Bin',

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -19,9 +19,9 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   NumberOfBins='10,10', Names='Dim1,Dim2',
                                                                   Units='U,U', OutputWorkspace='testHistoWorkspace',
                                                                   ), 'testHistoWorkspace')
-        cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=1, Extents=[1],
-                                                                      SignalInput=[1], ErrorInput=[4],
-                                                                      NumberOfBins=1, Names='Dim1',
+        cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=2, Extents='0,100,0,100',
+                                                                      SignalInput=signal, ErrorInput=error,
+                                                                      NumberOfBins='1,100', Names='Dim1,Dim2',
                                                                       Units='U', OutputWorkspace='testHistoWorkspace1Bin',
                                                                       ), 'testHistoWorkspace1Bin')
 

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -21,7 +21,7 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   ), 'testHistoWorkspace')
         cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=2, Extents='0,100,0,100',
                                                                       SignalInput=signal, ErrorInput=error,
-                                                                      NumberOfBins='1,100', Names='Dim1,Dim2',
+                                                                      NumberOfBins='100,1', Names='Dim1,Dim2',
                                                                       Units='U,U', OutputWorkspace='testHistoWorkspace1Bin',
                                                                       ), 'testHistoWorkspace1Bin')
 
@@ -44,7 +44,7 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
         # workspace needs to be registered with mslice for conversion
         try:
             add_workspace(self.workspace1Bin, self.workspace1Bin.name)
-            with self.assertRaises(AssertionError):
+            with self.assertRaises(TypeError):
                 self.workspace1Bin.convert_to_matrix()
         finally:
             # remove mslice tracking

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -22,7 +22,7 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
         cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=2, Extents='0,100,0,100',
                                                                       SignalInput=signal, ErrorInput=error,
                                                                       NumberOfBins='1,100', Names='Dim1,Dim2',
-                                                                      Units='U', OutputWorkspace='testHistoWorkspace1Bin',
+                                                                      Units='U,U', OutputWorkspace='testHistoWorkspace1Bin',
                                                                       ), 'testHistoWorkspace1Bin')
 
     def test_invalid_workspace(self):

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -19,6 +19,11 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   NumberOfBins='10,10', Names='Dim1,Dim2',
                                                                   Units='U,U', OutputWorkspace='testHistoWorkspace',
                                                                   ), 'testHistoWorkspace')
+        cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=2, Extents='0,100,0,100',
+                                                                      SignalInput=signal, ErrorInput=error,
+                                                                      NumberOfBins='1,1', Names='Dim1,Dim2',
+                                                                      Units='U,U', OutputWorkspace='testHistoWorkspace1Bin',
+                                                                      ), 'testHistoWorkspace1Bin')
 
     def test_invalid_workspace(self):
         self.assertRaisesRegex(TypeError, "HistogramWorkspace expected IMDHistoWorkspace, got int", lambda: HistogramWorkspace(4, 'name'))
@@ -34,6 +39,16 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
         finally:
             # remove mslice tracking
             remove_workspace(self.workspace)
+
+    def test_convert_to_matrix_error(self):
+        # workspace needs to be registered with mslice for conversion
+        try:
+            add_workspace(self.workspace1Bin, self.workspace1Bin.name)
+            with self.assertRaises(TypeError):
+                self.workspace1Bin.convert_to_matrix()
+        finally:
+            # remove mslice tracking
+            remove_workspace(self.workspace1Bin)
 
     def test_rename_workspace_which_contains_special_character(self):
         self.workspace.name = "specialcharacter)"

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -20,7 +20,7 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   Units='U,U', OutputWorkspace='testHistoWorkspace',
                                                                   ), 'testHistoWorkspace')
         cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=1, Extents=[1, 5],
-                                                                      SignalInput=[1, 2], ErrorInput=[4, 5],
+                                                                      SignalInput=[1], ErrorInput=[4],
                                                                       NumberOfBins=1, Names='Dim1',
                                                                       Units='U', OutputWorkspace='testHistoWorkspace1Bin',
                                                                       ), 'testHistoWorkspace1Bin')

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -19,10 +19,10 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   NumberOfBins='10,10', Names='Dim1,Dim2',
                                                                   Units='U,U', OutputWorkspace='testHistoWorkspace',
                                                                   ), 'testHistoWorkspace')
-        cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=2, Extents='0,100,0,100',
-                                                                      SignalInput=signal, ErrorInput=error,
-                                                                      NumberOfBins='1,10', Names='Dim1,Dim2',
-                                                                      Units='U,U', OutputWorkspace='testHistoWorkspace1Bin',
+        cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=1, Extents=[1, 5],
+                                                                      SignalInput=[1, 2], ErrorInput=[4, 5],
+                                                                      NumberOfBins=1, Names='Dim1',
+                                                                      Units='U', OutputWorkspace='testHistoWorkspace1Bin',
                                                                       ), 'testHistoWorkspace1Bin')
 
     def test_invalid_workspace(self):

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -21,7 +21,7 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
                                                                   ), 'testHistoWorkspace')
         cls.workspace1Bin = HistogramWorkspace(CreateMDHistoWorkspace(Dimensionality=2, Extents='0,100,0,100',
                                                                       SignalInput=signal, ErrorInput=error,
-                                                                      NumberOfBins='1,1', Names='Dim1,Dim2',
+                                                                      NumberOfBins='1,10', Names='Dim1,Dim2',
                                                                       Units='U,U', OutputWorkspace='testHistoWorkspace1Bin',
                                                                       ), 'testHistoWorkspace1Bin')
 

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -40,11 +40,11 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
             # remove mslice tracking
             remove_workspace(self.workspace)
 
-    def test_convert_to_matrix_error(self):
+    def test_convert_to_matrix_fail(self):
         # workspace needs to be registered with mslice for conversion
         try:
             add_workspace(self.workspace1Bin, self.workspace1Bin.name)
-            with self.assertRaises(TypeError):
+            with self.assertRaises(AssertionError):
                 self.workspace1Bin.convert_to_matrix()
         finally:
             # remove mslice tracking


### PR DESCRIPTION
**Description of work:**
When the intensity of a cut is changed to GDOS, a two-dimensional MDHisto workspace is created. When converting this to a matrix workspace, the bin size needs to be calculated on base of the second dimension, not the first. I have also added an error message in case a one-dimensional workspace or the second dimension does not have the correct size. This check is now also covered by a unit test.

**To test:**

Follow the instructions in the original issue: https://github.com/mantidproject/mslice/issues/986
In addition, please also check that the following problem does not re-occur: https://github.com/mantidproject/mslice/issues/972

Fixes #986.
