### PR TITLE
Use fetch-tags instead of tags

### DIFF
--- a/.github/workflows/deploy_conda.yml
+++ b/.github/workflows/deploy_conda.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,12 +1,11 @@
 name: Deploy MSlice nightly
 
 on: 
-  push
-#  workflow_run: 
-#    workflows: ["MSlice nightly build"]
-#    branches: [main]
-#    types:
-#      - completed
+  workflow_run: 
+    workflows: ["MSlice nightly build"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   build_conda_and_upload:
@@ -17,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -43,7 +42,7 @@ jobs:
           auto-activate-base: false
 
       - name: Build MSlice nightly conda package
-        #if: ${{ env.recentCommits == 'true' && env.headTagged == 'false'}}
+        if: ${{ env.recentCommits == 'true' && env.headTagged == 'false'}}
         uses: ./.github/actions/publish-package
         with:
           label: nightly

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,7 +1,7 @@
 name: Deploy MSlice nightly
 
-on: 
-  workflow_run: 
+on:
+  workflow_run:
     workflows: ["MSlice nightly build"]
     branches: [main]
     types:

--- a/.github/workflows/deploy_conda_nightly.yml
+++ b/.github/workflows/deploy_conda_nightly.yml
@@ -1,11 +1,12 @@
 name: Deploy MSlice nightly
 
-on:
-  workflow_run:
-    workflows: ["MSlice nightly build"]
-    branches: [main]
-    types:
-      - completed
+on: 
+  push
+#  workflow_run: 
+#    workflows: ["MSlice nightly build"]
+#    branches: [main]
+#    types:
+#      - completed
 
 jobs:
   build_conda_and_upload:
@@ -19,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          tags: true
+          fetch-tags: true
           ref: main
 
       - name: Check for changes since last build
@@ -42,7 +43,7 @@ jobs:
           auto-activate-base: false
 
       - name: Build MSlice nightly conda package
-        if: ${{ env.recentCommits == 'true' && env.headTagged == 'false'}}
+        #if: ${{ env.recentCommits == 'true' && env.headTagged == 'false'}}
         uses: ./.github/actions/publish-package
         with:
           label: nightly

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/unit_tests_nightly.yml
+++ b/.github/workflows/unit_tests_nightly.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout MSlice
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
**Description of work:**

There was a warning for the nightly conda deploy workflow saying that actions/checkout@v4 does not have a parameter tags. Now it is using "fetch-tags: true" instead. I have also upgraded checkout from v4 to v6.

**To test:**

Code review and double check documentation for actions/checkout@v6: https://github.com/actions/checkout


Fixes #1189.
