### PR TITLE
Remove mambaforge as miniforge-variant in workflows

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,7 +24,7 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       conda create -n build-env python=3.10
       conda activate build-env
-      conda install -c conda-forge conda-build anaconda-client conda-verify boa
+      mamba install -c conda-forge mamba conda-build anaconda-client conda-verify boa
       conda config --add channels mantid/label/nightly
       conda config --add channels mantid
 
@@ -33,5 +33,5 @@ runs:
     run: |
       conda activate build-env
       conda config --set anaconda_upload yes
-      conda --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
+      conda mambabuild --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       grep "Upload complete" upload.log

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -24,7 +24,7 @@ runs:
       conda config --set always_yes yes --set changeps1 no
       conda create -n build-env python=3.10
       conda activate build-env
-      mamba install -c conda-forge mamba conda-build anaconda-client conda-verify boa
+      conda install -c conda-forge conda-build anaconda-client conda-verify boa
       conda config --add channels mantid/label/nightly
       conda config --add channels mantid
 
@@ -33,5 +33,5 @@ runs:
     run: |
       conda activate build-env
       conda config --set anaconda_upload yes
-      conda mambabuild --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
+      conda --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       grep "Upload complete" upload.log

--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -21,7 +21,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: mslice-env
           environment-file: environment.yml
           auto-activate-base: false

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -30,7 +30,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: mslice-env
           environment-file: environment.yml
           auto-activate-base: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: mslice-env
           environment-file: environment.yml
           auto-activate-base: false

--- a/.github/workflows/unit_tests_nightly.yml
+++ b/.github/workflows/unit_tests_nightly.yml
@@ -19,7 +19,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          miniforge-variant: Mambaforge
           activate-environment: mslice-env
           environment-file: environment.yml
           auto-activate-base: false


### PR DESCRIPTION
**Description of work:**

The option to set mambaforge as a miniforge-variant for the conda incubator is deprecated as mambaforge and miniforge are identical within the conda incubator:
https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/

Subsequently, this setting has been removed in all our GitHub workflows.

**To test:**

Check that the GitHub workflow after pushing to the branch of this PR does not fail: https://github.com/mantidproject/mslice/actions/runs/10937162011

