### PR TITLE
Set parent windows on dialogs so they are transient for their owning …

### DIFF
--- a/src/mslice/models/workspacemanager/file_io.py
+++ b/src/mslice/models/workspacemanager/file_io.py
@@ -20,19 +20,22 @@ import numpy as np
 from scipy.io import savemat
 
 
-def get_save_directory(multiple_files=False, save_as_image=False, default_ext=None):
+def get_save_directory(
+    multiple_files=False, save_as_image=False, default_ext=None, parent=None
+):
     """
     Show file dialog so user can choose where to save.
     :param multiple_files: boolean - whether more than one file is being saved
     :param save_as_image: boolean - whether to allow saving as a .png/pdf
     :param default_ext: file extension that is selected by default
+    :param parent: parent widget for the save dialog
     :return: path to save directory, name to save the file as, file format extension
     :raises: RuntimeError if dialog is cancelled
     """
     if multiple_files:
-        return QFileDialog.getExistingDirectory(), None, default_ext
+        return QFileDialog.getExistingDirectory(parent), None, default_ext
     else:
-        file_dialog = QFileDialog()
+        file_dialog = QFileDialog(parent)
         file_dialog.setAcceptMode(QFileDialog.AcceptSave)
 
         filter = "Nexus (*.nxs);; NXSPE (*.nxspe);; Ascii (*.txt);; Matlab (*.mat)"
@@ -63,7 +66,7 @@ def get_save_directory(multiple_files=False, save_as_image=False, default_ext=No
             return None, None, None
 
 
-def save_nexus(workspace, path):
+def save_nexus(workspace, path, parent=None):
     if isinstance(workspace, HistogramWorkspace):
         _save_histogram_workspace(workspace, path)
         return
@@ -78,7 +81,7 @@ def save_nexus(workspace, path):
         SaveNexus(InputWorkspace=workspace, Filename=path)
 
 
-def save_nxspe(workspace, path):
+def save_nxspe(workspace, path, parent=None):
     if isinstance(workspace, HistogramWorkspace):
         _save_histogram_workspace(workspace, path)
         return
@@ -90,14 +93,14 @@ def save_nxspe(workspace, path):
         )
 
     if len(workspace.axes) == 2:
-        _validate_nxspe_save(workspace=workspace)
+        _validate_nxspe_save(workspace=workspace, parent=parent)
         return
 
     with WrapWorkspaceAttribute(workspace):
         SaveNXSPE(InputWorkspace=workspace, Filename=path)
 
 
-def save_ascii(workspace, path):
+def save_ascii(workspace, path, parent=None):
     if workspace.is_slice:
         _save_slice_to_ascii(workspace, path)
     else:
@@ -107,7 +110,7 @@ def save_ascii(workspace, path):
             SaveAscii(InputWorkspace=workspace, Filename=path, WriteSpectrumID=False)
 
 
-def save_matlab(workspace, path):
+def save_matlab(workspace, path, parent=None):
     labels = {}
     if isinstance(workspace, HistogramWorkspace):
         if workspace.is_slice:
@@ -288,7 +291,7 @@ def _to_absolute_path(filepath: str) -> str:
     return os.path.join(ConfigService.getString("defaultsave.directory"), filepath)
 
 
-def _validate_nxspe_save(workspace):
+def _validate_nxspe_save(workspace, parent=None):
     """Validates if the nxspe file can be saved."""
     q_check = np.allclose(
         [workspace.axes[0].start, workspace.axes[0].end],
@@ -304,5 +307,6 @@ def _validate_nxspe_save(workspace):
     )
     if not (q_check and e_check):
         QuickError(
-            "Cannot save a NXSPE file because the workspace limits and the axis limits don't match."
+            "Cannot save a NXSPE file because the workspace limits and the axis limits don't match.",
+            parent=parent,
         )

