### PR TITLE
Use dynamic versioning and update for Qt6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ var/
 .installed.cfg
 *.egg
 .flake8
+output/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -33,7 +33,7 @@ requirements:
     - ipython
     - matplotlib
     - numpy
-    - qtconsole
+    - qtconsole-base
     - qtpy
 
 tests:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,8 +19,12 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath(os.path.join("../..", "src")))
 
-# from mslice import version_info  # noqa: E402
-version_info = (2, 15, 0)
+from versioningit import get_version
+
+release_str = get_version("../..")
+
+major, minor = release_str.split(".")[:2]
+version_info = (int(major), int(minor), 0)
 
 # -- General configuration ------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,6 @@ default-tag = "0.0.0"
 method = "minor"
 
 [tool.versioningit.format]
-distance = "{base_version}.dev{distance}"
-dirty = "{base_version}.dev0"
-distance-dirty = "{base_version}.dev{distance}"
+distance = "{next_version}.dev{distance}"
+dirty = "{next_version}.dev0+uncommitted"
+distance-dirty = "{next_version}.dev{distance}+uncommitted"

--- a/src/mslice/__init__.py
+++ b/src/mslice/__init__.py
@@ -6,6 +6,11 @@ A PyQt-based version of the MSlice (http://mslice.isis.rl.ac.uk) program based
 on Mantid (http://www.mantidproject.org).
 """
 
-version_info = (2, 15, 0)
-__version__ = ".".join(map(str, version_info))
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("mslice")
+except PackageNotFoundError:
+    __version__ = "0+unknown"
+
 __project_url__ = "https://github.com/mantidproject/mslice"

--- a/src/mslice/app/__init__.py
+++ b/src/mslice/app/__init__.py
@@ -6,7 +6,6 @@ import sys
 
 import mslice.util.mantid.init_mantid  # noqa: F401
 from mslice.util.mantid import in_mantid
-from qtpy import QT_VERSION
 from mslice.util.qt.qapp import create_qapp_if_required
 
 
@@ -24,7 +23,7 @@ def main():
     qapp_ref = create_qapp_if_required()
     import matplotlib as mpl
 
-    mpl.use("Qt{}Agg".format(QT_VERSION[0]))
+    mpl.use("qtagg")
     show_gui()
     return qapp_ref.exec_()
 

--- a/src/mslice/plotting/backend.py
+++ b/src/mslice/plotting/backend.py
@@ -1,9 +1,6 @@
 # system imports
 import importlib
 
-# local imports
-from qtpy import QT_VERSION
-
 
 def get_canvas_and_toolbar_cls():
     """
@@ -22,5 +19,5 @@ def get_backend_module():
     """
     # Pick the relevant QtAgg one for the version we are running
     return importlib.import_module(
-        "matplotlib.backends.backend_qt{}agg".format(QT_VERSION[0])
+        "matplotlib.backends.backend_qtagg"
     )

--- a/src/mslice/plotting/backend.py
+++ b/src/mslice/plotting/backend.py
@@ -18,6 +18,4 @@ def get_backend_module():
     :return: A reference to the appropriate backend module
     """
     # Pick the relevant QtAgg one for the version we are running
-    return importlib.import_module(
-        "matplotlib.backends.backend_qtagg"
-    )
+    return importlib.import_module("matplotlib.backends.backend_qtagg")

--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -307,7 +307,8 @@ class PlotFigureManagerQT(QtCore.QObject):
             self.plot_handler.on_newplot(plot_over, ws_name)
 
     def move_window(self, x, y):
-        center = QtWidgets.QDesktopWidget().screenGeometry().center()
+        screen = QtWidgets.QApplication.primaryScreen()
+        center = screen.geometry().center()
         self.window.move(int(center.x() - x), int(center.y() - y))
 
     def get_window_title(self):

--- a/src/mslice/plotting/plot_window/plot_options.py
+++ b/src/mslice/plotting/plot_window/plot_options.py
@@ -4,8 +4,8 @@ import qtpy.QtWidgets as QtWidgets
 from qtpy.QtCore import Signal
 from mslice.models.colors import named_cycle_colors, color_to_name
 from mslice.util.qt import load_ui
-from qtpy.QtGui import QRegExpValidator
-from qtpy.QtCore import QRegExp
+from qtpy.QtGui import QRegularExpressionValidator
+from qtpy.QtCore import QRegularExpression
 from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
 from mantidqt.icons import get_icon
 
@@ -39,8 +39,8 @@ class PlotOptionsDialog(QtWidgets.QDialog):
         self.lneYMin.setValidator(self.y_min_validator)
         self.y_max_validator = LineEditDoubleValidator(self.lneYMax, 0.0)
         self.lneYMax.setValidator(self.y_max_validator)
-        two_postv_ints_regex = QRegExp(r"^\s*[1-9][0-9]?$")
-        self.all_fonts_size_validator = QRegExpValidator(two_postv_ints_regex)
+        two_postv_ints_regex = QRegularExpression(r"^\s*[1-9][0-9]?$")
+        self.all_fonts_size_validator = QRegularExpressionValidator(two_postv_ints_regex)
         self.allFntSz.setValidator(self.all_fonts_size_validator)
 
         self.lneFigureTitle.editingFinished.connect(self.titleEdited)

--- a/src/mslice/plotting/plot_window/plot_options.py
+++ b/src/mslice/plotting/plot_window/plot_options.py
@@ -40,7 +40,9 @@ class PlotOptionsDialog(QtWidgets.QDialog):
         self.y_max_validator = LineEditDoubleValidator(self.lneYMax, 0.0)
         self.lneYMax.setValidator(self.y_max_validator)
         two_postv_ints_regex = QRegularExpression(r"^\s*[1-9][0-9]?$")
-        self.all_fonts_size_validator = QRegularExpressionValidator(two_postv_ints_regex)
+        self.all_fonts_size_validator = QRegularExpressionValidator(
+            two_postv_ints_regex
+        )
         self.allFntSz.setValidator(self.all_fonts_size_validator)
 
         self.lneFigureTitle.editingFinished.connect(self.titleEdited)

--- a/src/mslice/widgets/dataloader/dataloader.py
+++ b/src/mslice/widgets/dataloader/dataloader.py
@@ -110,8 +110,7 @@ class DataLoaderWidget(QWidget):  # and some view interface
     def sort_files(self, column):
         self._sort_column = column
         self.table_view.sortByColumn(
-            column,
-            Qt.DescendingOrder if column % 2 else Qt.AscendingOrder
+            column, Qt.DescendingOrder if column % 2 else Qt.AscendingOrder
         )  # descending order for size/modified, ascending for name/type
 
     def go_to_home(self):

--- a/src/mslice/widgets/dataloader/dataloader.py
+++ b/src/mslice/widgets/dataloader/dataloader.py
@@ -110,7 +110,8 @@ class DataLoaderWidget(QWidget):  # and some view interface
     def sort_files(self, column):
         self._sort_column = column
         self.table_view.sortByColumn(
-            column, column % 2
+            column,
+            Qt.DescendingOrder if column % 2 else Qt.AscendingOrder
         )  # descending order for size/modified, ascending for name/type
 
     def go_to_home(self):

--- a/src/mslice/widgets/workspacemanager/workspacemanager.py
+++ b/src/mslice/widgets/workspacemanager/workspacemanager.py
@@ -1,4 +1,3 @@
-from qtpy import QT_VERSION
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QWidget, QListWidgetItem, QFileDialog, QInputDialog
 from mslice.models.workspacemanager.workspace_provider import get_workspace_handle
@@ -155,18 +154,11 @@ class WorkspaceManagerWidget(WorkspaceView, QWidget):
 
     def set_workspace_selected(self, index):
         current_list = self.current_list()
-        if QT_VERSION.startswith("5"):
-            for item_index in range(current_list.count()):
-                current_list.item(item_index).setSelected(False)
-            for this_index in index if hasattr(index, "__iter__") else [index]:
-                if this_index >= 0:
-                    current_list.item(this_index).setSelected(True)
-        else:
-            for item_index in range(current_list.count()):
-                current_list.setItemSelected(current_list.item(item_index), False)
-            for this_index in index if hasattr(index, "__iter__") else [index]:
-                if this_index >= 0:
-                    current_list.setItemSelected(current_list.item(this_index), True)
+        for item_index in range(current_list.count()):
+            current_list.item(item_index).setSelected(False)
+        for this_index in index if hasattr(index, "__iter__") else [index]:
+            if this_index >= 0:
+                current_list.item(this_index).setSelected(True)
 
     def get_workspace_index(self, ws_name):
         current_list = self.current_list()


### PR DESCRIPTION
**Description of work:**
This is a bunch of changes required to get mslice to install and launch alongside mantidworkbench nightly. It has been broken on Linux since the Linux build moved to Qt6. It should still be compatible with the Qt5 builds on other OS. Changes include:
- Remove all hard-coded instance of version numbers and correctly set the nightly version numbers to the next minor release. This will allow `mantidworkbench` to install nightly versions.
- Replace `qtconsole` with `qtconsole-base` to avoid conflict with the `PyQt6 >= 6.11` pin in `mantidqt` requirements
- Resolve all known Qt6 compatibility issues (e.g. obsolete classes)

It looks like the correct version number is being created for the conda package, but when you print `mslice.__version__` it adds a `+uncommitted` stamp. This can be fixed as a follow-up. The base version number is at least consistent.

**To test:**
Build the package locally. The version number of the package should be `<last tag>.dev<number of commits since last tag>`:
```
mamba create -n rattler-build-env
mamba activate rattler-build-env
rattler-build build --recipe ./conda/recipe.yaml -c conda-forge -c mantid/label/nightly -c mantid --variant "version=$(python -m versioningit)" --output-dir output
```
Install the package locally and launch mslice:
```
mamba create -n mslice-test
mamba activate mslice-test
mamba install -c ./output -c mantid/label/nightly mslice
mslice
```
Print the version number:
```
import mslice
print(mslice.__version__)
```
It should be the same as above, although for some reason it contains `+uncommitted`.