### PR TITLE
Fix for save script error

### DIFF
--- a/src/mslice/models/alg_workspace_ops.py
+++ b/src/mslice/models/alg_workspace_ops.py
@@ -13,8 +13,10 @@ def get_number_of_steps(axis):
 
     return int(np.ceil(step_num))
 
+
 def get_range_end(start, end, width):
     return min(start + width, end) if width is not None else end
+
 
 def get_axis_range(workspace, dimension_name):
     workspace = get_workspace_handle(workspace)

--- a/src/mslice/models/alg_workspace_ops.py
+++ b/src/mslice/models/alg_workspace_ops.py
@@ -13,6 +13,8 @@ def get_number_of_steps(axis):
 
     return int(np.ceil(step_num))
 
+def get_range_end(start, end, width):
+    return min(start + width, end) if width is not None else end
 
 def get_axis_range(workspace, dimension_name):
     workspace = get_workspace_handle(workspace)

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -6,6 +6,7 @@ from mslice.views.cut_plotter import (
     cut_figure_exists,
     get_current_plot,
 )
+from mslice.models.alg_workspace_ops import get_range_end
 from mslice.models.cut.cut import SampleTempValueError
 from mslice.models.cut.cut_functions import compute_cut
 from mslice.models.labels import generate_legend
@@ -123,20 +124,14 @@ class CutPlotterPresenter(PresenterUtility):
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
         cut_start = integration_start
-        if cut.width is not None:
-            cut_end = min(integration_start + cut.width, integration_end)
-        else:
-            cut_end = integration_end
+        cut_end = get_range_end(integration_start, integration_end, cut.width)
         while cut_start != cut_end:
             cut.integration_axis.start = cut_start
             cut.integration_axis.end = cut_end
             final_plot = True if cut_start + cut.width == integration_end else False
             self._plot_cut(workspace, cut, plot_over, final_plot=final_plot)
             cut_start = cut_end
-            if cut.width is not None:
-                cut_end = min(cut_end + cut.width, integration_end)
-            else:
-                cut_end = integration_end
+            cut_end = get_range_end(cut_end, integration_end, cut.width)
             cut.cut_ws = None
             # The first plot will respect which button the user pressed. The rest will over plot
             plot_over = True

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -130,7 +130,7 @@ class CutPlotterPresenter(PresenterUtility):
         while cut_start != cut_end:
             cut.integration_axis.start = cut_start
             cut.integration_axis.end = cut_end
-            final_plot = True if cut.width is not None and cut_start + cut.width == integration_end else False
+            final_plot = True if cut_start + cut.width == integration_end else False
             self._plot_cut(workspace, cut, plot_over, final_plot=final_plot)
             cut_start = cut_end
             if cut.width is not None:

--- a/src/mslice/presenters/cut_plotter_presenter.py
+++ b/src/mslice/presenters/cut_plotter_presenter.py
@@ -122,16 +122,21 @@ class CutPlotterPresenter(PresenterUtility):
         """This function handles the width parameter."""
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
-        cut_start, cut_end = (
-            integration_start,
-            min(integration_start + cut.width, integration_end),
-        )
+        cut_start = integration_start
+        if cut.width is not None:
+            cut_end = min(integration_start + cut.width, integration_end)
+        else:
+            cut_end = integration_end
         while cut_start != cut_end:
             cut.integration_axis.start = cut_start
             cut.integration_axis.end = cut_end
-            final_plot = True if cut_start + cut.width == integration_end else False
+            final_plot = True if cut.width is not None and cut_start + cut.width == integration_end else False
             self._plot_cut(workspace, cut, plot_over, final_plot=final_plot)
-            cut_start, cut_end = cut_end, min(cut_end + cut.width, integration_end)
+            cut_start = cut_end
+            if cut.width is not None:
+                cut_end = min(cut_end + cut.width, integration_end)
+            else:
+                cut_end = integration_end
             cut.cut_ws = None
             # The first plot will respect which button the user pressed. The rest will over plot
             plot_over = True

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -221,6 +221,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
         cut_start = integration_start
+        print(cut.width)
         if cut.width is not None:
             cut_end = min(integration_start + cut.width, integration_end)
         else:

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -254,7 +254,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 f"IntensityCorrection={intensity_correction_arg}, SampleTemperature={cut.raw_sample_temp})\n"
             )
             return_ws_vars.append(cut_ws)
-            print(cut_ws)
+            
             plot_over = False if index == 0 else True
             if intensity_range != (None, None):
                 script_lines.append(
@@ -274,7 +274,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 cut_end = integration_end
             index += 1
         cut.reset_integration_axis(cut.start, cut.end)
-
+    print(script_lines)
     return return_ws_vars
 
 

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -252,7 +252,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 f"IntensityCorrection={intensity_correction_arg}, SampleTemperature={cut.raw_sample_temp})\n"
             )
             return_ws_vars.append(cut_ws)
-            
+
             plot_over = False if index == 0 else True
             if intensity_range != (None, None):
                 script_lines.append(

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -254,6 +254,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 f"IntensityCorrection={intensity_correction_arg}, SampleTemperature={cut.raw_sample_temp})\n"
             )
             return_ws_vars.append(cut_ws)
