### PR TITLE
Catch unhandled exceptions

### DIFF
--- a/src/mslice/models/workspacemanager/workspace_provider.py
+++ b/src/mslice/models/workspacemanager/workspace_provider.py
@@ -19,12 +19,18 @@ def add_workspace(workspace, name):
 
 
 def remove_workspace(workspace):
-    workspace = get_workspace_handle(workspace)
+    try:
+        workspace = get_workspace_handle(workspace)
+    except KeyError:
+        return
     del _loaded_workspaces[workspace.name]
 
 
 def rename_workspace(workspace, new_name):
-    workspace = get_workspace_handle(workspace)
+    try:
+        workspace = get_workspace_handle(workspace)
+    except KeyError:
+        return
     _loaded_workspaces[new_name] = _loaded_workspaces.pop(workspace.name)
     workspace.name = new_name
     return workspace
@@ -49,7 +55,7 @@ def delete_workspace(workspace):
     try:
         workspace = get_workspace_handle(workspace)
     except KeyError:
-        return None
+        return
     remove_workspace(workspace)
     del workspace
 


### PR DESCRIPTION
**Description of work:**
When testing the new ADS observer, unreliable unhandled exceptions occurred when following testing instructions in https://developer.mantidproject.org/Testing/Direct/MSliceTestGuide.html#interaction-with-ads. This PR catches these exceptions to avoid crashes.

**To test:**

Replace the MSlice version in the current Mantid nightly and follow the instructions in the issue below.

Fixes #[38675](https://github.com/mantidproject/mantid/issues/38675)

(Since this is in a different repo, we will have to manually close this Mantid issue.)