### PR TITLE
Catch OSError exception when attempting to save to read-only folder

### DIFF
--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -270,9 +270,14 @@ def _get_slice_mdhisto_xye(histo_ws):
 
 
 def _output_data_to_ascii(output_path, out_data, header):
-    np.savetxt(
-        _to_absolute_path(str(output_path)), out_data, fmt="%12.9e", header=header
-    )
+    try : 
+        np.savetxt(
+            _to_absolute_path(str(output_path)), out_data, fmt="%12.9e", header=header
+        )  
+    except OSError as e:    
+        raise RuntimeError(
+            f"Error occurred: {e}"
+        )
 
 
 def _to_absolute_path(filepath: str) -> str:

--- a/src/mslice/util/mantid/algorithm_wrapper.py
+++ b/src/mslice/util/mantid/algorithm_wrapper.py
@@ -129,6 +129,5 @@ def remove_from_ads(workspacename):
     if AnalysisDataService.Instance().doesExist(hiddenworkspace):
         AnalysisDataService.Instance().remove(hiddenworkspace)
     hiddenworkspace = "__MSL" + workspacename + "_HIDDEN"
-    print(AnalysisDataService.Instance().getObjectNames())
     if AnalysisDataService.Instance().doesExist(hiddenworkspace):
         AnalysisDataService.Instance().remove(hiddenworkspace)


### PR DESCRIPTION
**Description of work:**
Attempting to save a cut as ASCII to a read-only folder caused an unhandled exception in the past.  Now MSlice handles this problem. 

**To test:**

Try to save a cut from the MDHisto tab to a read-only folder. Mantid should not crash.

Fixes #1073.
