### PR TITLE
Catch error when saving MDEventWorkspace2D as matlab

### DIFF
--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -103,6 +103,11 @@ def save_ascii(workspace, path):
 
 
 def save_matlab(workspace, path):
+    loader_name = get_workspace_handle(workspace).loader_name()
+    if loader_name is not None and loader_name == "LoadNXSPE":
+        raise RuntimeError(
+            "An NXSPE file cannot be saved as matlab - metadata may be lost."
+        )
     labels = {}
     if isinstance(workspace, HistogramWorkspace):
         if workspace.is_slice:


### PR DESCRIPTION
**Description of work:**

To avoid Mantid crashing when attempting to save an MDEventWorkspace2D as matlab, this error is now caught and the corresponding error message displayed on the MSlice interface.

**To test:**

Follow the instructions in the original issue.

Fixes #1052. 
