### PR TITLE
Added ADSObserver to MSlice

### DIFF
--- a/src/mslice/models/mslice_ads_observer.py
+++ b/src/mslice/models/mslice_ads_observer.py
@@ -1,0 +1,77 @@
+from functools import wraps
+import sys
+
+from mantid.api import AnalysisDataServiceObserver
+
+
+def _catch_exceptions(func):
+    """
+    Catch all exceptions in method and print a traceback to stderr
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception:
+            sys.stderr.write("Error occurred in handler:\n")
+            import traceback
+
+            traceback.print_exc()
+
+    return wrapper
+
+
+class MSliceADSObserver(AnalysisDataServiceObserver):
+    def __init__(self, delete_callback, clear_callback, replace_callback, rename_callback):
+        super(MSliceADSObserver, self).__init__()
+        self.delete_callback = delete_callback
+        self.clear_callback = clear_callback
+        self.replace_callback = replace_callback
+        self.rename_callback = rename_callback
+
+        self.observeDelete(True)
+        self.observeRename(True)
+        self.observeReplace(True)
+        self.observeClear(True)
+
+    @_catch_exceptions
+    def deleteHandle(self, workspace_name, workspace):
+        """
+        Called when the ADS deletes a workspace, removes it from the dict of tracked workspaces.
+        :param workspace_name: name of the workspace
+        :param workspace: reference to the workspace (not used)
+        """
+        self.delete_callback(workspace_name)
+
+    @_catch_exceptions
+    def renameHandle(self, old_workspace_name, new_workspace_name):
+        """
+        Called when the ADS renames a workspace, updates the dict with the new name.
+        :param old_workspace_name: original name of the workspace
+        :param new_workspace_name: new name for the workspace
+        """
+        self.rename_callback(old_workspace_name, new_workspace_name)
+
+    @_catch_exceptions
+    def clearHandle(self):
+        """
+        Called when the ADS has been cleared, removes all data.
+        """
+        self.clear_callback()
+
+    @_catch_exceptions
+    def replaceHandle(self, name, workspace):
+        """
+        Called when the ADS has replaced a workspace with one of the same name.
+        Updates the workspace stored in the dict.
+        :param name: The name of the workspace.
+        :param workspace: A reference to the new workspace
+        """
+        self.replace_callback(name, workspace)
+
+    def unsubscribe(self):
+        self.observeDelete(False)
+        self.observeRename(False)
+        self.observeClear(False)
+        self.observeReplace(False)

--- a/src/mslice/models/mslice_ads_observer.py
+++ b/src/mslice/models/mslice_ads_observer.py
@@ -23,16 +23,14 @@ def _catch_exceptions(func):
 
 
 class MSliceADSObserver(AnalysisDataServiceObserver):
-    def __init__(self, delete_callback, clear_callback, replace_callback, rename_callback):
+    def __init__(self, delete_callback, clear_callback, rename_callback):
         super(MSliceADSObserver, self).__init__()
         self.delete_callback = delete_callback
         self.clear_callback = clear_callback
-        self.replace_callback = replace_callback
         self.rename_callback = rename_callback
 
         self.observeDelete(True)
         self.observeRename(True)
-        self.observeReplace(True)
         self.observeClear(True)
 
     @_catch_exceptions
@@ -59,19 +57,3 @@ class MSliceADSObserver(AnalysisDataServiceObserver):
         Called when the ADS has been cleared, removes all data.
         """
         self.clear_callback()
-
-    @_catch_exceptions
-    def replaceHandle(self, name, workspace):
-        """
-        Called when the ADS has replaced a workspace with one of the same name.
-        Updates the workspace stored in the dict.
-        :param name: The name of the workspace.
-        :param workspace: A reference to the new workspace
-        """
-        self.replace_callback(name, workspace)
-
-    def unsubscribe(self):
-        self.observeDelete(False)
-        self.observeRename(False)
-        self.observeClear(False)
-        self.observeReplace(False)

--- a/src/mslice/models/workspacemanager/workspace_provider.py
+++ b/src/mslice/models/workspacemanager/workspace_provider.py
@@ -36,6 +36,10 @@ def get_visible_workspace_names():
     return [key for key in iterkeys(_loaded_workspaces) if key[:2] != '__']
 
 
