### PR TITLE
Cache the Temperature Log Entered for Use in Subsequent Slices

### DIFF
--- a/src/mslice/plotting/plot_window/cachable_input_dialog.py
+++ b/src/mslice/plotting/plot_window/cachable_input_dialog.py
@@ -1,6 +1,16 @@
-from PyQt5.QtWidgets import QComboBox, QFormLayout, QLabel, QPushButton, QWidget, QSpacerItem, QSizePolicy, QVBoxLayout, \
-    QHBoxLayout
+from PyQt5.QtWidgets import (
+    QComboBox,
+    QFormLayout,
+    QLabel,
+    QPushButton,
+    QWidget,
+    QSpacerItem,
+    QSizePolicy,
+    QVBoxLayout,
+    QHBoxLayout,
+)
 from qtpy.QtWidgets import QDialog, QCheckBox
+
 
 class QCacheableInputDialog(QDialog):
     """
@@ -41,7 +51,9 @@ class QCacheableInputDialog(QDialog):
         return self.combo.currentText(), self.cache_checkbox.isChecked()
 
     @staticmethod
-    def ask_for_input(parent: QWidget, title: str, label_text: str, options: list) -> tuple[str, bool, bool]:
+    def ask_for_input(
+        parent: QWidget, title: str, label_text: str, options: list
+    ) -> tuple[str, bool, bool]:
         """
         :param parent: Parent QWidget.
         :param title: Dialog title.

--- a/src/mslice/plotting/plot_window/cachable_input_dialog.py
+++ b/src/mslice/plotting/plot_window/cachable_input_dialog.py
@@ -1,0 +1,36 @@
+from PyQt5.QtWidgets import QComboBox, QVBoxLayout, QFormLayout, QLabel, QPushButton
+from qtpy.QtWidgets import QDialog, QCheckBox
+
+class QCacheableInputDialog(QDialog):
+
+    def __init__(self, parent=None):
+        super(QCacheableInputDialog, self).__init__(parent)
+
+        layout = QFormLayout(self)
+        self.text = QLabel(self)
+        layout.addRow(self.text)
+        self.combo = QComboBox(self)
+        self.combo.setEditable(True)
+        layout.addRow(self.combo)
+        self.check_text = QLabel(self)
+        self.check_text.setText("Overwrite Cached Value?")
+        self.cache_checkbox = QCheckBox(self)
+        layout.addRow(self.check_text, self.cache_checkbox)
+        self.okay_button = QPushButton("OK")
+        self.cancel_button = QPushButton("Cancel")
+        self.okay_button.clicked.connect(self.accept)
+        layout.addRow(self.cancel_button, self.okay_button)
+
+    def value(self):
+        return self.combo.currentText(), self.cache_checkbox.isChecked()
+
+    @staticmethod
+    def ask_for_input(parent, title, label_text, options):
+        dialog = QCacheableInputDialog(parent)
+        dialog.setWindowTitle(title)
+        dialog.text.setText(label_text)
+        dialog.combo.addItems(options)
+
+        dialog_result = dialog.exec_()
+        chosen_option, is_cached = dialog.value()
+        return chosen_option, is_cached, dialog_result == QDialog.Accepted

--- a/src/mslice/plotting/plot_window/cachable_input_dialog.py
+++ b/src/mslice/plotting/plot_window/cachable_input_dialog.py
@@ -1,31 +1,54 @@
-from PyQt5.QtWidgets import QComboBox, QVBoxLayout, QFormLayout, QLabel, QPushButton
+from PyQt5.QtWidgets import QComboBox, QFormLayout, QLabel, QPushButton, QWidget, QSpacerItem, QSizePolicy, QVBoxLayout, \
+    QHBoxLayout
 from qtpy.QtWidgets import QDialog, QCheckBox
 
 class QCacheableInputDialog(QDialog):
+    """
+    An input dialog that allows the user to select an option from a list or
+    input a custom one of their own.
+
+    The dialog also contains a checkbox, which allows the user to indicate that
+    they wish to cache the entered value to be used later.
+    """
 
     def __init__(self, parent=None):
         super(QCacheableInputDialog, self).__init__(parent)
 
-        layout = QFormLayout(self)
+        layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
         self.text = QLabel(self)
