### PR TITLE
Fix for bug in width calculation

### DIFF
--- a/src/mslice/models/cut/cut.py
+++ b/src/mslice/models/cut/cut.py
@@ -143,7 +143,7 @@ class Cut(object):
                 except ValueError:
                     raise ValueError("Invalid width")
         elif width_str == "":
-            self._width = self.end - self.start
+            self._width = round(self.end - self.start, 8)
         else:
             self._width = None
 

--- a/src/mslice/models/cut/cut.py
+++ b/src/mslice/models/cut/cut.py
@@ -143,7 +143,7 @@ class Cut(object):
                 except ValueError:
                     raise ValueError("Invalid width")
         elif width_str == "":
-            self._width = round(self.end - self.start, 8)
+            self._width = self.end - self.start
         else:
             self._width = None
 

--- a/src/mslice/widgets/cut/cut.py
+++ b/src/mslice/widgets/cut/cut.py
@@ -146,6 +146,8 @@ class CutWidget(CutView, QWidget):
         return str(self.lneCutIntegrationEnd.text())
 
     def get_integration_width(self):
+        if self.lneCutIntegrationWidth.text() == "":
+            return None
         return str(self.lneCutIntegrationWidth.text())
 
     def get_intensity_start(self):


### PR DESCRIPTION
**Description of work:**
Due to rounding errors MSlice sometimes assumed a set width for producing more than one cut when only one cut was intended. This has been fixed by setting the width to None if no value was provided.

**To test:**

Please replace MSlice in an installed Mantid with the version from this branch and follow steps in the original issue.

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #[39285](https://github.com/mantidproject/mantid/issues/39285) - Might need to get closed manually as it is a Mantid issue.
