### PR TITLE
Add ability to manually trigger nightly build

### DIFF
--- a/.github/workflows/unit_tests_nightly.yml
+++ b/.github/workflows/unit_tests_nightly.yml
@@ -3,6 +3,7 @@ name: MSlice nightly build
 on:
   schedule:
     - cron: '0 2 * * *'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
**Description of work:**
Adds a [workflow_dispatch trigger](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch) for manually setting off the nightly run

**To test:**
Just examine the change. Once merged, you should be able to go to the action and click "run workflow".