+            print(cut_ws)
             plot_over = False if index == 0 else True
             if intensity_range != (None, None):
                 script_lines.append(
@@ -273,7 +274,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 cut_end = integration_end
             index += 1
         cut.reset_integration_axis(cut.start, cut.end)
-        print(return_ws_vars)
+
     return return_ws_vars
 
 

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from mslice.models.alg_workspace_ops import get_range_end
 from mslice.models.labels import get_recoil_key
 from mslice.util.intensity_correction import IntensityType, IntensityCache
 import re
@@ -221,10 +222,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
         cut_start = integration_start
-        if cut.width is not None:
-            cut_end = min(integration_start + cut.width, integration_end)
-        else:
-            cut_end = integration_end
+        cut_end = get_range_end(integration_start, integration_end, cut.width)
         intensity_range = (cut.intensity_start, cut.intensity_end)
         norm_to_one = cut.norm_to_one
         algo_str = "" if "Rebin" in cut.algorithm else f', Algorithm="{cut.algorithm}"'
@@ -268,12 +266,8 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 )
 
             cut_start = cut_end
-            if cut.width is not None:
-                cut_end = min(cut_end + cut.width, integration_end)
-            else:
-                cut_end = integration_end
+            cut_end = get_range_end(cut_end, integration_end, cut.width)
             index += 1
-            
         cut.reset_integration_axis(cut.start, cut.end)
     return return_ws_vars
 

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -221,7 +221,6 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
         cut_start = integration_start
-        print(len(errorbars))
         if cut.width is not None:
             cut_end = min(integration_start + cut.width, integration_end)
         else:
@@ -270,13 +269,10 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
 
             cut_start = cut_end
             if cut.width is not None:
-                cut_end = min(integration_start + cut.width, integration_end)
+                cut_end = min(cut_end + cut.width, integration_end)
             else:
                 cut_end = integration_end
             index += 1
-            print("new int")
-            print(cut_start)
-            print(cut_end)
             
         cut.reset_integration_axis(cut.start, cut.end)
     return return_ws_vars

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -221,7 +221,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
         cut_start = integration_start
-        print(cut.width)
+
         if cut.width is not None:
             cut_end = min(integration_start + cut.width, integration_end)
         else:
@@ -231,6 +231,8 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
         algo_str = "" if "Rebin" in cut.algorithm else f', Algorithm="{cut.algorithm}"'
 
         while cut_start != cut_end and index < len(errorbars):
+            print(cut_start)
+            print(cut_end)
             cut.integration_axis.start = cut_start
             cut.integration_axis.end = cut_end
             cut_axis = str(cut.cut_axis)

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -220,10 +220,11 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
     for cut in cuts:
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
-        cut_start, cut_end = (
-            integration_start,
-            min(integration_start + cut.width, integration_end),
-        )
+        cut_start = integration_start
+        if cut.width is not None:
+            cut_end = min(integration_start + cut.width, integration_end)
+        else:
+            cut_end = integration_end
         intensity_range = (cut.intensity_start, cut.intensity_end)
         norm_to_one = cut.norm_to_one
         algo_str = "" if "Rebin" in cut.algorithm else f', Algorithm="{cut.algorithm}"'
@@ -265,7 +266,11 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                     f"lw={width}, plot_over={plot_over})\n\n"
                 )
 
-            cut_start, cut_end = cut_end, min(cut_end + cut.width, integration_end)
+            cut_start = cut_end
+            if cut.width is not None:
+                cut_end = min(integration_start + cut.width, integration_end)
+            else:
+                cut_end = integration_end
             index += 1
         cut.reset_integration_axis(cut.start, cut.end)
     return return_ws_vars

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -231,8 +231,6 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
         algo_str = "" if "Rebin" in cut.algorithm else f', Algorithm="{cut.algorithm}"'
 
         while cut_start != cut_end and index < len(errorbars):
-            print(cut_start)
-            print(cut_end)
             cut.integration_axis.start = cut_start
             cut.integration_axis.end = cut_end
             cut_axis = str(cut.cut_axis)
@@ -276,6 +274,10 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
             else:
                 cut_end = integration_end
             index += 1
+            print("new int")
+            print(cut_start)
+            print(cut_end)
+            
         cut.reset_integration_axis(cut.start, cut.end)
     return return_ws_vars
 

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -221,7 +221,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
         integration_start = cut.integration_axis.start
         integration_end = cut.integration_axis.end
         cut_start = integration_start
-
+        print(len(errorbars))
         if cut.width is not None:
             cut_end = min(integration_start + cut.width, integration_end)
         else:

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -273,6 +273,7 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 cut_end = integration_end
             index += 1
         cut.reset_integration_axis(cut.start, cut.end)
+        print(return_ws_vars)
     return return_ws_vars
 
 

