### PR TITLE
Updated mslice docs after interface updates in Mantid

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -8,10 +8,12 @@ MSlice is included in the Mantid distribution so the easiest way to start it is 
 
 .. image:: images/quickstart/mantid_interfaces_menu.png
 
-The version of *MSlice* distributed with Mantid is the last stable version. However, there is currently quite rapid ongoing
-development to the program, which is available in the development version on `GitHub`. To get this version, please
-download this `zip <https://github.com/mantidproject/mslice/archive/main.zip>`_ and extract it to a folder on your computer.
-You can then copy the ``mslice`` subfolder (the folder containing a file called ``__init__.py``) to the
+The version of *MSlice* distributed with Mantid is the last stable version. Starting with *MantidWorkbench* version 6.12, MSlice is
+included as a conda package within *MantidWorkbench*. This enables users to replace the MSlice version within the conda environment
+where *MantidWorkbench* is set up.
+For versions of *MantidWorkbench* prior to 6.12. it is possible to replace MSlice with the latest development version on `GitHub`.
+To get this version, please download this `zip <https://github.com/mantidproject/mslice/archive/main.zip>`_ and extract it to a
+folder on your computer. You can then copy the ``mslice`` subfolder (the folder containing a file called ``__init__.py``) to the
 ``scripts/ExternalInterfaces/`` folder of *Mantid*, which will make the new version accessible from *MantidWorkbench*.
 
 Alternatively, Mslice is available as a conda package via anaconda.org on the `mantid channel <https://anaconda.org/mantid/mslice>`_.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -11,7 +11,7 @@ MSlice is included in the Mantid distribution so the easiest way to start it is 
 The version of *MSlice* distributed with Mantid is the last stable version. Starting with *MantidWorkbench* version 6.12, MSlice is
 included as a conda package within *MantidWorkbench*. This enables users to replace the MSlice version within the conda environment
 where *MantidWorkbench* is set up.
-For versions of *MantidWorkbench* prior to 6.12. it is possible to replace MSlice with the latest development version on `GitHub`.
+For versions of *MantidWorkbench* prior to 6.12., it is possible to replace MSlice with the latest development version on `GitHub`.
 To get this version, please download this `zip <https://github.com/mantidproject/mslice/archive/main.zip>`_ and extract it to a
 folder on your computer. You can then copy the ``mslice`` subfolder (the folder containing a file called ``__init__.py``) to the
 ``scripts/ExternalInterfaces/`` folder of *Mantid*, which will make the new version accessible from *MantidWorkbench*.


### PR DESCRIPTION
**Description of work:**
The MSlice documentation provides information for the user on how to replace MSlice within Mantid Workbench. From Mantid 6.12 on, MSlice will not be an external interface anymore, but a conda package. This needs to be reflected in these instructions.

**To test:**

Please read the instructions and verify whether they make sense. Also, check spelling and grammar.
