### PR TITLE
Replaced six with Python 3 code

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,7 +38,6 @@ requirements:
   - qtconsole
   - qtpy
   - setuptools
-  - six
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "ipython",
     "numpy",
     "matplotlib>=3.9.2",
-    "six",
     "qtawesome",
     "pre-commit",
     "qtpy",

--- a/src/mslice/cli/_mslice_commands.py
+++ b/src/mslice/cli/_mslice_commands.py
@@ -17,7 +17,6 @@ from mslice.cli.helperfunctions import (_string_to_integration_axis, _process_ax
                                         _check_workspace_type, _correct_intensity)
 from mslice.workspace.pixel_workspace import PixelWorkspace
 from mslice.util.qt.qapp import QAppThreadCall, mainloop
-from six import string_types
 from mslice.workspace.histogram_workspace import HistogramWorkspace
 from mslice.workspace.workspace import Workspace as MSliceWorkspace
 from mslice.util.mantid.mantid_algorithms import *  # noqa: F401, F403
@@ -73,7 +72,7 @@ def Load(Filename, OutputWorkspace=None):
     """
     from mslice.app.presenters import get_dataloader_presenter
 
-    if not isinstance(Filename, string_types):
+    if not isinstance(Filename, str):
         raise RuntimeError('path given to load must be a string')
     merge = False
     if not ospath.exists(Filename):

--- a/src/mslice/models/colors.py
+++ b/src/mslice/models/colors.py
@@ -22,7 +22,6 @@ import re
 
 from matplotlib import rcParams
 
-from six import iteritems
 try:
     from matplotlib.colors import to_hex
 except ImportError:
@@ -103,11 +102,11 @@ def color_to_name(color):
     :raises: ValueError if the color is not known and is not a HEX code
     """
     color_as_hex = to_hex(color)
-    for name, hexvalue in iteritems(_BASIC_COLORS_HEX_MAPPING):
+    for name, hexvalue in _BASIC_COLORS_HEX_MAPPING.items():
         if color_as_hex == hexvalue:
             return name
 
-    for name, value in iteritems(mpl_named_colors()):
+    for name, value in mpl_named_colors().items():
         if color_as_hex == to_hex(value):
             return pretty_name(name)
 

--- a/src/mslice/models/intensity_correction_algs.py
+++ b/src/mslice/models/intensity_correction_algs.py
@@ -1,5 +1,4 @@
 from __future__ import (absolute_import, division, print_function)
-from six import string_types
 import numpy as np
 
 from scipy import constants
@@ -265,7 +264,7 @@ def sample_temperature(ws_name, sample_temp_fields):
             pass
         except AttributeError:
             sample_temp = ws.getExperimentInfo(0).run().getLogData(field_name).value
-    if isinstance(sample_temp, string_types):
+    if isinstance(sample_temp, str):
         sample_temp = get_sample_temperature_from_string(sample_temp)
     elif isinstance(sample_temp, np.ndarray) or isinstance(sample_temp, list):
         sample_temp = np.mean(sample_temp)

--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -11,7 +11,6 @@ from os.path import splitext
 
 import numpy as np
 from scipy import constants
-from six import string_types
 
 import mslice.util.mantid.init_mantid  # noqa: F401
 
@@ -253,7 +252,7 @@ def save_workspaces(workspaces, path, save_name, extension):
         save_method = save_matlab
     else:
         raise RuntimeError("unrecognised file extension")
-    if isinstance(save_name, string_types):
+    if isinstance(save_name, str):
         if len(workspaces) == 1:
             save_names = [save_name]
         else:
@@ -285,7 +284,7 @@ def remove_workspace_from_ads(workspacename):
 def _save_single_ws(workspace, save_name, save_method, path, extension):
     save_as = save_name if save_name is not None else str(workspace) + extension
     full_path = os.path.join(str(path), save_as)
-    if isinstance(workspace, string_types):
+    if isinstance(workspace, str):
         workspace = get_workspace_handle(workspace)
     save_method(workspace, full_path)
 

--- a/src/mslice/models/workspacemanager/workspace_provider.py
+++ b/src/mslice/models/workspacemanager/workspace_provider.py
@@ -1,5 +1,3 @@
-from six import iterkeys, string_types
-
 from mslice.workspace.base import WorkspaceBase as Workspace
 
 _loaded_workspaces = {}
@@ -33,12 +31,12 @@ def rename_workspace(workspace, new_name):
 
 
 def get_visible_workspace_names():