-        layout.addRow(self.text)
+        form_layout.addRow(self.text)
         self.combo = QComboBox(self)
         self.combo.setEditable(True)
-        layout.addRow(self.combo)
+        form_layout.addRow(self.combo)
         self.check_text = QLabel(self)
         self.check_text.setText("Overwrite Cached Value?")
         self.cache_checkbox = QCheckBox(self)
-        layout.addRow(self.check_text, self.cache_checkbox)
+        form_layout.addRow(self.check_text, self.cache_checkbox)
+        layout.addLayout(form_layout)
+        button_layout = QHBoxLayout()
         self.okay_button = QPushButton("OK")
         self.cancel_button = QPushButton("Cancel")
         self.okay_button.clicked.connect(self.accept)
-        layout.addRow(self.cancel_button, self.okay_button)
+        self.cancel_button.clicked.connect(self.reject)
+        spacer = QSpacerItem(20, 0, QSizePolicy.Expanding, QSizePolicy.Minimum)
+        button_layout.addSpacerItem(spacer)
+        button_layout.addWidget(self.cancel_button)
+        button_layout.addWidget(self.okay_button)
+        layout.addLayout(button_layout)
 
     def value(self):
         return self.combo.currentText(), self.cache_checkbox.isChecked()
 
     @staticmethod
-    def ask_for_input(parent, title, label_text, options):
+    def ask_for_input(parent: QWidget, title: str, label_text: str, options: list) -> tuple[str, bool, bool]:
+        """
+        :param parent: Parent QWidget.
+        :param title: Dialog title.
+        :param label_text: Text indicating what the combobox selects.
+        :param options: Options the combobox will be populated with.
+        :return: Chosen option, true if option should be cached, true if OK was clicked.
+        """
         dialog = QCacheableInputDialog(parent)
         dialog.setWindowTitle(title)
         dialog.text.setText(label_text)

--- a/src/mslice/plotting/plot_window/cut_plot.py
+++ b/src/mslice/plotting/plot_window/cut_plot.py
@@ -76,6 +76,7 @@ class CutPlot(IPlot):
             "x_label_size",
             "y_label_size",
         ]