+def get_workspace_names():
+    return [key for key in iterkeys(_loaded_workspaces)]
+
+
 def get_workspace_name(workspace):
     """Returns the name of a workspace given the workspace handle"""
     if isinstance(workspace, string_types):

--- a/src/mslice/models/workspacemanager/workspace_provider.py
+++ b/src/mslice/models/workspacemanager/workspace_provider.py
@@ -37,7 +37,7 @@ def get_visible_workspace_names():
 
 
 def get_workspace_names():
-    return [key for key in iterkeys(_loaded_workspaces)]
+    return [key for key in _loaded_workspaces.keys()]
 
 
 def get_workspace_name(workspace):

--- a/src/mslice/plotting/plot_window/interactive_cut.py
+++ b/src/mslice/plotting/plot_window/interactive_cut.py
@@ -114,7 +114,7 @@ class InteractiveCut(object):
         self.plot_cut(*self.rect.extents)
 
     def window_closing(self):
-        self.slice_plot.toggle_interactive_cuts()
+        self.slice_plot.toggle_interactive_cuts(False)
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
 
     def refresh_rect_selector(self, ax):
@@ -125,8 +125,9 @@ class InteractiveCut(object):
         self.rect.extents = extents
         self.slice_plot.set_cross_cursor()
 
-    def store_icut_cut_upon_toggle_and_reset(self):
-        self._cut_plotter_presenter.store_icut_cut()
+    def store_icut_cut_upon_toggle_and_reset(self, store=True):
+        if store:
+            self._cut_plotter_presenter.store_icut_cut()
         self._cut_plotter_presenter.set_icut_cut(None)
 
     def set_icut_intensity_category(self, intensity_type):

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -403,11 +403,11 @@ class SlicePlot(IPlot):
         self.update_legend()
         self._canvas.draw()
 
-    def toggle_interactive_cuts(self):
-        self.toggle_icut_button()
+    def toggle_interactive_cuts(self, store=True):
+        self.toggle_icut_button(store)
         self.toggle_icut()
 
-    def toggle_icut_button(self):
+    def toggle_icut_button(self, store=True):
         if not self.icut:
             self.manager.picking_connected(False)
             if self.plot_window.action_zoom_in.isChecked():
@@ -428,7 +428,7 @@ class SlicePlot(IPlot):
             self.plot_window.action_flip_axis.setVisible(False)
             self._canvas.setCursor(Qt.ArrowCursor)
             self.icut.set_icut_intensity_category(self.intensity_type)
-            self.icut.store_icut_cut_upon_toggle_and_reset()
+            self.icut.store_icut_cut_upon_toggle_and_reset(store)
             self.plot_window.menu_intensity.setDisabled(False)
 
     def toggle_icut(self):

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -4,13 +4,15 @@ from six import string_types
 from .busy import show_busy
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
+from mslice.models.mslice_ads_observer import MSliceADSObserver
 from mslice.models.workspacemanager.file_io import get_save_directory
 from mslice.models.workspacemanager.workspace_algorithms import (save_workspaces, export_workspace_to_ads, subtract,
                                                                  is_pixel_workspace, combine_workspace,
                                                                  add_workspace_runs, scale_workspaces,
                                                                  remove_workspace_from_ads)
 from mslice.models.workspacemanager.workspace_provider import (get_workspace_handle, get_visible_workspace_names,
-                                                               get_workspace_name, delete_workspace, rename_workspace)
+                                                               get_workspace_names, get_workspace_name,
+                                                               delete_workspace, rename_workspace)
 from .interfaces.workspace_manager_presenter import WorkspaceManagerPresenterInterface
 from .interfaces.main_presenter import MainPresenterInterface
 from .validation_decorators import require_main_presenter
@@ -38,6 +40,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 lambda: self._workspace_manager_view._display_error('Please select a Compose action from the dropdown menu'),
             Command.Scale: self._scale_workspace,
             Command.Bose: lambda: self._scale_workspace(is_bose=True)}
+        self._ads_observer = MSliceADSObserver(self.delete_handle, self.clear_handle, self.rename_handle)
 
     def register_master(self, main_presenter):
         assert (isinstance(main_presenter, MainPresenterInterface))
