### PR TITLE
Check for tag before deploy

### DIFF
--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Check for changes since last build
         run: |
           echo "recentCommits=$(test -z $(git log --since="yesterday" -1 --format=%h) && echo false || echo true)" >> $GITHUB_ENV
-          
+
       - name: Check whether the HEAD is tagged
-        run: |      
+        run: |
           echo "headTagged=$(test -z $(git describe --exact-match --tags) && echo false || echo true)" >> $GITHUB_ENV
 
       - name: Setup Miniconda


### PR DESCRIPTION
**Description of work:**
When MSlice is released, the last commit is the tag with the new version number. This means that at night the nightly deploy workflow detects that there were commits to main and triggers a nightly build that will subsequently overwrite the `main` label of the released package. This PR adds a check to the workflow to prevent the nightly deploy when the last commit was a tag.

**To test:**

The only possible test for this would be to push a temporary tag to main and check the next day whether the nightly build was uploaded to the Mantid channel on Anaconda after merging this PR.
