### PR TITLE
Fix versioning for release versions

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
   {% set version_tag = environ.get('GIT_DESCRIBE_TAG', '0.0.0') %}
   {% set version_number = environ.get('GIT_DESCRIBE_NUMBER', '0') | string %}
-  {% set is_dev = '1' if version_number != '0' else '0'
+  {% set is_dev = '1' if version_number != '0' else '0' %}
   {% set version_number = '.dev' + version_number if is_dev != '0' else '' %}
 
   {% set version_parts = version_tag.split('.') %}


### PR DESCRIPTION
**Description of work:**

There were two checks for `version_number != '0'`, but after the first one` version_number` was already changed, so the second check would always end with the same result.

**To test:**

Unfortunately the only way to test this is to check the version number on Anaconda after the release, so for now it has to be code review only.
