### PR TITLE
Preserve colorbar font sizes when the colorbar is recreated.

### DIFF
--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -326,11 +326,15 @@ class SlicePlot(IPlot):
             norm = colors.Normalize(vmin, vmax)
 
         label = self.colorbar_label
+        label_size = self.colorbar_label_size
+        range_font_size = self.colorbar_range_font_size
         colormesh.colorbar.remove()
         colormesh.set_clim((vmin, vmax))
         colormesh.set_norm(norm)
         self._canvas.figure.colorbar(colormesh)
         self.colorbar_label = label
+        self.colorbar_label_size = label_size
+        self.colorbar_range_font_size = range_font_size
 
     def get_line_options(self, target):
         line_options = {


### PR DESCRIPTION
`change_axis_scale` destroys and recreates the colorbar whenever the colorbar range or log/linear scale changes.  It already saved and restored the label text, but not the font sizes.  This caused the "Intensity" label (`colorbar_label_size`) and the colorbar tick labels (`colorbar_range_font_size`) to reset to matplotlib defaults after any operation that calls change_axis_scale:

- changing the colorbar range (including via the quick-options dialog)
- toggling logarithmic scale
- switching intensity type (S(Q,E), chi'', GDOS, ...)
- clicking OK in the plot-options or quick-options dialogs, which unconditionally fire the colorbar_log and colorbar_range setters

Save both font sizes before removing the colorbar and restore them after recreating it.

**Description of work:**

**To test:**

<!-- Instructions for testing. -->

1. Go to 'Workspace Manager'
2. Go to 'Slice' tab
3. Click on 'Display' button
4. In the new window, click the gear icon
5. Change the font size
6. Click Ok to exit preferences
7. Doubleclick the colorbar
8. Change the font size
9. Click Ok to exit this new dialog
10. Observe the font size now be changed <-- this one is new behavior


<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #1157.
