### PR TITLE
Omit spectrum ID when saving as ASCII

### DIFF
--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -85,7 +85,7 @@ def save_ascii(workspace, path):
         if isinstance(workspace, HistogramWorkspace):
             _save_cut_to_ascii(workspace, path)
         else:
-            SaveAscii(InputWorkspace=workspace, Filename=path)
+            SaveAscii(InputWorkspace=workspace, Filename=path, WriteSpectrumID=False)
 
 
 def save_matlab(workspace, path):


### PR DESCRIPTION
**Description of work:**

The spectrum ID is now omitted when saving a 2D workspace as an ASCII file.

**To test:**

1. Load a workspace into MSlice
2. Select the workpace in the 2D tab of the workspace manager
3. Click the Save button and select ASCII
4. Check that the second line remains empty

Fixes #993.