+        self.plot_window.set_manual_temp_log_visible(False)
 
     def save_default_options(self):
         self.default_options = {

--- a/src/mslice/plotting/plot_window/plot_window.py
+++ b/src/mslice/plotting/plot_window/plot_window.py
@@ -154,7 +154,9 @@ class PlotWindow(QtWidgets.QMainWindow):
 
         menu.addSeparator()
 
-        self.action_set_temp_log = add_action(menu, self, "Set Temperature Log", checkable=False, visible=True)
+        self.action_set_temp_log = add_action(
+            menu, self, "Set Temperature Log", checkable=False, visible=True
+        )
         menu.addAction(self.action_set_temp_log)
 
     def create_toolbar(self):

--- a/src/mslice/plotting/plot_window/plot_window.py
+++ b/src/mslice/plotting/plot_window/plot_window.py
@@ -152,6 +152,11 @@ class PlotWindow(QtWidgets.QMainWindow):
         menu.addAction(self.action_gdos)
         IntensityCache.cache_action(IntensityType.GDOS, "action_gdos")
 
+        menu.addSeparator()
+
+        self.action_set_temp_log = add_action(menu, self, "Set Temperature Log", checkable=False, visible=True)
+        menu.addAction(self.action_set_temp_log)
+
     def create_toolbar(self):
         self.toolbar = QtWidgets.QToolBar()
         self.add_toolbar_actions(self.toolbar)

--- a/src/mslice/plotting/plot_window/plot_window.py
+++ b/src/mslice/plotting/plot_window/plot_window.py
@@ -298,6 +298,9 @@ class PlotWindow(QtWidgets.QMainWindow):
         except AttributeError:
             pass
 
+    def set_manual_temp_log_enabled(self, enabled: bool):
+        self.action_set_temp_log.setEnabled(enabled)
+
     def uncheck_action_by_text(self, holder, item_text):
         for action in holder.actions():
             if (

--- a/src/mslice/plotting/plot_window/plot_window.py
+++ b/src/mslice/plotting/plot_window/plot_window.py
@@ -301,6 +301,9 @@ class PlotWindow(QtWidgets.QMainWindow):
     def set_manual_temp_log_enabled(self, enabled: bool):
         self.action_set_temp_log.setEnabled(enabled)
 
+    def set_manual_temp_log_visible(self, visible: bool):
+        self.action_set_temp_log.setVisible(visible)
+
     def uncheck_action_by_text(self, holder, item_text):
         for action in holder.actions():
             if (

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -69,6 +69,7 @@ class SlicePlot(IPlot):
             "colorbar_label_size",
             "colorbar_range_font_size",
         ]
+        self.plot_window.set_manual_temp_log_enabled(False)
 
     def save_default_options(self):
         self.default_options = {
@@ -426,12 +427,14 @@ class SlicePlot(IPlot):
             cbar_range = self.colorbar_range
             title = self.title
             if temp_dependent:
+                self.plot_window.set_manual_temp_log_enabled(True)
                 if not self._run_temp_dependent(slice_plotter_method, previous):
                     self.manager.reset_current_figure_as_previous(
                         last_active_figure_number, disable_make_current_after_plot
                     )
                     return
             else:
+                self.plot_window.set_manual_temp_log_enabled(False)
                 slice_plotter_method(self.ws_name)
             self.update_canvas(cbar_range, cbar_log, title)
         else:

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -459,9 +459,14 @@ class SlicePlot(IPlot):
             slice_plotter_method(self.ws_name)
         except ValueError:  # sample temperature not yet set, get it and reattempt method
             # First, try to get it from the temperature cache:
-            cached_temp_log = self._slice_plotter_presenter.get_cached_sample_temp()
+            cached_temp_pack = self._slice_plotter_presenter.get_cached_sample_temp()
+            if cached_temp_pack is not None:
+                cached_temp_log, is_field = cached_temp_pack
+            else:
+                cached_temp_log = None
+                is_field = None
             if cached_temp_log is not None:
-                self._handle_temperature_input(cached_temp_log, True, False)
+                self._handle_temperature_input(cached_temp_log, is_field, False)
                 return True
             if self._set_sample_temperature(previous):
                 slice_plotter_method(self.ws_name)
@@ -500,7 +505,7 @@ class SlicePlot(IPlot):
 
         self.default_options["temp"] = temp_value
         self.temp = temp_value
-        self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value, temp_value_raw, is_cached)
+        self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value, temp_value_raw, is_cached, field)
         return True
 
     def ask_sample_temperature_field(self, ws_name: str) -> tuple[str, bool, bool]:

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -165,6 +165,7 @@ class SlicePlot(IPlot):
                 True,
             )
         )
+        plot_window.action_set_temp_log.triggered.connect(self._get_prev_and_set_sample_temperature)
 
         plot_window.action_hydrogen.triggered.connect(
             partial(toggle_overplot_line, self, self._slice_plotter_presenter, 1, True)
@@ -464,6 +465,12 @@ class SlicePlot(IPlot):
             else:  # failed to get sample temperature
                 return False
         return True
+
+    def _get_prev_and_set_sample_temperature(self) -> bool:
+        """
+        Helper for the sake of simplifying the call for changing the temp via the menu.
+        """
+        return self._set_sample_temperature(self.selected_intensity())
 
     def _set_sample_temperature(self, previous: QtWidgets.QAction) -> bool:
         try:

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -234,6 +234,7 @@ class SlicePlot(IPlot):
         plot_window.action_d2sig_dw_de.triggered.disconnect()
         plot_window.action_symmetrised_sqe.triggered.disconnect()
         plot_window.action_gdos.triggered.disconnect()
+        plot_window.action_set_temp_log.triggered.disconnect()
         plot_window.action_hydrogen.triggered.disconnect()
         plot_window.action_deuterium.triggered.disconnect()
         plot_window.action_helium.triggered.disconnect()

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -454,6 +454,11 @@ class SlicePlot(IPlot):
         except (
             ValueError
         ):  # sample temperature not yet set, get it and reattempt method
+            # First, try to get it from the temperature cache:
+            cached_temp_log = self._slice_plotter_presenter.get_cached_sample_temp()
+            if cached_temp_log is not None:
+                self._handle_temperature_input(cached_temp_log, True)
+                return True
             if self._set_sample_temperature(previous):
                 slice_plotter_method(self.ws_name)
             else:  # failed to get sample temperature
@@ -485,7 +490,7 @@ class SlicePlot(IPlot):
 
         self.default_options["temp"] = temp_value
         self.temp = temp_value
-        self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value)
+        self._slice_plotter_presenter.set_sample_temperature(self.ws_name, temp_value, temp_value_raw)
         return True
 
     def ask_sample_temperature_field(self, ws_name: str) -> str:

