### PR TITLE
Replaced mambabuild and boa for package building

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -25,7 +25,8 @@ runs:
       conda create -n build-env
       conda init
       conda activate build-env
-      mamba install -c conda-forge mamba conda-build anaconda-client conda-verify boa
+      mamba install -c conda-forge mamba conda-build anaconda-client conda-verify conda-libmamba-solver
+      conda config --set solver libmamba
       conda config --add channels mantid/label/nightly
       conda config --add channels mantid
 
@@ -34,5 +35,5 @@ runs:
     run: |
       conda activate build-env
       conda config --set anaconda_upload yes
-      conda mambabuild --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
+      conda build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       grep "Upload complete" upload.log


### PR DESCRIPTION
**Description of work:**

This PR replaces `boa` with the `conda-libmamba-solver` and, subsequently, `mambabuild` with `build`.

Occasionally, the MSlice nightly is falling over because of mambabuild: https://github.com/mantidproject/mslice/actions/runs/25414436276
This has happened a few times in the past. Using conda-libmamba-solver instead of boa allows me to have the speed of mamba without using boa. I hope it is more robust in the long term.

**To test:**

Code review.
