### PR TITLE
Simplified GitHub action by installing into conda base

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -22,18 +22,14 @@ runs:
     shell: bash -l {0}
     run: |
       conda config --set always_yes yes --set changeps1 no
-      conda create -n build-env
-      conda init
-      conda activate build-env
-      mamba install -c conda-forge mamba conda-build anaconda-client conda-verify conda-libmamba-solver
       conda config --set solver libmamba
       conda config --add channels mantid/label/nightly
       conda config --add channels mantid
+      mamba install -c conda-forge conda-build anaconda-client conda-verify
 
   - name: Build package
     shell: bash -l {0}
     run: |
-      conda activate build-env
       conda config --set anaconda_upload yes
       conda build --user ${{ inputs.repository }} --token ${{ inputs.token }} --label ${{ inputs.label }} $GITHUB_WORKSPACE/conda |& tee upload.log
       grep "Upload complete" upload.log


### PR DESCRIPTION
**Description of work:**

The GitHub action for publishing a Conda package used a Conda environment for building the package in two separate steps. This sometimes causes problems as the environment is not always switched reliably. By installing into the base environment this problem is avoided. In a CI runner, polluting the base environment does not cause new problems as it does not persist past running the GitHub action.

**To test:**

This can only be tested by merging into the code base and monitoring the respective GitHub action for a while as the original problem occurred randomly.
