### PR TITLE
Improve deletion of workspaces that are in the ADS

### DIFF
--- a/src/mslice/models/workspacemanager/workspace_provider.py
+++ b/src/mslice/models/workspacemanager/workspace_provider.py
@@ -46,7 +46,10 @@ def get_workspace_name(workspace):
 
 
 def delete_workspace(workspace):
-    workspace = get_workspace_handle(workspace)
+    try:
+        workspace = get_workspace_handle(workspace)
+    except KeyError:
+        return None
     remove_workspace(workspace)
     del workspace
 

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -98,6 +98,13 @@ def remove_from_ads(workspacename):
     if AnalysisDataService.Instance().doesExist(workspacename):
         AnalysisDataService.Instance().remove(workspacename)
     # Remove hidden workspaces from ADS
-    workspacename = '__MSL' + workspacename
-    if AnalysisDataService.Instance().doesExist(workspacename):
-        AnalysisDataService.Instance().remove(workspacename)
+    hiddenworkspace = '__MSL' + workspacename
+    if AnalysisDataService.Instance().doesExist(hiddenworkspace):
+        AnalysisDataService.Instance().remove(hiddenworkspace)
+    hiddenworkspace = '__MSL__mat' + workspacename
+    if AnalysisDataService.Instance().doesExist(hiddenworkspace):
+        AnalysisDataService.Instance().remove(hiddenworkspace)
+    hiddenworkspace = '__MSL' + workspacename + '_HIDDEN'
+    print(AnalysisDataService.Instance().getObjectNames())
+    if AnalysisDataService.Instance().doesExist(hiddenworkspace):
+        AnalysisDataService.Instance().remove(hiddenworkspace)


### PR DESCRIPTION
**Description of work:**
Deleting a workspace within MSlice that is also in the ADS caused a crash in Mantid. The reason was that deleting the workspace in MSlice updated the ADS and, as a result, the ADS triggered a deletion request for this workspace in MSlice. This request then failed as the workspace was already deleted within MSlice. To avoid this situation, MSlice does not attempt to delete non-existing workspaces anymore. In addition, all corresponding hidden workspaces are now deleted from the ADS as well.

**To test:**

Follow the instructions on the original issue.

Fixes #1044.
