### PR TITLE
Update to support Qt6. Drop pyqt5 and just use qtpy.

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -31,7 +31,6 @@ requirements:
   - ipython
   - matplotlib
   - numpy
-  - pyqt
   - qtconsole
   - qtpy
 

--- a/src/mslice/plotting/plot_window/cachable_input_dialog.py
+++ b/src/mslice/plotting/plot_window/cachable_input_dialog.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QComboBox,
     QFormLayout,
     QLabel,
@@ -8,8 +8,9 @@ from PyQt5.QtWidgets import (
     QSizePolicy,
     QVBoxLayout,
     QHBoxLayout,
+    QDialog,
+    QCheckBox,
 )
-from qtpy.QtWidgets import QDialog, QCheckBox
 
 
 class QCacheableInputDialog(QDialog):


### PR DESCRIPTION
**Description of work:**

We don't need to include `pyqt` in the conda recipe since `mantidqt` will pull in correct `pyqt` version. The should allow mslice package to work with both Qt5 and Qt6 versions of Mantid.

This should address the workbench package build issue in mantidproject/mantid#41652

I haven't actually tested mslice to see if anything fails when running under Qt6. That should be a follow up once we actually have it running with a Qt6 version of Mantid.

**To test:**

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #xxxx.
