### PR TITLE
Revert "Fix remaining GitHub workflow warnings"

### DIFF
--- a/.github/workflows/online_doc_update.yml
+++ b/.github/workflows/online_doc_update.yml
@@ -15,11 +15,11 @@ jobs:
         sudo apt-get install texlive-latex-base texlive-latex-recommended \
             texlive-fonts-recommended texlive-latex-extra dvipng
     - id: deployment
-      uses: sphinx-notes/pages@v3.6
+      uses: sphinx-notes/pages@v3
       with:
         publish: false
         documentation_path: ./docs/source
-    - uses: peaceiris/actions-gh-pages@v4.1
+    - uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ${{ steps.deployment.outputs.artifact }}


### PR DESCRIPTION
Reverts mantidproject/mslice#1197 as the workflow seems to be unable to resolve the new version numbers.