### PR TITLE
Changed dry run option to false

### DIFF
--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -56,7 +56,7 @@ jobs:
           PACKAGE_NAME: "mslice"
           LABEL: "nightly"
           KEEP: "5"
-          DRY_RUN: "true"
+          DRY_RUN: "false"
         run: |
           ANACONDA_URL="https://api.anaconda.org/package/${ORGANIZATION}/${PACKAGE_NAME}"
           RAW_RESULT=$(curl --max-time 5.5 -s ${ANACONDA_URL})


### PR DESCRIPTION
**Description of work:**

The new feature of removing older nightly builds of MSlice when uploading a new nightly build has been tested with the dry run option set to true. This test was successful, so now the dry run option can be set to false to actually remove old packages.

**To test:**

Code review only.