@@ -228,3 +231,19 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
 
     def _clear_displayed_error(self):
         self._workspace_manager_view.clear_displayed_error()
+
+    def delete_handle(self, workspace):
+        delete_workspace(workspace)
+        self.update_displayed_workspaces()
+
+    def clear_handle(self):
+        for workspace in get_workspace_names():
+            delete_workspace(workspace)
+        self.update_displayed_workspaces()
+
+    def rename_handle(self, workspace, new_name):
+        if new_name is None:
+            return
+        if workspace in get_visible_workspace_names():
+            rename_workspace(workspace, new_name)
+            self.update_displayed_workspaces()

--- a/src/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/src/mslice/widgets/workspacemanager/workspacemanager.py
@@ -88,12 +88,15 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
             raise TypeError("Loaded file is not a valid workspace")
 
     def display_loaded_workspaces(self, workspaces):
+        to_be_removed = []
         for workspace in workspaces:
             if workspace not in self.onscreen_workspaces:
                 self.add_workspace(workspace)
         for workspace in self.onscreen_workspaces:
             if workspace not in workspaces:
-                self.remove_workspace(workspace)
+                to_be_removed.append(workspace)
+        for workspace in to_be_removed:
+            self.remove_workspace(workspace)
 
     def remove_workspace(self, workspace):
         """Remove workspace from list.

--- a/tests/workspacemanager_presenter_ads_test.py
+++ b/tests/workspacemanager_presenter_ads_test.py
@@ -31,7 +31,8 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
           presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        workspace = CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        AnalysisDataService.addOrReplace("ws", workspace)
         AnalysisDataService.clear(True)
 
         presenter.clear_handle.assert_called_once()
@@ -44,8 +45,8 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        print(AnalysisDataService.getObjectNames())
+        workspace = CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        AnalysisDataService.addOrReplace("ws", workspace)
         AnalysisDataService.remove("ws")
 
         presenter.delete_handle.assert_called_once_with("ws")
@@ -58,7 +59,8 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        workspace = CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        AnalysisDataService.addOrReplace("ws", workspace)
         RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
 
         presenter.rename_handle.assert_called_once_with("ws", "ws1")

--- a/tests/workspacemanager_presenter_ads_test.py
+++ b/tests/workspacemanager_presenter_ads_test.py
@@ -1,68 +1,52 @@
 from __future__ import (absolute_import, division, print_function)
 import unittest
 
-import mock
 from mock import MagicMock
 
 from mantid.api import AnalysisDataService
-from mantid.simpleapi import RenameWorkspace
+from mantid.simpleapi import CreateSampleWorkspace, RenameWorkspace
 
 from mslice.models.mslice_ads_observer import MSliceADSObserver
-from mslice.models.workspacemanager.workspace_algorithms import export_workspace_to_ads
-from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
-from mslice.views.interfaces.mainview import MainView
-from mslice.views.interfaces.workspace_view import WorkspaceView
-from tests.testhelpers.workspace_creator import create_workspace
 
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.test_workspace = create_workspace('ws')
-
-    def setUp(self):
-        self.view = mock.create_autospec(spec=WorkspaceView)
-        self.mainview = mock.create_autospec(MainView)
-        self.main_presenter = mock.create_autospec(MainPresenterInterface)
-        self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
-
     def test_ensure_that_the_ads_observer_calls_delete_handle(self):
-        presenter = WorkspaceManagerPresenter(self.view)
+        presenter = WorkspaceManagerPresenter(MagicMock())
         presenter.delete_handle = MagicMock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        export_workspace_to_ads(self.test_workspace)
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
         AnalysisDataService.remove("ws")
 
         presenter.delete_handle.assert_called_once_with("ws")
 
     def test_ensure_that_the_ads_observer_calls_rename_handle(self):
-        presenter = WorkspaceManagerPresenter(self.view)
+        presenter = WorkspaceManagerPresenter(MagicMock())
         presenter.rename_handle = MagicMock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        export_workspace_to_ads(self.test_workspace)
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
         RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
 
         presenter.rename_handle.assert_called_once_with("ws", "ws1")
 
     def test_ensure_that_the_ads_observer_calls_clear_handle(self):
-        presenter = WorkspaceManagerPresenter(self.view)
+        presenter = WorkspaceManagerPresenter(MagicMock())
         presenter.clear_handle = MagicMock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
           presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        export_workspace_to_ads(self.test_workspace)
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
         AnalysisDataService.clear(True)
 
         presenter.clear_handle.assert_called_once()

--- a/tests/workspacemanager_presenter_ads_test.py
+++ b/tests/workspacemanager_presenter_ads_test.py
@@ -1,0 +1,68 @@
+from __future__ import (absolute_import, division, print_function)
+import unittest
+
+import mock
+from mock import MagicMock
+
+from mantid.api import AnalysisDataService
+from mantid.simpleapi import RenameWorkspace
+
+from mslice.models.mslice_ads_observer import MSliceADSObserver
+from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
+from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
+from mslice.views.interfaces.mainview import MainView
+from mslice.views.interfaces.workspace_view import WorkspaceView
+from mslice.util.mantid.mantid_algorithms import CreateSampleWorkspace
+
+
+class WorkspaceManagerPresenterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.view = mock.create_autospec(spec=WorkspaceView)
+        self.mainview = mock.create_autospec(MainView)
+        self.main_presenter = mock.create_autospec(MainPresenterInterface)
+        self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
+
+    def test_ensure_that_the_ads_observer_calls_clear_handle(self):
+        presenter = WorkspaceManagerPresenter(self.view)
+        presenter.clear_handle = MagicMock()
+        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        presenter._ads_observer = MSliceADSObserver(
+          presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        )
+
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        AnalysisDataService.clear(True)
+
+        presenter.clear_handle.assert_called_once()
+
+    def test_ensure_that_the_ads_observer_calls_delete_handle(self):
+        presenter = WorkspaceManagerPresenter(self.view)
+        presenter.delete_handle = MagicMock()
+        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        presenter._ads_observer = MSliceADSObserver(
+            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        )
+
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        print(AnalysisDataService.getObjectNames())
+        AnalysisDataService.remove("ws")
+
+        presenter.delete_handle.assert_called_once_with("ws")
+
+    def test_ensure_that_the_ads_observer_calls_rename_handle(self):
+        presenter = WorkspaceManagerPresenter(self.view)
+        presenter.rename_handle = MagicMock()
+        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        presenter._ads_observer = MSliceADSObserver(
+            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        )
+
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
+
+        presenter.rename_handle.assert_called_once_with("ws", "ws1")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/workspacemanager_presenter_ads_test.py
+++ b/tests/workspacemanager_presenter_ads_test.py
@@ -3,28 +3,24 @@ import unittest
 
 import mock
 from mock import MagicMock
-import numpy as np
 
 from mantid.api import AnalysisDataService
 from mantid.simpleapi import RenameWorkspace
 
 from mslice.models.mslice_ads_observer import MSliceADSObserver
+from mslice.models.workspacemanager.workspace_algorithms import export_workspace_to_ads
 from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.views.interfaces.mainview import MainView
 from mslice.views.interfaces.workspace_view import WorkspaceView
-from mslice.util.mantid.mantid_algorithms import CreateWorkspace
-from mslice.util.mantid.algorithm_wrapper import add_to_ads
+from tests.testhelpers.workspace_creator import create_workspace
 
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        x = np.linspace(0, 99, 100)
-        y = x * 1
-        e = y * 0 + 2
-        cls.m_workspace = CreateWorkspace(x, y, e, OutputWorkspace="ws")
+        cls.test_workspace = create_workspace('ws')
 
     def setUp(self):
         self.view = mock.create_autospec(spec=WorkspaceView)
@@ -40,7 +36,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        add_to_ads(self.m_workspace)
+        export_workspace_to_ads(self.test_workspace)
         AnalysisDataService.remove("ws")
 
         presenter.delete_handle.assert_called_once_with("ws")
@@ -53,7 +49,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        add_to_ads(self.m_workspace)
+        export_workspace_to_ads(self.test_workspace)
         RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
 
         presenter.rename_handle.assert_called_once_with("ws", "ws1")
@@ -66,7 +62,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
           presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        add_to_ads(self.m_workspace)
+        export_workspace_to_ads(self.test_workspace)
         AnalysisDataService.clear(True)
 
         presenter.clear_handle.assert_called_once()

--- a/tests/workspacemanager_presenter_ads_test.py
+++ b/tests/workspacemanager_presenter_ads_test.py
@@ -31,8 +31,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
           presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        workspace = CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        AnalysisDataService.addOrReplace("ws", workspace)
+        AnalysisDataService.addOrReplace("ws", CreateSampleWorkspace(OutputWorkspace="ws"))
         AnalysisDataService.clear(True)
 
         presenter.clear_handle.assert_called_once()
@@ -45,8 +44,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        workspace = CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        AnalysisDataService.addOrReplace("ws", workspace)
+        AnalysisDataService.addOrReplace("ws", CreateSampleWorkspace(OutputWorkspace="ws"))
         AnalysisDataService.remove("ws")
 
         presenter.delete_handle.assert_called_once_with("ws")
@@ -59,8 +57,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        workspace = CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        AnalysisDataService.addOrReplace("ws", workspace)
+        AnalysisDataService.addOrReplace("ws", CreateSampleWorkspace(OutputWorkspace="ws"))
         RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
 
         presenter.rename_handle.assert_called_once_with("ws", "ws1")

--- a/tests/workspacemanager_presenter_ads_test.py
+++ b/tests/workspacemanager_presenter_ads_test.py
@@ -12,6 +12,9 @@ from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresen
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
 
+    def setUp(self):
+        AnalysisDataService.clear(True)
+
     def test_ensure_that_the_ads_observer_calls_delete_handle(self):
         presenter = WorkspaceManagerPresenter(MagicMock())
         presenter.delete_handle = MagicMock()

--- a/tests/workspacemanager_presenter_ads_test.py
+++ b/tests/workspacemanager_presenter_ads_test.py
@@ -12,9 +12,6 @@ from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresen
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
 
-    def setUp(self):
-        AnalysisDataService.clear(True)
-
     def test_ensure_that_the_ads_observer_calls_delete_handle(self):
         presenter = WorkspaceManagerPresenter(MagicMock())
         presenter.delete_handle = MagicMock()

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -38,6 +38,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.mainview = mock.create_autospec(MainView)
         self.main_presenter = mock.create_autospec(MainPresenterInterface)
         self.mainview.get_presenter = mock.Mock(return_value=self.main_presenter)
+        self._ads_observer = mock.Mock()
 
     def test_register_master_success(self):
         workspace_presenter = WorkspaceManagerPresenter(self.view)
@@ -168,12 +169,12 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         # Create a workspace that reports a single selected workspace on calls to get_workspace_selected
         workspace_to_be_removed = CloneWorkspace(self.m_workspace.raw_ws, OutputWorkspace='file1')
         self.view.get_workspace_selected = mock.Mock(return_value=[workspace_to_be_removed])
-        self.view.display_loaded_workspaces = mock.Mock()
 
         self.presenter.notify(Command.RemoveSelectedWorkspaces)
         self.view.get_workspace_selected.assert_called_once_with()
-        delete_ws_mock.assert_called_once_with(workspace_to_be_removed)
-        self.view.display_loaded_workspaces.assert_called_once()
+        delete_calls = [call(workspace_to_be_removed)]
+        delete_ws_mock.assert_has_calls(delete_calls)
+        self.assertTrue(self.view.display_loaded_workspaces.called)
 
     @patch('mslice.presenters.workspace_manager_presenter.delete_workspace')
     def test_remove_multiple_workspaces(self, delete_ws_mock):

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -458,6 +458,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         )
 
         CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        print(AnalysisDataService.getObjectNames())
         AnalysisDataService.remove("ws")
 
         presenter.delete_handle.assert_called_once_with("ws")
@@ -471,6 +472,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         )
 
         CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        print(AnalysisDataService.getObjectNames())
         RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
 
         presenter.rename_handle.assert_called_once_with("ws", "ws1")

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -436,21 +436,6 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.ComposeWorkspace)
         self.view._display_error.assert_called()
 
-    def test_ensure_that_the_ads_observer_calls_delete_handle(self):
-        presenter = WorkspaceManagerPresenter(self.view)
-        presenter.delete_handle = mock.Mock()
-        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
-        presenter._ads_observer = MSliceADSObserver(
-            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
-        )
-
-        # Ensure ADS is empty before test
-        AnalysisDataService.clear(True)
-        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        AnalysisDataService.remove("ws")
-
-        presenter.delete_handle.assert_called_once_with("ws")
-
     def test_ensure_that_the_ads_observer_calls_clear_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)
         presenter.clear_handle = mock.Mock()
@@ -459,12 +444,23 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
-        # Ensure ADS is empty before test
-        AnalysisDataService.clear(True)
         CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
         AnalysisDataService.clear(True)
 
         presenter.clear_handle.assert_called_once()
+
+    def test_ensure_that_the_ads_observer_calls_delete_handle(self):
+        presenter = WorkspaceManagerPresenter(self.view)
+        presenter.delete_handle = mock.Mock()
+        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        presenter._ads_observer = MSliceADSObserver(
+            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        )
+
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        AnalysisDataService.remove("ws")
+
+        presenter.delete_handle.assert_called_once_with("ws")
 
     def test_ensure_that_the_ads_observer_calls_rename_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -436,32 +436,32 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.ComposeWorkspace)
         self.view._display_error.assert_called()
 
-    def test_ensure_that_the_ads_observer_calls_clear_handle(self):
-        presenter = WorkspaceManagerPresenter(self.view)
-        presenter.clear_handle = MagicMock()
-        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
-        presenter._ads_observer = MSliceADSObserver(
-            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
-        )
+    # def test_ensure_that_the_ads_observer_calls_clear_handle(self):
+        # presenter = WorkspaceManagerPresenter(self.view)
+        # presenter.clear_handle = MagicMock()
+        # self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        # presenter._ads_observer = MSliceADSObserver(
+        #   presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        # )
 
-        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        AnalysisDataService.clear(True)
+        # CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        # AnalysisDataService.clear(True)
 
-        presenter.clear_handle.assert_called_once()
+        # presenter.clear_handle.assert_called_once()
 
-    def test_ensure_that_the_ads_observer_calls_delete_handle(self):
-        presenter = WorkspaceManagerPresenter(self.view)
-        presenter.delete_handle = MagicMock()
-        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
-        presenter._ads_observer = MSliceADSObserver(
-            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
-        )
+    # def test_ensure_that_the_ads_observer_calls_delete_handle(self):
+        # presenter = WorkspaceManagerPresenter(self.view)
+        # presenter.delete_handle = MagicMock()
+        # self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        # presenter._ads_observer = MSliceADSObserver(
+        #     presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        # )
 
-        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        print(AnalysisDataService.getObjectNames())
-        AnalysisDataService.remove("ws")
+        # CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        # print(AnalysisDataService.getObjectNames())
+        # AnalysisDataService.remove("ws")
 
-        presenter.delete_handle.assert_called_once_with("ws")
+        # presenter.delete_handle.assert_called_once_with("ws")
 
     def test_ensure_that_the_ads_observer_calls_rename_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -2,13 +2,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import mock
-from mock import call, patch, MagicMock
+from mock import call, patch
 import numpy as np
 
-from mantid.api import AnalysisDataService
-from mantid.simpleapi import RenameWorkspace
-
-from mslice.models.mslice_ads_observer import MSliceADSObserver
 from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.views.interfaces.mainview import MainView
@@ -16,7 +12,7 @@ from mslice.views.interfaces.workspace_view import WorkspaceView
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.util.mantid.mantid_algorithms import (AddSampleLog, CreateWorkspace, CreateSimulationWorkspace,
-                                                  ConvertToMD, CloneWorkspace, CreateSampleWorkspace)
+                                                  ConvertToMD, CloneWorkspace)
 
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
@@ -435,47 +431,6 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view._display_error = mock.Mock()
         self.presenter.notify(Command.ComposeWorkspace)
         self.view._display_error.assert_called()
-
-    # def test_ensure_that_the_ads_observer_calls_clear_handle(self):
-        # presenter = WorkspaceManagerPresenter(self.view)
-        # presenter.clear_handle = MagicMock()
-        # self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
-        # presenter._ads_observer = MSliceADSObserver(
-        #   presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
-        # )
-
-        # CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        # AnalysisDataService.clear(True)
-
-        # presenter.clear_handle.assert_called_once()
-
-    # def test_ensure_that_the_ads_observer_calls_delete_handle(self):
-        # presenter = WorkspaceManagerPresenter(self.view)
-        # presenter.delete_handle = MagicMock()
-        # self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
-        # presenter._ads_observer = MSliceADSObserver(
-        #     presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
-        # )
-
-        # CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        # print(AnalysisDataService.getObjectNames())
-        # AnalysisDataService.remove("ws")
-
-        # presenter.delete_handle.assert_called_once_with("ws")
-
-    def test_ensure_that_the_ads_observer_calls_rename_handle(self):
-        presenter = WorkspaceManagerPresenter(self.view)
-        presenter.rename_handle = MagicMock()
-        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
-        presenter._ads_observer = MSliceADSObserver(
-            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
-        )
-
-        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        print(AnalysisDataService.getObjectNames())
-        RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
-
-        presenter.rename_handle.assert_called_once_with("ws", "ws1")
 
 
 if __name__ == '__main__':

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import mock
-from mock import call, patch
+from mock import call, patch, MagicMock
 import numpy as np
 
 from mantid.api import AnalysisDataService
@@ -438,7 +438,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_ensure_that_the_ads_observer_calls_clear_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)
-        presenter.clear_handle = mock.Mock()
+        presenter.clear_handle = MagicMock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
@@ -451,7 +451,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_ensure_that_the_ads_observer_calls_delete_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)
-        presenter.delete_handle = mock.Mock()
+        presenter.delete_handle = MagicMock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
@@ -464,7 +464,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_ensure_that_the_ads_observer_calls_rename_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)
-        presenter.rename_handle = mock.Mock()
+        presenter.rename_handle = MagicMock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import mock
-from mock import call, patch, MagicMock
+from mock import call, patch
 import numpy as np
 
 from mantid.api import AnalysisDataService
@@ -438,12 +438,14 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_ensure_that_the_ads_observer_calls_delete_handle(self, _):
         presenter = WorkspaceManagerPresenter(self.view)
-        presenter.delete_handle = MagicMock()
+        presenter.delete_handle = mock.Mock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
+        # Ensure ADS is empty before test
+        AnalysisDataService.clear()
         CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
         AnalysisDataService.remove("ws")
 
@@ -451,12 +453,14 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_ensure_that_the_ads_observer_calls_clear_handle(self, _):
         presenter = WorkspaceManagerPresenter(self.view)
-        presenter.clear_handle = MagicMock()
+        presenter.clear_handle = mock.Mock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
         )
 
+        # Ensure ADS is empty before test
+        AnalysisDataService.clear()
         CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
         AnalysisDataService.clear()
 
@@ -464,7 +468,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
     def test_ensure_that_the_ads_observer_calls_rename_handle(self, _):
         presenter = WorkspaceManagerPresenter(self.view)
-        presenter.rename_handle = MagicMock()
+        presenter.rename_handle = mock.Mock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
         presenter._ads_observer = MSliceADSObserver(
             presenter.delete_handle, presenter.clear_handle, presenter.rename_handle

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -2,9 +2,13 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import mock
-from mock import call, patch
+from mock import call, patch, MagicMock
 import numpy as np
 
+from mantid.api import AnalysisDataService
+from mantid.simpleapi import RenameWorkspace
+
+from mslice.models.mslice_ads_observer import MSliceADSObserver
 from mslice.presenters.interfaces.main_presenter import MainPresenterInterface
 from mslice.presenters.workspace_manager_presenter import WorkspaceManagerPresenter
 from mslice.views.interfaces.mainview import MainView
@@ -12,7 +16,7 @@ from mslice.views.interfaces.workspace_view import WorkspaceView
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.util.mantid.mantid_algorithms import (AddSampleLog, CreateWorkspace, CreateSimulationWorkspace,
-                                                  ConvertToMD, CloneWorkspace)
+                                                  ConvertToMD, CloneWorkspace, CreateSampleWorkspace)
 
 
 class WorkspaceManagerPresenterTest(unittest.TestCase):
@@ -431,6 +435,45 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view._display_error = mock.Mock()
         self.presenter.notify(Command.ComposeWorkspace)
         self.view._display_error.assert_called()
+
+    def test_ensure_that_the_ads_observer_calls_delete_handle(self, _):
+        presenter = WorkspaceManagerPresenter(self.view)
+        presenter.delete_handle = MagicMock()
+        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        presenter._ads_observer = MSliceADSObserver(
+            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        )
+
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        AnalysisDataService.remove("ws")
+
+        presenter.delete_handle.assert_called_once_with("ws")
+
+    def test_ensure_that_the_ads_observer_calls_clear_handle(self, _):
+        presenter = WorkspaceManagerPresenter(self.view)
+        presenter.clear_handle = MagicMock()
+        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        presenter._ads_observer = MSliceADSObserver(
+            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        )
+
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        AnalysisDataService.clear()
+
+        presenter.clear_handle.assert_called_once()
+
+    def test_ensure_that_the_ads_observer_calls_rename_handle(self, _):
+        presenter = WorkspaceManagerPresenter(self.view)
+        presenter.rename_handle = MagicMock()
+        self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
+        presenter._ads_observer = MSliceADSObserver(
+            presenter.delete_handle, presenter.clear_handle, presenter.rename_handle
+        )
+
+        CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
+        RenameWorkspace(InputWorkspace="ws", OutputWorkspace="ws1")
+
+        presenter.rename_handle.assert_called_once_with("ws", "ws1")
 
 
 if __name__ == '__main__':

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -445,7 +445,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         )
 
         # Ensure ADS is empty before test
-        AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
         CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
         AnalysisDataService.remove("ws")
 
@@ -460,9 +460,9 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         )
 
         # Ensure ADS is empty before test
-        AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
         CreateSampleWorkspace(OutputWorkspace="ws", StoreInADS=True)
-        AnalysisDataService.clear()
+        AnalysisDataService.clear(True)
 
         presenter.clear_handle.assert_called_once()
 

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -436,7 +436,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.ComposeWorkspace)
         self.view._display_error.assert_called()
 
-    def test_ensure_that_the_ads_observer_calls_delete_handle(self, _):
+    def test_ensure_that_the_ads_observer_calls_delete_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)
         presenter.delete_handle = mock.Mock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
@@ -451,7 +451,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
         presenter.delete_handle.assert_called_once_with("ws")
 
-    def test_ensure_that_the_ads_observer_calls_clear_handle(self, _):
+    def test_ensure_that_the_ads_observer_calls_clear_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)
         presenter.clear_handle = mock.Mock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))
@@ -466,7 +466,7 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
         presenter.clear_handle.assert_called_once()
 
-    def test_ensure_that_the_ads_observer_calls_rename_handle(self, _):
+    def test_ensure_that_the_ads_observer_calls_rename_handle(self):
         presenter = WorkspaceManagerPresenter(self.view)
         presenter.rename_handle = mock.Mock()
         self.assertTrue(isinstance(presenter._ads_observer, MSliceADSObserver))


### PR DESCRIPTION
**Description of work:**
So far MSlice interacted with the ADS in a one-sided way. Some of its workspaces were stored in the ADS and occasionally deleted, but changes to the ADS from the Mantid side ignored. This sometimes led to missing workspaces in MSlice when the respective workspace was deleted on the Mantid side. However, the respective workspace would still get displayed in MSlice and cause a crash when selected.

This PR introduces an ADS observer that modifies MSlice workspaces on delete, clear and rename, respectively. 
In addition, two small bugs were fixed that became obvious when testing these changes:
1. When taking an interactive cut and closing the interactive cut window without saving the cut to the workspace, a cut was showing up in the MD Histo tab. 
2. When clearing all workspace, there were still workspaces shown in the MD Histo tab that were not available anymore and caused crashes on selection. This was particularly visible after a clear() from the ADS that should cause all workspaces in all tabs to get cleared.

**To test:**

With workspaces saved to the ADS from the MSlice interface, check that the ADS commands clear, delete and rename work as expected in MSlice when run from Mantid.


Fixes #839.