--- a/src/mslice/presenters/slice_plotter_presenter.py
+++ b/src/mslice/presenters/slice_plotter_presenter.py
@@ -22,7 +22,6 @@ from mslice.presenters.presenter_utility import PresenterUtility
 
 
 class SlicePlotterPresenter(PresenterUtility):
-
     def __init__(self):
         self._main_presenter = None
         self._slice_cache = {}
@@ -168,7 +167,9 @@ class SlicePlotterPresenter(PresenterUtility):
             raise ValueError()
         return intensity_start, intensity_end
 
-    def set_sample_temperature(self, workspace_name, temp, temp_value_raw=None, is_cached=False, is_field=True):
+    def set_sample_temperature(
+        self, workspace_name, temp, temp_value_raw=None, is_cached=False, is_field=True
+    ):
         self._slice_cache[workspace_name].sample_temp = temp
         if is_cached:
             self.set_cached_sample_temp((temp_value_raw, is_field))

--- a/src/mslice/presenters/slice_plotter_presenter.py
+++ b/src/mslice/presenters/slice_plotter_presenter.py
@@ -169,14 +169,15 @@ class SlicePlotterPresenter(PresenterUtility):
             raise ValueError()
         return intensity_start, intensity_end
 
-    def set_sample_temperature(self, workspace_name, temp, temp_value_raw=None):
+    def set_sample_temperature(self, workspace_name, temp, temp_value_raw=None, is_cached=False):
         self._slice_cache[workspace_name].sample_temp = temp
-        self._cached_temp = temp_value_raw
+        if is_cached:
+            self.set_cached_sample_temp(temp_value_raw)
 
-    def get_cached_sample_temp(self) -> float:
+    def get_cached_sample_temp(self) -> Optional[float | str]:
         return self._cached_temp
 
-    def set_cached_sample_temp(self, value: float):
+    def set_cached_sample_temp(self, value: Optional[float | str]):
         self._cached_temp = value
 
     def workspace_selection_changed(self):

--- a/src/mslice/presenters/slice_plotter_presenter.py
+++ b/src/mslice/presenters/slice_plotter_presenter.py
@@ -22,7 +22,6 @@ from mslice.presenters.presenter_utility import PresenterUtility
 
 
 class SlicePlotterPresenter(PresenterUtility):
-    _cached_temp: Optional[float | str]
 
     def __init__(self):
         self._main_presenter = None
@@ -169,15 +168,15 @@ class SlicePlotterPresenter(PresenterUtility):
             raise ValueError()
         return intensity_start, intensity_end
 
-    def set_sample_temperature(self, workspace_name, temp, temp_value_raw=None, is_cached=False):
+    def set_sample_temperature(self, workspace_name, temp, temp_value_raw=None, is_cached=False, is_field=True):
         self._slice_cache[workspace_name].sample_temp = temp
         if is_cached:
-            self.set_cached_sample_temp(temp_value_raw)
+            self.set_cached_sample_temp((temp_value_raw, is_field))
 
-    def get_cached_sample_temp(self) -> Optional[float | str]:
+    def get_cached_sample_temp(self) -> Optional[tuple[[float | str], bool]]:
         return self._cached_temp
 
-    def set_cached_sample_temp(self, value: Optional[float | str]):
+    def set_cached_sample_temp(self, value: Optional[tuple[[float | str], bool]]):
         self._cached_temp = value
 
     def workspace_selection_changed(self):

--- a/src/mslice/presenters/slice_plotter_presenter.py
+++ b/src/mslice/presenters/slice_plotter_presenter.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from matplotlib.colors import Normalize
 
 from mslice.models.slice.slice_functions import compute_slice, compute_recoil_line