--- a/src/mslice/scripting/helperfunctions.py
+++ b/src/mslice/scripting/helperfunctions.py
@@ -274,7 +274,6 @@ def add_cut_lines_with_width(errorbars, script_lines, cuts, intensity_correction
                 cut_end = integration_end
             index += 1
         cut.reset_integration_axis(cut.start, cut.end)
-    print(script_lines)
     return return_ws_vars
 
 

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -544,6 +544,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
             "1",
         )
         cut_0.parent_ws_name = "ws_0"
+        cut_0.width = 0.5
 
         cut_2 = Cut(
             Axis("|Q|", "1", "3", "1"),
@@ -568,7 +569,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
                 0,
                 "ws_0",
                 cuts[0].cut_axis,
-                "DeltaE,-1.0,0.0,0.0",
+                "DeltaE,-1.0,-0.5,0.0",
                 cuts[0].norm_to_one,
                 False,
                 None,
@@ -582,7 +583,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
                 1,
                 "ws_0",
                 cuts[0].cut_axis,
-                "DeltaE,0.0,1.0,0.0",
+                "DeltaE,-0.5,0.0,0.0",
                 cuts[0].norm_to_one,
                 False,
                 None,

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -544,7 +544,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
             "1",
         )
         cut_0.parent_ws_name = "ws_0"
-        cut_0.width = 0.5
+        cut_0.width = "0.5"
 
         cut_2 = Cut(
             Axis("|Q|", "1", "3", "1"),

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -544,7 +544,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
             "1",
         )
         cut_0.parent_ws_name = "ws_0"
-        cut_0.width = "0.5"
+        #cut_0.width = "0.5"
 
         cut_2 = Cut(
             Axis("|Q|", "1", "3", "1"),

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -535,7 +535,6 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
                 label="error_label_{}".format(i),
             )
         errorbars = plt.gca().containers
-
         cut_0 = Cut(
             Axis("|Q|", "1", "3", "1"),
             Axis("DeltaE", "-1", "1", "0"),

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -544,7 +544,6 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
             "1",
         )
         cut_0.parent_ws_name = "ws_0"
-        #cut_0.width = "0.5"
 
         cut_2 = Cut(
             Axis("|Q|", "1", "3", "1"),
@@ -569,7 +568,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
                 0,
                 "ws_0",
                 cuts[0].cut_axis,
-                "DeltaE,-1.0,-0.5,0.0",
+                "DeltaE,-1.0,0.0,0.0",
                 cuts[0].norm_to_one,
                 False,
                 None,
@@ -583,7 +582,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
                 1,
                 "ws_0",
                 cuts[0].cut_axis,
-                "DeltaE,-0.5,0.0,0.0",
+                "DeltaE,0.0,1.0,0.0",
                 cuts[0].norm_to_one,
                 False,
                 None,

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -535,6 +535,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
                 label="error_label_{}".format(i),
             )
         errorbars = plt.gca().containers
+        print(errorbars)
         cut_0 = Cut(
             Axis("|Q|", "1", "3", "1"),
             Axis("DeltaE", "-1", "1", "0"),

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -627,7 +627,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
             ),
             script_lines,
         )
-        
+
         self.assertEqual(["cut_ws_0", "cut_ws_1", "cut_ws_2"], ret_val)
 
     def test_show_or_hide_containers_in_script(self):

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -561,7 +561,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
         ret_val = add_cut_lines_with_width(
             errorbars, script_lines, cuts, IntensityType.SCATTERING_FUNCTION
         )
-
+        print(ret_val)
         self.assertIn(
             'cut_ws_{} = mc.Cut(ws_{}, CutAxis="{}", IntegrationAxis="{}", NormToOne={}, IntensityCorrection={}, '
             "SampleTemperature={})\n".format(
@@ -627,7 +627,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
             ),
             script_lines,
         )
-
+        
         self.assertEqual(["cut_ws_0", "cut_ws_1", "cut_ws_2"], ret_val)
 
     def test_show_or_hide_containers_in_script(self):

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -561,7 +561,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
         ret_val = add_cut_lines_with_width(
             errorbars, script_lines, cuts, IntensityType.SCATTERING_FUNCTION
         )
-        print(ret_val)
+
         self.assertIn(
             'cut_ws_{} = mc.Cut(ws_{}, CutAxis="{}", IntegrationAxis="{}", NormToOne={}, IntensityCorrection={}, '
             "SampleTemperature={})\n".format(

--- a/tests/scripting_helperfunctions_test.py
+++ b/tests/scripting_helperfunctions_test.py
@@ -535,7 +535,7 @@ class ScriptingHelperFunctionsTest(unittest.TestCase):
                 label="error_label_{}".format(i),
             )
         errorbars = plt.gca().containers
-        print(errorbars)
+
         cut_0 = Cut(
             Axis("|Q|", "1", "3", "1"),
             Axis("DeltaE", "-1", "1", "0"),


### PR DESCRIPTION
**Description of work:**

Prevent addition of `None` values for width when calculating the cut end. For the issue the crash happened when creating a script from a cut plot. However, the same problem could also occur in the cut plot presenter, so I've applied the same fix there as well.

**To test:**

Please follow the instructions in the original issue. In addition, try to use float values in the `width` box.

Fixes #1105 
