### PR TITLE
GDOS save_ascii outputting data in single line fix

### DIFF
--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -186,12 +186,14 @@ def load_from_ascii(file_path, ws_name):
 
 def _get_md_histo_xye(histo_ws):
     dim = histo_ws.getDimension(0)
+    if dim.getNBins() == 1:
+        dim = histo_ws.getDimension(1)
     start = dim.getMinimum()
     end = dim.getMaximum()
     nbin = dim.getNBins()
     x = np.linspace(start, end, nbin)
-    y = histo_ws.getSignalArray()
-    e = np.sqrt(histo_ws.getErrorSquaredArray())
+    y = np.squeeze(histo_ws.getSignalArray())
+    e = np.squeeze(np.sqrt(histo_ws.getErrorSquaredArray()))
     if histo_ws.displayNormalization() == MDNormalization.NumEventsNormalization:
         num_events = histo_ws.getNumEventsArray()
         y = y / num_events


### PR DESCRIPTION
**Description of work:**

As noted in [PR#987](https://github.com/mantidproject/mslice/pull/987), a GDOS cut is "tranposed" such that the data is align along the second dimension. The code to extract a set of `x, y, e` from the `MDHisto` workspace explicitly assumes that it is along the first dimension and so fails. This PR fixes this.

**To test:**

Run this script:

```python
import mslice.cli as mc

ws = mc.Load(Filename='MAR21335_Ei60meV.nxs', OutputWorkspace='MAR21335_Ei60meV')
cut_ws = mc.Cut(ws, CutAxis="DeltaE,0.0,55.0,0.25", IntegrationAxis="|Q|,4.0,10.0,0.0", NormToOne=False, IntensityCorrection='gdos', SampleTemperature=300.0)
mc.save_ascii(cut_ws, 'cut_gdos.txt')

cut_ws = mc.Cut(ws, CutAxis="DeltaE,0.0,55.0,0.25", IntegrationAxis="|Q|,4.0,10.0,0.0", NormToOne=False, IntensityCorrection=False, SampleTemperature=None)
mc.save_ascii(cut_ws, 'cut_sqe.txt')
```

and check that both output text files have three data columns. The datafile is included in Mantid test files.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #1004.
