### PR TITLE
Remove invisible workspace from MSlice when deleted in ADS

### DIFF
--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -271,6 +271,8 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
         self._workspace_manager_view.clear_displayed_error()
 
     def delete_handle(self, workspace):
+        if workspace.startswith("__MSL"):
+            workspace = workspace[5:]
         delete_workspace(workspace)
         self.update_displayed_workspaces()
 


### PR DESCRIPTION
**Description of work:**
Added code that allows the user to delete a hidden workspace in the ADS, so that the corresponding workspace is deleted in MSlice as well. This prevents crashes when this workspace is accessed again after deletion. Before, this was only possible with visible workspaces.

**To test:**

Follow the steps to reproduce this problem in the original issue.

Fixes #1050.