-    return [key for key in iterkeys(_loaded_workspaces) if key[:2] != '__']
+    return [key for key in _loaded_workspaces.keys() if key[:2] != '__']
 
 
 def get_workspace_name(workspace):
     """Returns the name of a workspace given the workspace handle"""
-    if isinstance(workspace, string_types):
+    if isinstance(workspace, str):
         return workspace
     return workspace.name
 

--- a/src/mslice/plotting/plot_window/iplot.py
+++ b/src/mslice/plotting/plot_window/iplot.py
@@ -1,34 +1,33 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class IPlot(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def window_closing(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def plot_options(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def plot_clicked(self, x, y):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def object_clicked(self, target):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def update_legend(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_line_options(self, line):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def set_line_options(self, line, line_options):
         pass

--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -1,7 +1,7 @@
 import os.path
 import weakref
 import io
-import six
+
 from qtpy.QtCore import Qt
 from qtpy import QtCore, QtGui, QtWidgets, QtPrintSupport
 from mslice.util.qt.qapp import (QAppThreadCall, create_qapp_if_required,
@@ -296,7 +296,7 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.window.move(int(center.x() - x), int(center.y() - y))
 
     def get_window_title(self):
-        return six.text_type(self.window.windowTitle())
+        return str(self.window.windowTitle())
 
     def set_window_title(self, title):
         self.window.setWindowTitle(title)

--- a/src/mslice/plotting/plot_window/plot_options.py
+++ b/src/mslice/plotting/plot_window/plot_options.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 from numpy import arange as np_arange
-from six import iteritems
 
 import qtpy.QtWidgets as QtWidgets
 from qtpy.QtCore import Signal
@@ -322,8 +321,8 @@ class LegendAndLineOptionsSetter(QtWidgets.QWidget):
                     '*': 'Star', 'h': 'Hexagon 1', 'H': 'Hexagon 2', '+': 'Plus', 'x': 'X', 'D': 'Diamond',
                     'd': 'Diamond (thin)', '|': 'Vertical line', '_': 'Horizontal line', 'None': 'None'}
 
-    inverse_styles = {v: k for k, v in iteritems(styles)}
-    inverse_markers = {v: k for k, v in iteritems(markers)}
+    inverse_styles = {v: k for k, v in styles.items()}
+    inverse_markers = {v: k for k, v in markers.items()}
 
     def __init__(self, line_options, color_validator, show_legends, remove_line_callback=None):
         super(LegendAndLineOptionsSetter, self).__init__()

--- a/src/mslice/presenters/interfaces/data_loader_presenter.py
+++ b/src/mslice/presenters/interfaces/data_loader_presenter.py
@@ -1,22 +1,21 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class DataLoaderPresenterInterface(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def register_master(self, main_view):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def load_workspace(self, file_paths, merge):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def _report_load_errors(self, ws_names, not_opened, not_loaded):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def workspace_selection_changed(self):
         pass

--- a/src/mslice/presenters/interfaces/main_presenter.py
+++ b/src/mslice/presenters/interfaces/main_presenter.py
@@ -1,62 +1,61 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class MainPresenterInterface(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_selected_workspaces(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def set_selected_workspaces(self, workspace_list):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def update_displayed_workspaces(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def notify_workspace_selection_changed(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def subscribe_to_workspace_selection_monitor(self, client):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def register_workspace_selector(self, workspace_selector):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def change_ws_tab(self, tab):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def highlight_ws_tab(self, tab):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def show_workspace_manager_tab(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def show_tab_for_workspace(self, ws):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def subscribe_to_energy_default_monitor(self, client):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def subscribe_to_cut_algo_default_monitor(self, client):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def is_energy_conversion_allowed(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_cut_algorithm(self):
         pass

--- a/src/mslice/presenters/interfaces/plot_selector.py
+++ b/src/mslice/presenters/interfaces/plot_selector.py
@@ -1,22 +1,21 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class PlotSelectorPresenterInterface(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def register_master(self, main_view):
         pass
 
-    # @abc.abstractmethod
+    # @abstractmethod
     # def load_workspace(self, file_paths, merge):
     #     pass
     #
-    # @abc.abstractmethod
+    # @abstractmethod
     # def _report_load_errors(self, ws_names, not_opened, not_loaded):
     #     pass
 
-    # @abc.abstractmethod
+    # @abstractmethod
     # def workspace_selection_changed(self):
     #     pass

--- a/src/mslice/presenters/interfaces/powder_projection_presenter.py
+++ b/src/mslice/presenters/interfaces/powder_projection_presenter.py
@@ -1,18 +1,17 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class PowderProjectionPresenterInterface(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def register_master(self, main_view):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def notify(self, command):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def workspace_selection_changed(self):
         pass

--- a/src/mslice/presenters/interfaces/slice_plotter_presenter.py
+++ b/src/mslice/presenters/interfaces/slice_plotter_presenter.py
@@ -1,18 +1,17 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class SlicePlotterPresenterInterface(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def register_master(self, main_view):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def notify(self, command):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def workspace_selection_changed(self):
         pass

--- a/src/mslice/presenters/interfaces/workspace_manager_presenter.py
+++ b/src/mslice/presenters/interfaces/workspace_manager_presenter.py
@@ -1,26 +1,25 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class WorkspaceManagerPresenterInterface(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def register_master(self, main_view):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def notify(self, command):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_selected_workspaces(self):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def set_selected_workspaces(self, workspace_list):
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def update_displayed_workspaces(self):
         pass

--- a/src/mslice/presenters/quick_options_presenter.py
+++ b/src/mslice/presenters/quick_options_presenter.py
@@ -1,4 +1,3 @@
-from six import string_types
 from matplotlib import text
 from matplotlib.mathtext import MathTextParser
 from mslice.plotting.plot_window.quick_options import QuickAxisOptions, QuickLabelOptions, QuickLineOptions, QuickError
@@ -8,7 +7,7 @@ def quick_options(target, model, has_logarithmic=None, redraw_signal=None):
     """Find which quick_options to use based on type of target"""
     if isinstance(target, text.Text):
         quick_label_options(model.plot_window, target, redraw_signal)
-    elif isinstance(target, string_types):
+    elif isinstance(target, str):
         return quick_axis_options(model.plot_window, target, model, has_logarithmic, redraw_signal)
     else:
         quick_line_options(model.plot_window, target, model)

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -1,5 +1,4 @@
 from __future__ import (absolute_import, division, print_function)
-from six import string_types
 
 from .busy import show_busy
 from mslice.widgets.workspacemanager.command import Command
@@ -210,7 +209,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         get_index = self._workspace_manager_view.get_workspace_index
         index_list = []
         for item in workspace_list:
-            if isinstance(item, string_types):
+            if isinstance(item, str):
                 index_list.append(get_index(item))
             elif isinstance(item, int):
                 index_list.append(item)

--- a/src/mslice/scripting/__init__.py
+++ b/src/mslice/scripting/__init__.py
@@ -2,7 +2,6 @@ from qtpy import QtGui, QtWidgets
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
 from mslice.scripting.helperfunctions import add_plot_statements, replace_ws_special_chars
 from mslice.app.presenters import get_cut_plotter_presenter
-from six import string_types
 
 
 def generate_script(ws_name, filename=None, plot_handler=None, window=None, clipboard=False):
@@ -76,7 +75,7 @@ def _parse_prop(prop):
     pname = prop.name()
     hidden = False
     output_ws = None
-    if isinstance(pval, string_types):
+    if isinstance(pval, str):
         pval = pval.replace("__MSL", "").replace("_HIDDEN", "")
     if prop.name() == "OutputWorkspace":
         output_ws = replace_ws_special_chars(pval)

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 from uuid import uuid4
-from six import string_types
 
 from mslice.models.workspacemanager.workspace_provider import add_workspace, get_workspace_handle
 from mantid.api import AnalysisDataService, AlgorithmManager, Workspace
@@ -16,7 +15,7 @@ def _parse_ws_names(args, kwargs):
     if input_workspace:
         kwargs['InputWorkspace'] = _name_or_wrapper_to_workspace(input_workspace)
     elif len(args) > 0:
-        if isinstance(args[0], MsliceWorkspace) or isinstance(args[0], string_types):
+        if isinstance(args[0], MsliceWorkspace) or isinstance(args[0], str):
             input_workspace = get_workspace_handle(args[0])
         args = (_name_or_wrapper_to_workspace(args[0]),) + args[1:]
 
@@ -49,7 +48,7 @@ def wrap_algorithm(algorithm):
             kwargs['InputWorkspaces'] = [_name_or_wrapper_to_workspace(arg) for arg in kwargs['InputWorkspaces']]
 
         for ky in [k for k in kwargs.keys() if 'Workspace' in k]:
-            if isinstance(kwargs[ky], string_types) and '__MSL' not in kwargs[ky]:
+            if isinstance(kwargs[ky], str) and '__MSL' not in kwargs[ky]:
                 kwargs[ky] = _name_or_wrapper_to_workspace(kwargs[ky])
 
         if _alg_has_outputws(algorithm):
@@ -81,7 +80,7 @@ def wrap_algorithm(algorithm):
 def _name_or_wrapper_to_workspace(input_ws):
     if isinstance(input_ws, MsliceWorkspace):
         return input_ws.raw_ws
-    elif isinstance(input_ws, string_types):
+    elif isinstance(input_ws, str):
         return get_workspace_handle(input_ws).raw_ws
     else:
         return input_ws

--- a/src/mslice/util/mantid/mantid_algorithms.py
+++ b/src/mslice/util/mantid/mantid_algorithms.py
@@ -4,11 +4,10 @@ from mantid.simpleapi import *  # noqa: F401, F403
 from mantid.simpleapi import _create_algorithm_function
 from mslice.util.mantid.algorithm_wrapper import wrap_algorithm
 from mantid.api import AlgorithmFactory, AlgorithmManager
-from six import iteritems
 
 algorithms = AlgorithmFactory.getRegisteredAlgorithms(False)
 
-for algorithm, versions in iteritems(algorithms):
+for algorithm, versions in algorithms.items():
     try:
         globals()[algorithm] = wrap_algorithm(globals()[algorithm])
     except KeyError:   # Possibly a user defined algorithm

--- a/src/mslice/workspace/base.py
+++ b/src/mslice/workspace/base.py
@@ -1,38 +1,37 @@
-import abc
-from six import add_metaclass
+from abc import ABCMeta, abstractmethod
 
 
-@add_metaclass(abc.ABCMeta)
 class WorkspaceBase(object):
+    __metaclass__ = ABCMeta
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_coordinates(self):
         return
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_signal(self):
         return
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_error(self):
         return
 
-    @abc.abstractmethod
+    @abstractmethod
     def get_variance(self):
         return
 
-    @abc.abstractmethod
+    @abstractmethod
     def rewrap(self, ws):
         return
 
-    @abc.abstractmethod
+    @abstractmethod
     def __neg__(self):
         return
 
-    @abc.abstractmethod
+    @abstractmethod
     def save_attributes(self):
         return
 
-    @abc.abstractmethod
+    @abstractmethod
     def remove_saved_attributes(self):
         return

--- a/tests/cut_widget_presenter_test.py
+++ b/tests/cut_widget_presenter_test.py
@@ -4,8 +4,6 @@ from mock import call, patch
 import unittest
 import warnings
 
-from six import string_types
-
 from mslice.models.axis import Axis
 from mslice.models.alg_workspace_ops import get_available_axes
 from mslice.presenters.cut_plotter_presenter import CutPlotterPresenter
@@ -27,7 +25,7 @@ class CutWidgetPresenterTest(unittest.TestCase):
         integration_start, integration_end, width = tuple(args[2:5])
         intensity_start, intensity_end, is_norm = tuple(args[5:8])
         workspace, integrated_axis, cut_algorithm = tuple(args[8:11])
-        if isinstance(workspace, string_types):
+        if isinstance(workspace, str):
             workspace = [workspace]
         self.main_presenter.get_selected_workspaces = mock.Mock(return_value=workspace)
         self.view.get_cut_axis = mock.Mock(return_value=axis.units)

--- a/tests/energy_units_test.py
+++ b/tests/energy_units_test.py
@@ -1,6 +1,5 @@
 import unittest
 from mslice.models.units import EnergyUnits
-from six import string_types
 
 
 class EnergyUnitsTest(unittest.TestCase):
@@ -12,10 +11,10 @@ class EnergyUnitsTest(unittest.TestCase):
         self.assertEqual(en_unit.factor_from_meV(), 1.)
         self.assertEqual(en_unit.factor_to_meV(), 1.)
         val = list(en_unit.convert_from('meV', 1.))[0]
-        self.assertTrue(isinstance(val, string_types))
+        self.assertTrue(isinstance(val, str))
         self.assertAlmostEqual(float(val),  1., 3)
         val = list(en_unit.convert_to('meV', 1.))[0]
-        self.assertTrue(isinstance(val, string_types))
+        self.assertTrue(isinstance(val, str))
         self.assertAlmostEqual(float(val),  1., 3)
 
     def test_invalid(self):


### PR DESCRIPTION
**Description of work:**
To ensure compatibility with both Python 2 and 3, MSlice used the `six` library. This PR moves it on to Python 3 code instead.

**To test:**

Code review and observe that tests pass.

Fixes #1039.