@@ -20,9 +22,12 @@ from mslice.presenters.presenter_utility import PresenterUtility
 
 
 class SlicePlotterPresenter(PresenterUtility):
+    _cached_temp: Optional[float | str]
+
     def __init__(self):
         self._main_presenter = None
         self._slice_cache = {}
+        self._cached_temp = None
 
     def plot_slice(
         self,
@@ -164,8 +169,15 @@ class SlicePlotterPresenter(PresenterUtility):
             raise ValueError()
         return intensity_start, intensity_end
 
-    def set_sample_temperature(self, workspace_name, temp):
+    def set_sample_temperature(self, workspace_name, temp, temp_value_raw=None):
         self._slice_cache[workspace_name].sample_temp = temp
+        self._cached_temp = temp_value_raw
+
+    def get_cached_sample_temp(self) -> float:
+        return self._cached_temp
+
+    def set_cached_sample_temp(self, value: float):
+        self._cached_temp = value
 
     def workspace_selection_changed(self):
         pass

--- a/tests/slice_plot_test.py
+++ b/tests/slice_plot_test.py
@@ -95,7 +95,6 @@ class SlicePlotTest(unittest.TestCase):
         self.slice_plotter.add_overplot_line.assert_any_call("workspace", 4, True, "")
         mock_handle_temperature_input.assert_called_with("test_log", True, False)
 
-
     @patch("mslice.plotting.plot_window.slice_plot.QtWidgets.QInputDialog.getInt")
     def test_arbitrary_recoil_line(self, qt_get_int_mock):
         qt_get_int_mock.return_value = (5, True)

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -106,7 +106,9 @@ class SlicePlotterPresenterTest(unittest.TestCase):
     def test_set_sample_temperature(self):
         slice_presenter = SlicePlotterPresenter()
         slice_presenter._slice_cache["test"] = mock.MagicMock()
-        slice_presenter.set_sample_temperature("test", 104, "test_temp", is_cached=False)
+        slice_presenter.set_sample_temperature(
+            "test", 104, "test_temp", is_cached=False
+        )
         self.assertIsNone(slice_presenter._cached_temp)
         slice_presenter.set_sample_temperature("test", 104, "test_temp", is_cached=True)
         self.assertEqual(slice_presenter._cached_temp, ("test_temp", True))

--- a/tests/slice_plotter_presenter_test.py
+++ b/tests/slice_plotter_presenter_test.py
@@ -102,3 +102,11 @@ class SlicePlotterPresenterTest(unittest.TestCase):
         slice_presenter.hide_overplot_line("workspace", key)
         self.assertTrue(key not in cache_mock.overplot_lines)
         remove_line_mock.assert_called_once_with("line")
+
+    def test_set_sample_temperature(self):
+        slice_presenter = SlicePlotterPresenter()
+        slice_presenter._slice_cache["test"] = mock.MagicMock()
+        slice_presenter.set_sample_temperature("test", 104, "test_temp", is_cached=False)
+        self.assertIsNone(slice_presenter._cached_temp)
+        slice_presenter.set_sample_temperature("test", 104, "test_temp", is_cached=True)
+        self.assertEqual(slice_presenter._cached_temp, ("test_temp", True))


### PR DESCRIPTION
**Description of work:**

Adds a temperature log cache to the slice presenter such that subsequent slices will, by default, use that log for setting the temperature of the slice. 

A menu item to allow this option to be set manually has also been added and is available when an appropriate Intensity is selected.

**To test:**
1. Load `MAR21335_Ei60meV` from the ISIS Sample Data
2. Swap to Workspace Manager and click `Display`
3. Change the Intensity in the menu bar to `Chi''(Q,E)`
4. Check that the `Set Temperature Log` option starts greyed out.
5. Select `moderator_temp` and tick `Overwrite Cached Value`.
6. Close the plot.
7. Click `Display` again. 
8. Select `Intensity` -> `Chi''(Q,E)` again.
9. No dialog should appear, as it is now automatically using the previously selected log.
10. Check that `Intensity` -> `Set Temperature Log` is now enabled and can be used to open the log selection dialog.

Fixes #877