--- a/src/mslice/models/workspacemanager/workspace_algorithms.py
+++ b/src/mslice/models/workspacemanager/workspace_algorithms.py
@@ -285,12 +285,13 @@ def scale_workspaces(workspaces, scale_factor=None, from_temp=None, to_temp=None
             propagate_properties(ws, result)
 
 
-def save_workspaces(workspaces, path, save_name, extension):
+def save_workspaces(workspaces, path, save_name, extension, parent=None):
     """
     :param workspaces: list of workspaces to save
     :param path: directory to save to
     :param save_name: name to save the file as (plus file extension). Pass none to use workspace name
     :param extension: file extension (such as .txt)
+    :param parent: parent widget for dialogs raised during save validation
     """
     if extension == ".nxs":
         save_method = save_nexus
@@ -316,7 +317,9 @@ def save_workspaces(workspaces, path, save_name, extension):
         if len(save_names) != len(workspaces):
             save_names = [None] * len(workspaces)
     for workspace, save_name_single in zip(workspaces, save_names):
-        _save_single_ws(workspace, save_name_single, save_method, path, extension)
+        _save_single_ws(
+            workspace, save_name_single, save_method, path, extension, parent=parent
+        )
 
 
 def export_workspace_to_ads(workspace):
@@ -334,12 +337,12 @@ def remove_workspace_from_ads(workspacename):
     remove_from_ads(workspacename)
 
 
-def _save_single_ws(workspace, save_name, save_method, path, extension):
+def _save_single_ws(workspace, save_name, save_method, path, extension, parent=None):
     save_as = save_name if save_name is not None else str(workspace) + extension
     full_path = os.path.join(str(path), save_as)
     if isinstance(workspace, str):
         workspace = get_workspace_handle(workspace)
-    save_method(workspace, full_path)
+    save_method(workspace, full_path, parent=parent)
 
 
 def get_axis_from_dimension(workspace, id):

--- a/src/mslice/plotting/plot_window/overplot_interface.py
+++ b/src/mslice/plotting/plot_window/overplot_interface.py
@@ -75,7 +75,7 @@ def toggle_overplot_line(
 
 def cif_file_powder_line(plot_handler, plotter_presenter, checked):
     if checked:
-        cif_path = QFileDialog().getOpenFileName(
+        cif_path = QFileDialog.getOpenFileName(
             plot_handler.plot_window, "Open CIF file", "/home", "Files (*.cif)"
         )
         cif_path = str(cif_path[0]) if isinstance(cif_path, tuple) else str(cif_path)

--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -193,7 +193,7 @@ class PlotFigureManagerQT(QtCore.QObject):
         printer = QtPrintSupport.QPrinter()
         printer.setResolution(300)
         printer.setOrientation(QtPrintSupport.QPrinter.Landscape)
-        print_dialog = QtPrintSupport.QPrintDialog(printer)
+        print_dialog = QtPrintSupport.QPrintDialog(printer, self.window)
         if print_dialog.exec_():
             pixmap_image = QtWidgets.QWidget.grab(self.canvas)
             page_size = printer.pageRect()
@@ -216,7 +216,9 @@ class PlotFigureManagerQT(QtCore.QObject):
         return resolution
 
     def save_plot(self):
-        file_path, save_name, ext = get_save_directory(save_as_image=True)
+        file_path, save_name, ext = get_save_directory(
+            save_as_image=True, parent=self.window
+        )
         if file_path is None:
             return
         if hasattr(self.plot_handler, "ws_list"):
@@ -227,7 +229,7 @@ class PlotFigureManagerQT(QtCore.QObject):
             else:
                 workspaces = [self.plot_handler.ws_name]
         try:
-            save_workspaces(workspaces, file_path, save_name, ext)
+            save_workspaces(workspaces, file_path, save_name, ext, parent=self.window)
         except RuntimeError as e:
             if str(e) == "unrecognised file extension":
                 supported_image_types = list(
@@ -255,7 +257,7 @@ class PlotFigureManagerQT(QtCore.QObject):
                 raise RuntimeError(e)
         except KeyError:  # Could be case of interactive cuts when the workspace has not been saved yet
             workspace = self.plot_handler.save_icut()
-            save_workspaces([workspace], file_path, save_name, ext)
+            save_workspaces([workspace], file_path, save_name, ext, parent=self.window)
 
     def save_image(self, path, resolution=300):
         self.canvas.figure.savefig(path, dpi=resolution)
@@ -277,7 +279,7 @@ class PlotFigureManagerQT(QtCore.QObject):
         )
 
     def error_box(self, message):
-        error_box = QtWidgets.QMessageBox()
+        error_box = QtWidgets.QMessageBox(self.window)
         error_box.setWindowTitle("Error")
         error_box.setIcon(QtWidgets.QMessageBox.Warning)
         error_box.setText(message)

--- a/src/mslice/plotting/plot_window/quick_options.py
+++ b/src/mslice/plotting/plot_window/quick_options.py
@@ -186,8 +186,8 @@ class QuickLineOptions(QuickOptions):
         return self.line_widget.legend
 
 
-def QuickError(message):
-    error_box = QtWidgets.QMessageBox()
+def QuickError(message, parent=None):
+    error_box = QtWidgets.QMessageBox(parent)
     error_box.setWindowTitle("Error")
     error_box.setIcon(QtWidgets.QMessageBox.Warning)
     error_box.setText(message)

--- a/src/mslice/presenters/quick_options_presenter.py
+++ b/src/mslice/presenters/quick_options_presenter.py
@@ -91,7 +91,7 @@ def _set_label(view, target):
     if check_latex(label):
         target.set_text(label)
     else:
-        QuickError("Invalid LaTeX in label string")
+        QuickError("Invalid LaTeX in label string", view)
 
 
 def _set_font_size(view, target):

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -127,6 +127,7 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
                 multiple_files=len(selected_workspaces) > 1,
                 save_as_image=False,
                 default_ext=extension,
+                parent=self._workspace_manager_view,
             )
         except RuntimeError as e:
             if str(e) == "dialog cancelled":
@@ -138,7 +139,13 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             self._workspace_manager_view.error_invalid_save_path()
             return
         try:
-            save_workspaces(selected_workspaces, save_directory, save_name, extension)
+            save_workspaces(
+                selected_workspaces,
+                save_directory,
+                save_name,
+                extension,
+                parent=self._workspace_manager_view,
+            )
         except RuntimeError as e:
             self._workspace_manager_view._display_error(str(e))
 

--- a/src/mslice/widgets/dataloader/dataloader.py
+++ b/src/mslice/widgets/dataloader/dataloader.py
@@ -142,7 +142,7 @@ class DataLoaderWidget(QWidget):  # and some view interface
 
     def get_workspace_efixed(self, workspace, hasMultipleWS=False, default_value=None):
         Ef, applyToAll, success = EfInputDialog.getEf(
-            workspace, hasMultipleWS, default_value
+            workspace, hasMultipleWS, default_value, parent=self
         )
         if not success:
             raise ValueError("Fixed final energy not given")

--- a/src/mslice/widgets/plotselector/view.py
+++ b/src/mslice/widgets/plotselector/view.py
@@ -641,7 +641,10 @@ class PlotSelectorView(QWidget):
         """
         # Returns a tuple containing the filename and extension
         absolute_path = QFileDialog.getSaveFileName(
-            caption="Select filename for exported plot", filter="*{}".format(extension)
+            self,
+            "Select filename for exported plot",
+            "",
+            "*{}".format(extension),
         )
         return absolute_path[0]
 
@@ -654,7 +657,7 @@ class PlotSelectorView(QWidget):
         # in the directory on Linux, but using the non-native dialog
         # is not very pleasant on Windows or Mac
         directory = QFileDialog.getExistingDirectory(
-            caption="Select folder for exported plots"
+            self, "Select folder for exported plots"
         )
         return directory
 

--- a/src/mslice/widgets/projection/powder/powder.py
+++ b/src/mslice/widgets/projection/powder/powder.py
@@ -95,7 +95,7 @@ class PowderWidget(PowderView, QWidget):
         self.error_occurred.emit(error_string)
 
     def display_message_box(self, message):
-        msg_box = QMessageBox()
+        msg_box = QMessageBox(self)
         msg_box.setWindowTitle("Powder Projection Error")
         msg_box.setText(message)
         msg_box.exec_()

--- a/src/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/src/mslice/widgets/workspacemanager/workspacemanager.py
@@ -124,7 +124,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         for i in range(current_list.count()):
             item = current_list.item(i).text()
             items.append(item)
-        dialog = QInputDialog()
+        dialog = QInputDialog(self)
         dialog.setWindowTitle("Add Workspace")
         dialog.setLabelText("Choose a workspace to add:")
         dialog.setOptions(QInputDialog.UseListViewForComboBoxItems)
@@ -176,7 +176,7 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
         return -1
 
     def get_workspace_to_load_path(self):
-        paths = QFileDialog.getOpenFileNames()
+        paths = QFileDialog.getOpenFileNames(self)
         return (
             paths[0]
             if isinstance(paths, tuple)

--- a/tests/file_io_test.py
+++ b/tests/file_io_test.py
@@ -27,10 +27,14 @@ class FileIOTest(unittest.TestCase):
 
     @patch("mslice.models.workspacemanager.file_io.QFileDialog")
     def test_save_directory_default(self, file_dialog_mock):
+        parent = Mock()
         file_dialog_mock.return_value = self.mock_dialog
         self.mock_dialog.selectedFilter.return_value = "Nexus (*.nxs)"
 
-        directory, file_name, extension = get_save_directory(default_ext=".nxs")
+        directory, file_name, extension = get_save_directory(
+            default_ext=".nxs", parent=parent
+        )
+        file_dialog_mock.assert_called_once_with(parent)
         self.mock_dialog.setNameFilter.assert_called_once_with(
             "Nexus (*.nxs);; NXSPE (*.nxspe);; Ascii (*.txt);; Matlab (*.mat)"
         )
@@ -56,11 +60,13 @@ class FileIOTest(unittest.TestCase):
 
     @patch("mslice.models.workspacemanager.file_io.QFileDialog")
     def test_save_directory_multiple(self, file_dialog_mock):
+        parent = Mock()
         file_dialog_mock.getExistingDirectory = Mock(return_value=self.path)
 
         directory, file_name, extension = get_save_directory(
-            multiple_files=True, default_ext=".nxs"
+            multiple_files=True, default_ext=".nxs", parent=parent
         )
+        file_dialog_mock.getExistingDirectory.assert_called_once_with(parent)
         self.assertEqual(directory, self.path)
         self.assertEqual(file_name, None)
         self.assertEqual(extension, ".nxs")
@@ -177,5 +183,5 @@ class FileIOTest(unittest.TestCase):
                     "|Q|": [limit_Q_start, limit_Q_end],
                     "DeltaE": [limit_deltaE_start, limit_deltaE_end],
                 }
-                _validate_nxspe_save(ws)
+                _validate_nxspe_save(ws, parent=None)
         self.assertEqual(mock_quick_error.call_count, 8)

--- a/tests/plot_figure_test.py
+++ b/tests/plot_figure_test.py
@@ -52,7 +52,10 @@ class PlotFigureTest(unittest.TestCase):
             get_slice_cache.return_value = slice_cache
             get_handle.return_value = workspace
             fg.save_plot()
-            save_nexus.assert_called_once_with(workspace, file_name[1])
+            get_save_dir.assert_called_once_with(save_as_image=True, parent=fg.window)
+            save_nexus.assert_called_once_with(
+                workspace, file_name[1], parent=fg.window
+            )
             get_slice_cache.assert_called_once()
 
     def test_save_slice_matlab_gdos(self):
@@ -81,5 +84,8 @@ class PlotFigureTest(unittest.TestCase):
             get_handle.return_value = workspace
             fg.plot_handler.intensity_type = IntensityType.GDOS
             fg.save_plot()
-            save_matlab.assert_called_once_with(workspace, file_name[1])
+            get_save_dir.assert_called_once_with(save_as_image=True, parent=fg.window)
+            save_matlab.assert_called_once_with(
+                workspace, file_name[1], parent=fg.window
+            )
             get_slice_cache.assert_called_once()

--- a/tests/quick_options_test.py
+++ b/tests/quick_options_test.py
@@ -299,7 +299,7 @@ class QuickLabelTest(unittest.TestCase):
         quick_label_options_view.return_value = self.view
         type(self.view).label = PropertyMock(return_value="$\a$")
         _set_label_options(self.view, self.target)
-        assert quickerror.called
+        quickerror.assert_called_once_with("Invalid LaTeX in label string", self.view)
         assert not self.target.set_text.called
 
 

--- a/tests/workspacemanager_presenter_test.py
+++ b/tests/workspacemanager_presenter_test.py
@@ -81,10 +81,17 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(
-            multiple_files=False, save_as_image=False, default_ext=".nxs"
+            multiple_files=False,
+            save_as_image=False,
+            default_ext=".nxs",
+            parent=self.view,
         )
         save_ws_mock.assert_called_once_with(
-            [workspace_to_save], path_to_save_to, "file1", ".nxs"
+            [workspace_to_save],
+            path_to_save_to,
+            "file1",
+            ".nxs",
+            parent=self.view,
         )
 
         # Test save failure
@@ -118,11 +125,18 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         save_dir_mock.return_value = (path_to_save_to, workspace_to_save, ".txt")
         self.presenter.notify(Command.SaveSelectedWorkspaceAscii)
         save_dir_mock.assert_called_once_with(
-            multiple_files=False, save_as_image=False, default_ext=".txt"
+            multiple_files=False,
+            save_as_image=False,
+            default_ext=".txt",
+            parent=self.view,
         )
         self.view.get_workspace_selected.assert_called_once_with()
         save_ws_mock.assert_called_once_with(
-            [workspace_to_save], path_to_save_to, "file1", ".txt"
+            [workspace_to_save],
+            path_to_save_to,
+            "file1",
+            ".txt",
+            parent=self.view,
         )
 
     @patch("mslice.presenters.workspace_manager_presenter.get_save_directory")
@@ -139,10 +153,17 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.SaveSelectedWorkspaceMatlab)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(
-            multiple_files=False, save_as_image=False, default_ext=".mat"
+            multiple_files=False,
+            save_as_image=False,
+            default_ext=".mat",
+            parent=self.view,
         )
         save_ws_mock.assert_called_once_with(
-            [workspace_to_save], path_to_save_to, "file1", ".mat"
+            [workspace_to_save],
+            path_to_save_to,
+            "file1",
+            ".mat",
+            parent=self.view,
         )
 
     @patch("mslice.presenters.workspace_manager_presenter.get_save_directory")
@@ -174,10 +195,13 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.presenter.notify(Command.SaveSelectedWorkspaceNexus)
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(
-            multiple_files=True, save_as_image=False, default_ext=".nxs"
+            multiple_files=True,
+            save_as_image=False,
+            default_ext=".nxs",
+            parent=self.view,
         )
         save_ws_mock.assert_called_with(
-            ["file1", "file2"], path_to_save_to, None, ".nxs"
+            ["file1", "file2"], path_to_save_to, None, ".nxs", parent=self.view
         )
 
     @patch("mslice.presenters.workspace_manager_presenter.get_save_directory")
@@ -211,7 +235,10 @@ class WorkspaceManagerPresenterTest(unittest.TestCase):
         self.view.get_workspace_selected.assert_called_once_with()
         self.view.get_workspace_selected.assert_called_once_with()
         save_dir_mock.assert_called_once_with(
-            multiple_files=False, save_as_image=False, default_ext=".nxs"
+            multiple_files=False,
+            save_as_image=False,
+            default_ext=".nxs",
+            parent=self.view,
         )
         self.view.error_invalid_save_path.assert_called_once()
         save_ws_mock.assert_not_called()


### PR DESCRIPTION
… application windows.

**Description of work:**

This PR sets a parent window on all dialogs so they are transient for their owning application windows, which means they will be shown together close to their application windows--and not somewhere else, or, the other extreme, just obscuring the entire application window they belong to.

**To test:**
Open the respective dialog window on a big screen. You'll see each dialog now is a (smaller) popup centered over the owning application window and stays close to it.
