### PR TITLE
Fixed for publish action

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -28,7 +28,7 @@ runs:
         conda-build \
           -c mantid/label/nightly \
           -c mantid \
-          $GITHUB_WORKSPACE/conda
+          $GITHUB_WORKSPACE/conda \
           --user ${{ inputs.repository }} \
           --token ${{ inputs.token }} \
           --label ${{ inputs.label }} \

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -67,7 +67,7 @@ jobs:
 
           FILES_TO_REMOVE=$(echo "${RAW_RESULT}" \
             | jq -r '
-              [.files[] | select(.labels | index("'"${LABEL}"'"))]
+              [.files[] | select((.labels | index("'"${LABEL}"'")) and (.labels | index("mains") | not))]
               | group_by(.version)
               | map({
                   version: .[0].version,


### PR DESCRIPTION
**Description of work:**

The last MSlice nightly did not upload since there was a line continuation missing. Also, the removal step did not take into account that some nightly packages have both labels `nightly` and `main`. The one with a `main` label should never get removed.

**To test:**

Code review only.
