### PR TITLE
Added None as a line option

### DIFF
--- a/src/mslice/plotting/plot_window/plot_options.py
+++ b/src/mslice/plotting/plot_window/plot_options.py
@@ -314,7 +314,7 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
     """This is a widget that has various legend and line controls for each line of a plot"""
 
     # dictionaries used to convert from matplotlib arguments to UI selection and vice versa
-    styles = {'-': 'Solid', '--': 'Dashed', '-.': 'Dashdot', ':': 'Dotted'}
+    styles = {'-': 'Solid', '--': 'Dashed', '-.': 'Dashdot', ':': 'Dotted', 'None': 'None'}
 
     markers = {'o': 'Circle', ',': 'Pixel', '.': 'Point', 'v': 'Triangle down', '^': 'Triangle up',
                     '<': 'Triangle_left', '>': 'Triangle right', '1': 'Arrow down', '2': 'Arrow up',


### PR DESCRIPTION
**Description of work:**

Added a new line style, "None". Here, only the error bars are plotted and not the line. 

**To test:**

1. Load a workspace into MSlice
2. Do a cut
3. Click on the settings icon and change the line style to 'None'
4. Observe that the cut only shows error bars and no line
5. Change the line style to any of the other options
6. Check that the line on the plot is shown with the corresponding line style

Fixes #981 
