### PR TITLE
Catch error for vectors of different length

### DIFF
--- a/src/mslice/util/numpy_helper.py
+++ b/src/mslice/util/numpy_helper.py
@@ -19,7 +19,7 @@ def apply_with_corrected_shape(method, shape_array, array, exception):
             array = np.transpose(array)
         if shape_array.shape[0] in array.shape and shape_array.shape[0] != 1:  # array matches the wrong (leftmost) axis
             return apply_with_swapped_axes(method, shape_array, array)
-        elif shape_array.shape[1] == array.shape[1]:
+        elif shape_array.ndim > 1 and shape_array.shape[1] == array.shape[1]:
             return method(shape_array, array)
         else:
             raise exception


### PR DESCRIPTION
**Description of work:**
We had reports of random Mantid crashes with the following stack trace:

`Stack Trace:
        Traceback (most recent call last):
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/util/numpy_helper.py", line 14, in apply_with_corrected_shape
    return_value = method(shape_array, array)
ValueError: operands could not be broadcast together with shapes (123,) (124,)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/plotting/plot_window/cut_plot.py", line 563, in show_intensity_plot
    if not self._run_temp_dependent(method, previous_type):
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/plotting/plot_window/cut_plot.py", line 576, in _run_temp_dependent
    cut_plotter_method(self._canvas.figure.axes[0])
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/presenters/cut_plotter_presenter.py", line 263, in show_dynamical_susceptibility
    self._show_intensity(self._cut_cache_dict[axes], IntensityType.CHI)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/presenters/cut_plotter_presenter.py", line 255, in _show_intensity
    self._plot_cut(workspace, cached_cut, plot_over=plot_over, intensity_correction=intensity_correction)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/presenters/cut_plotter_presenter.py", line 56, in _plot_cut
    cut_ws = cut.get_intensity_corrected_ws(intensity_correction)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/models/cut/cut.py", line 201, in get_intensity_corrected_ws
    return self.chi
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/models/cut/cut.py", line 157, in chi
    self._chi = compute_chi(self._cut_ws, self.sample_temp, self.e_axis)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/models/intensity_correction_algs.py", line 50, in compute_chi
    out = scattering_data * (chi / mag_scale)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/util/mantid/_workspace_ops.py", line 69, in op_wrapper
    return _binary_op(self, other, algorithm, result_info, inplace, reverse)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/util/mantid/_workspace_ops.py", line 48, in _binary_op
    inner_res = self._binary_op_array(_binary_operator_map[algorithm], other)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/workspace/histo_mixin.py", line 39, in _binary_op_array
    new_signal = apply_with_corrected_shape(operator, signal, other, array_size_error)
  File "/opt/mantidworkbench6.11/scripts/ExternalInterfaces/mslice/util/numpy_helper.py", line 22, in apply_with_corrected_shape
    elif shape_array.shape[1] == array.shape[1]:
IndexError: tuple index out of range
        Using: workbench 6.11.0 on Rocky Linux 8.10 (Green Obsidian)`

Basically, there was an attempt to perform a binary operation on two vectors of different lengths. In this case, it is not possible to change the input arrays to match NumPy's broadcasting rules.

This PR adds a check to prevent this from happening.

**To test:**

Code review only.
