### PR TITLE
Prevent crash for invalid characters

### DIFF
--- a/src/mslice/presenters/cut_widget_presenter.py
+++ b/src/mslice/presenters/cut_widget_presenter.py
@@ -114,8 +114,16 @@ class CutWidgetPresenter(PresenterUtility):
             e_units,
         )
 
-        intensity_start = self._cut_view.get_intensity_start()
-        intensity_end = self._cut_view.get_intensity_end()
+        try:
+            intensity_start = float(self._cut_view.get_intensity_start())
+        except ValueError:
+            intensity_start = None
+            warnings.warn("Invalid intensity start parameter")
+        try:
+            intensity_end = float(self._cut_view.get_intensity_end())
+        except ValueError:
+            intensity_end = None
+            warnings.warn("Invalid intensity end parameter")
 
         norm_to_one = bool(self._cut_view.get_intensity_is_norm_to_one())
         width = self._cut_view.get_integration_width()

--- a/src/mslice/widgets/workspacemanager/input_boxes.py
+++ b/src/mslice/widgets/workspacemanager/input_boxes.py
@@ -50,4 +50,16 @@ class ScaleInputBox(QDialog):
     def user_input(self):
         v1 = self.edit1.text()
         v2 = self.edit2.text()
-        return float(v1) if v1 else None, float(v2) if v2 else None
+        v1_value = None
+        v2_value = None
+        if v1:
+            try:
+                v1_value = float(v1)
+            except ValueError:
+                pass
+        if v2:
+            try:
+                v2_value = float(v2)
+            except ValueError:
+                pass                
+        return v1_value, v2_value

--- a/src/mslice/widgets/workspacemanager/input_boxes.py
+++ b/src/mslice/widgets/workspacemanager/input_boxes.py
@@ -61,5 +61,5 @@ class ScaleInputBox(QDialog):
             try:
                 v2_value = float(v2)
             except ValueError:
-                pass                
+                pass
         return v1_value, v2_value

--- a/src/mslice/widgets/workspacemanager/input_boxes.py
+++ b/src/mslice/widgets/workspacemanager/input_boxes.py
@@ -50,16 +50,12 @@ class ScaleInputBox(QDialog):
     def user_input(self):
         v1 = self.edit1.text()
         v2 = self.edit2.text()
-        v1_value = None
-        v2_value = None
-        if v1:
-            try:
-                v1_value = float(v1)
-            except ValueError:
-                pass
-        if v2:
-            try:
-                v2_value = float(v2)
-            except ValueError:
-                pass
+        try:
+            v1_value = float(v1) if v1 else None
+        except ValueError:
+            v1_value = None
+        try:
+            v2_value = float(v2) if v1 else None
+        except ValueError:
+            v2_value = None
         return v1_value, v2_value


### PR DESCRIPTION
**Description of work:**
During manual testing, a few crashes were caused by entering invalid characters into the boxes for `Bose` and `Scale` for `Compose` as well as for `Intensity` on the `Cut` tab.

**To test:**

Enter a special character into the boxes mentioned above and observe no crash, but a message warning about the invalid input. In case for the the` Intensity`, the message differentiates between invalid entries for the start and end value.


Fixes #1087 
