### PR TITLE
Improve robustness for missing workspaces after ADS clear

### DIFF
--- a/src/mslice/models/workspacemanager/workspace_provider.py
+++ b/src/mslice/models/workspacemanager/workspace_provider.py
@@ -16,7 +16,12 @@ def get_workspace_handle(workspace_name):
 
 
 def add_workspace(workspace, name):
-    raw_name = workspace.raw_ws.name()
+    try:
+        raw_name = workspace.raw_ws.name()
+    except RuntimeError:
+        # Mantid invalidates workspace proxies when ADS is cleared (e.g. mtd.clear()).
+        # There is nothing useful to add, so bail out silently.
+        return
     if raw_name.endswith("_HIDDEN"):
         RenameWorkspace(workspace.raw_ws, OutputWorkspace=raw_name[:-7])
     _loaded_workspaces[name] = workspace

--- a/src/mslice/plotting/plot_window/interactive_cut.py
+++ b/src/mslice/plotting/plot_window/interactive_cut.py
@@ -174,7 +174,7 @@ class InteractiveCut(object):
     def window_closing(self):
         if not workspace_exists(self._ws_title):
             # Workspace has been removed (e.g. ADS cleared); skip storing the cut
-            # workspace so we don't access an invalidated Mantid workspace proxy.
+            # workspace .
             self.store_icut_cut_upon_toggle_and_reset(store=False)
         self.slice_plot.toggle_interactive_cuts()
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)

--- a/src/mslice/plotting/plot_window/interactive_cut.py
+++ b/src/mslice/plotting/plot_window/interactive_cut.py
@@ -5,7 +5,7 @@ from mslice.models.cut.cut import Cut
 from mslice.models.cut.cut_functions import output_workspace_name
 from mslice.models.units import EnergyUnits
 from mslice.models.workspacemanager.workspace_algorithms import get_limits
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
+from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, workspace_exists
 from mslice.presenters.cut_plotter_presenter import CutPlotterPresenter
 from mslice.plotting.pyplot import GlobalFigureManager
 
@@ -64,6 +64,8 @@ class InteractiveCut(object):
         self._rect_pos_cache = rect_pos
 
     def plot_cut(self, x1, x2, y1, y2, store=False):
