### PR TITLE
Fixed a crash when saving MDEventWorkspace2D as Matlab

### DIFF
--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -115,7 +115,7 @@ def save_matlab(workspace, path):
             x, y, e = _get_md_histo_xye(workspace.raw_ws)
             labels = {"x": get_display_name(workspace.axes[0])}
     else:
-        if not hasattr(workspace.raw_ws, 'extractX'):
+        if not hasattr(workspace.raw_ws, "extractX"):
             raise RuntimeError("Only cuts and slices can be saved as Matlab.")
 
         if workspace.is_slice:

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -155,8 +155,9 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
 
         self.presenter.notify(Command.SaveSelectedWorkspaceMatlab)
 
-        self.view._display_error.assert_called_once_with("Only cuts and slices can be saved as Matlab.")
-
+        self.view._display_error.assert_called_once_with(
+            "Only cuts and slices can be saved as Matlab."
+        )
 
     @patch("mslice.presenters.workspace_manager_presenter.get_save_directory")
     @patch("mslice.presenters.workspace_manager_presenter.save_workspaces")


### PR DESCRIPTION
**Description of work:**
This fixes the crash when saving a MDEventWorkspace2D as Matlab and raises RuntimeError as only cuts and slices can be saved as Matlab.

**To test:**

1. Load HYSPEC data (contact if you cannot find)
2. Click on `Calculate Projection` on the Powder tab
3. Navigate to the `MD Event` tab
4. Click on `Save` and select `Matlab`
5. mslice GUI should not crash and instead show the error `Only cuts and slices can be saved as Matlab.`
6. Click `Display` button on `Slice` tab
7. Click on Save icon(Flopppy disk) of the plot
8. select `Matlab` as the `Save as type`
9. clicking on `Save` should save the file at desired location.

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->

Fixes #1052.
