### PR TITLE
Fix converting to workspace2D issue

### DIFF
--- a/src/mslice/workspace/histogram_workspace.py
+++ b/src/mslice/workspace/histogram_workspace.py
@@ -64,25 +64,18 @@ class HistogramWorkspace(
             Scale,
             ConvertToDistribution,
         )
-
+        if len(self.raw_ws.getNonIntegratedDimensions()) == 0:
+            raise TypeError("Workspace has only one bin.")
         ws_conv = ConvertMDHistoToMatrixWorkspace(
             self.name,
             Normalization="NumEventsNormalization",
-            FindXAxis=False,
+            FindXAxis=True,
             OutputWorkspace="__mat" + self.name,
         )
         coord = self.get_coordinates()
         bin_size = 1
-        if self.raw_ws.getNumDims() == 2:
-            # for a 2 dimensional workspace use the second dimension to determine bin size
-            # this is the case after changing the intensity to GDOS for a cut
-            first_dim = coord[self.raw_ws.getDimension(1).name]
-        elif self.raw_ws.getNumDims() == 1:
-            first_dim = coord[self.raw_ws.getDimension(0).name]
-        if len(first_dim) > 1:
-            bin_size = first_dim[1] - first_dim[0]
-        else:
-            raise TypeError("Workspace has only one bin.")
+        first_dim = coord[self.raw_ws.getNonIntegratedDimensions()[0].name]
+        bin_size = first_dim[1] - first_dim[0]
         ws_conv = Scale(ws_conv, bin_size, OutputWorkspace="__mat" + self.name)
         ConvertToDistribution(ws_conv)
         return ws_conv

--- a/tests/histogram_workspace_test.py
+++ b/tests/histogram_workspace_test.py
@@ -28,13 +28,39 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
             ),
             "testHistoWorkspace",
         )
-        cls.workspace1Bin = HistogramWorkspace(
+        cls.workspace1D = HistogramWorkspace(
             CreateMDHistoWorkspace(
                 Dimensionality=2,
                 Extents="0,100,0,100",
                 SignalInput=signal,
                 ErrorInput=error,
                 NumberOfBins="100,1",
+                Names="Dim1,Dim2",
+                Units="U,U",
+                OutputWorkspace="testHistoWorkspace1D",
+            ),
+            "testHistoWorkspace1D",
+        )
+        cls.workspace1D_rev = HistogramWorkspace(
+            CreateMDHistoWorkspace(
+                Dimensionality=2,
+                Extents="-0.5,100.5,-0.5,100.5",
+                SignalInput=signal,
+                ErrorInput=error,
+                NumberOfBins="1,100",
+                Names="Dim1,Dim2",
+                Units="U,U",
+                OutputWorkspace="testHistoWorkspace1D_rev",
+            ),
+            "testHistoWorkspace1D_rev",
+        )
+        cls.workspace1Bin = HistogramWorkspace(
+            CreateMDHistoWorkspace(
+                Dimensionality=2,
+                Extents="-0.5,100.5,-0.5,100.5",
+                SignalInput=[0],
+                ErrorInput=[0],
+                NumberOfBins="1,1",
                 Names="Dim1,Dim2",
                 Units="U,U",
                 OutputWorkspace="testHistoWorkspace1Bin",
@@ -52,6 +78,33 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
     def test_convert_to_matrix(self):
         # workspace needs to be registered with mslice for conversion
         try:
+            add_workspace(self.workspace1D, self.workspace1D.name)
+            matrix_ws = self.workspace1D.convert_to_matrix()
+
+            self.assertEqual(1, matrix_ws.raw_ws.getNumberHistograms())
+            self.assertEqual(100, matrix_ws.raw_ws.blocksize())
+            np.testing.assert_allclose(np.arange(0, 100)*100/99,matrix_ws.raw_ws.readY(0))
+        finally:
+            # remove mslice tracking
+            remove_workspace(self.workspace1D)
+
+    def test_convert_to_matrix2(self):
+        # workspace needs to be registered with mslice for conversion
+        try:
+            add_workspace(self.workspace1D_rev, self.workspace1D_rev.name)
+            matrix_ws = self.workspace1D_rev.convert_to_matrix()
+
+            self.assertEqual(1, matrix_ws.raw_ws.getNumberHistograms())
+            self.assertEqual(100, matrix_ws.raw_ws.blocksize())
+            np.testing.assert_allclose(np.arange(0, 100)*100/99,matrix_ws.raw_ws.readY(0), rtol=1e-5)
+        finally:
+            # remove mslice tracking
+            remove_workspace(self.workspace1D_rev)
+
+
+    def test_convert_to_matrix_1d(self):
+        # workspace needs to be registered with mslice for conversion
+        try:
             add_workspace(self.workspace, self.workspace.name)
             matrix_ws = self.workspace.convert_to_matrix()
 
@@ -60,6 +113,7 @@ class HistogramWorkspaceTest(BaseWorkspaceTest):
         finally:
             # remove mslice tracking
             remove_workspace(self.workspace)
+
 
     def test_convert_to_matrix_fail(self):
         # workspace needs to be registered with mslice for conversion


### PR DESCRIPTION
**Description of work:**
Fix finding the correct axis for 1D histograms, when exporting to workbench.

Here is what happened before:
<img width="1479" height="1189" alt="image" src="https://github.com/user-attachments/assets/db7a2034-9484-4a33-aeeb-9c8b99becfba" />
I do a cut along |Q|, and when I export it to workbench it's using the values from DeltaE. For some reason, when plotting GDOS is fine, since the order of |Q| and DeltaE is changed in the MDHisto workspace.

**To test:**
Use any NXSPE with pixel instrument, and do a cut along |Q|. Save it to workbench and try to plot it (or look at data)