+        if not workspace_exists(self._ws_title):
+            return
         if x2 > x1 and y2 > y1:
             ax, integration_start, integration_end = self.get_cut_parameters(
                 (x1, y1), (x2, y2)
@@ -104,6 +106,7 @@ class InteractiveCut(object):
                 self._is_initial_cut_plotter_presenter = False
                 GlobalFigureManager.disable_make_current()
                 self.slice_plot.plot_window.action_save_cut.setVisible(True)
+                self.slice_plot.plot_window.action_save_cut.setEnabled(True)
             self._cut_plotter_presenter.store_icut(self)
 
     def get_cut_parameters(self, pos1, pos2):
@@ -140,6 +143,8 @@ class InteractiveCut(object):
             self.rect.update()
 
     def save_cut(self):
+        if not workspace_exists(self._ws_title):
+            return
         x1, x2, y1, y2 = self.rect.extents
         self.plot_cut(x1, x2, y1, y2, store=True)
         self.update_workspaces()
@@ -167,6 +172,10 @@ class InteractiveCut(object):
         self.plot_cut(*self.rect.extents)
 
     def window_closing(self):
+        if not workspace_exists(self._ws_title):
+            # Workspace has been removed (e.g. ADS cleared); skip storing the cut
+            # workspace so we don't access an invalidated Mantid workspace proxy.
+            self.store_icut_cut_upon_toggle_and_reset(store=False)
         self.slice_plot.toggle_interactive_cuts()
         self.slice_plot.plot_window.action_interactive_cuts.setChecked(False)
 

--- a/src/mslice/plotting/plot_window/interactive_cut.py
+++ b/src/mslice/plotting/plot_window/interactive_cut.py
@@ -5,7 +5,10 @@ from mslice.models.cut.cut import Cut
 from mslice.models.cut.cut_functions import output_workspace_name
 from mslice.models.units import EnergyUnits
 from mslice.models.workspacemanager.workspace_algorithms import get_limits
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, workspace_exists
+from mslice.models.workspacemanager.workspace_provider import (
+    get_workspace_handle,
+    workspace_exists,
+)
 from mslice.presenters.cut_plotter_presenter import CutPlotterPresenter
 from mslice.plotting.pyplot import GlobalFigureManager
 

--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -29,6 +29,19 @@ def release_active_interactive_cuts_on_slice_plots() -> None:
             action_icuts.setChecked(False)
 
 
+def disable_icut_buttons_for_missing_workspaces() -> None:
+    """Disable icut toolbar buttons on slice plots whose backing workspace no longer exists."""
+    from mslice.models.workspacemanager.workspace_provider import workspace_exists
+
+    for each_figure in GlobalFigureManager.all_figures():
+        plot_handler = each_figure.plot_handler
+        if isinstance(plot_handler, SlicePlot) and not workspace_exists(
+            plot_handler.ws_name
+        ):
+            plot_handler.plot_window.action_save_cut.setEnabled(False)
+            plot_handler.plot_window.action_flip_axis.setEnabled(False)
+
+
 class PlotFigureManagerQT(QtCore.QObject):
     """Manage a Qt window along with the keep/make current status"""
 

--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -30,7 +30,7 @@ def release_active_interactive_cuts_on_slice_plots() -> None:
 
 
 def disable_icut_buttons_for_missing_workspaces() -> None:
-    """Disable icut toolbar buttons on slice plots whose backing workspace no longer exists."""
+    """Disable icut toolbar buttons on slice plots whose underlying workspace no longer exists."""
     from mslice.models.workspacemanager.workspace_provider import workspace_exists
 
     for each_figure in GlobalFigureManager.all_figures():

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -11,7 +11,10 @@ from mslice.models.colors import to_hex, name_to_color
 from mslice.models.units import get_sample_temperature_from_string
 from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options, check_latex
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, workspace_exists
+from mslice.models.workspacemanager.workspace_provider import (
+    get_workspace_handle,
+    workspace_exists,
+)
 from mslice.plotting.plot_window.cachable_input_dialog import QCacheableInputDialog
 from mslice.plotting.plot_window.iplot import IPlot
 from mslice.plotting.plot_window.interactive_cut import InteractiveCut

--- a/src/mslice/plotting/plot_window/slice_plot.py
+++ b/src/mslice/plotting/plot_window/slice_plot.py
@@ -11,7 +11,7 @@ from mslice.models.colors import to_hex, name_to_color
 from mslice.models.units import get_sample_temperature_from_string
 from mslice.presenters.plot_options_presenter import SlicePlotOptionsPresenter
 from mslice.presenters.quick_options_presenter import quick_options, check_latex
-from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
+from mslice.models.workspacemanager.workspace_provider import get_workspace_handle, workspace_exists
 from mslice.plotting.plot_window.cachable_input_dialog import QCacheableInputDialog
 from mslice.plotting.plot_window.iplot import IPlot
 from mslice.plotting.plot_window.interactive_cut import InteractiveCut
@@ -557,6 +557,10 @@ class SlicePlot(IPlot):
         self._canvas.draw()
 
     def toggle_interactive_cuts(self):
+        if not self.icut and not workspace_exists(self.ws_name):
+            # Workspace has been removed (e.g. ADS cleared); reset the button and bail out
+            self.plot_window.action_interactive_cuts.setChecked(False)
+            return
         self.toggle_icut_button()
         self.toggle_icut()
 
@@ -571,6 +575,7 @@ class SlicePlot(IPlot):
             self.plot_window.action_keep.setEnabled(False)
             self.plot_window.action_make_current.setEnabled(False)
             self.plot_window.action_flip_axis.setVisible(True)
+            self.plot_window.action_flip_axis.setEnabled(True)
             self.plot_window.menu_intensity.setDisabled(True)
         else:
             self.manager.picking_connected(True)

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -1,5 +1,7 @@
 from .busy import show_busy
-from mslice.plotting.plot_window.plot_figure_manager import disable_icut_buttons_for_missing_workspaces
+from mslice.plotting.plot_window.plot_figure_manager import (
+    disable_icut_buttons_for_missing_workspaces,
+)
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.models.mslice_ads_observer import MSliceADSObserver

--- a/src/mslice/presenters/workspace_manager_presenter.py
+++ b/src/mslice/presenters/workspace_manager_presenter.py
@@ -1,4 +1,5 @@
 from .busy import show_busy
+from mslice.plotting.plot_window.plot_figure_manager import disable_icut_buttons_for_missing_workspaces
 from mslice.widgets.workspacemanager.command import Command
 from mslice.widgets.workspacemanager import TAB_2D, TAB_NONPSD
 from mslice.models.mslice_ads_observer import MSliceADSObserver
@@ -288,11 +289,13 @@ class WorkspaceManagerPresenter(WorkspaceManagerPresenterInterface):
             workspace = workspace[5:]
         delete_workspace(workspace)
         self.update_displayed_workspaces()
+        disable_icut_buttons_for_missing_workspaces()
 
     def clear_handle(self):
         for workspace in get_workspace_names():
             delete_workspace(workspace)
         self.update_displayed_workspaces()
+        disable_icut_buttons_for_missing_workspaces()
 
     def rename_handle(self, workspace, new_name):
         if new_name is None:


### PR DESCRIPTION
**Description of work:**

Occasionally, users clear the ADS via Mantid and still attempt to modify plots in MSlice even though the underlying workspace was deleted. There is a variety of ways to cause a crash by doing this. Some of these were summarised in [#1181](https://github.com/mantidproject/mslice/issues/1181). This PR attempts to prevent crashes after ADS clear by guarding against access of deleted workspaces.

**To test:**

Follow the instructions in the original issue.


Fixes #1181.
