### PR TITLE
Fix for rare ghost plot situation in slices or cuts

### DIFF
--- a/src/mslice/plotting/plot_window/plot_figure_manager.py
+++ b/src/mslice/plotting/plot_window/plot_figure_manager.py
@@ -192,15 +192,27 @@ class PlotFigureManagerQT(QtCore.QObject):
         self.canvas.draw()
 
     def plot_clicked(self, event):
+        last_fignum, disable_make_curr_after = (
+            self.report_as_current_and_return_previous_status()
+        )
         if event.dblclick or event.button == 3:
             self.plot_handler.plot_clicked(event.x, event.y)
+        self.reset_current_figure_as_previous(last_fignum, disable_make_curr_after)
 
     def object_clicked(self, event):
+        last_fignum, disable_make_curr_after = (
+            self.report_as_current_and_return_previous_status()
+        )
         if event.mouseevent.dblclick or event.mouseevent.button == 3:
             self.plot_handler.object_clicked(event.artist)
+        self.reset_current_figure_as_previous(last_fignum, disable_make_curr_after)
 
     def _plot_options(self):
+        last_fignum, disable_make_curr_after = (
+            self.report_as_current_and_return_previous_status()
+        )
         self.plot_handler.plot_options()
+        self.reset_current_figure_as_previous(last_fignum, disable_make_curr_after)
 
     def print_plot(self):
         printer = QtPrintSupport.QPrinter()

--- a/tests/figure_manager_test.py
+++ b/tests/figure_manager_test.py
@@ -127,6 +127,25 @@ class CurrentFigureTest(unittest.TestCase):
         self.assertTrue(fig1 == mock_figures[0])
         self.assertTrue(fig2 == mock_figures[1])
 
+    def test_new_figure_is_issued_when_all_figures_are_kept_and_active_figure_is_retrieved(
+        self, mock_figure_class
+    ):
+        mock_figure = [mock.Mock(), mock.Mock()]
+        mock_figure_class.side_effect = mock_figure
+
+        # GlobalFigureManager creates a new figure if all open figures are marked as kept. This can create an empty plot when trying
+        # to alter a plot and all plots are marked as kept. This is prevented by setting the figure changing its properties as current.
+        fig1 = GlobalFigureManager.get_active_figure()
+        GlobalFigureManager.set_figure_as_kept(1)
+        self.assertTrue(GlobalFigureManager._active_figure is None)
+        fig2 = GlobalFigureManager.get_active_figure()
+        self.assertTrue(fig1 != fig2)
+
+        GlobalFigureManager.set_figure_as_kept(2)
+        self.assertTrue(GlobalFigureManager._active_figure is None)
+        GlobalFigureManager.set_figure_as_current(1)
+        self.assertTrue(fig1 == GlobalFigureManager.get_active_figure())
+
     def test_close_non_existant_window_fail(self, mock_figure_class):
         mock_figures = [mock.Mock()]
         mock_figure_class.side_effect = mock_figures

--- a/tests/testscripts/subtract_scaled_ws.py
+++ b/tests/testscripts/subtract_scaled_ws.py
@@ -1,8 +1,14 @@
+import pathlib
 import mslice.cli as mc
 import mslice.plotting.pyplot as plt
 
+
+TEST_FILE_PATH = (
+    pathlib.Path(__file__).resolve().parents[1] / "testdata" / "MAR21335_Ei60meV.nxs"
+)
+
 MAR21335_Ei60meV = mc.Load(
-    Filename=r"tests/testdata/MAR21335_Ei60meV.nxs", OutputWorkspace="MAR21335_Ei60meV"
+    Filename=str(TEST_FILE_PATH), OutputWorkspace="MAR21335_Ei60meV"
 )
 MAR21335_Ei60meV_scaled = mc.Scale(
     InputWorkspace=MAR21335_Ei60meV, OutputWorkspace="MAR21335_Ei60meV_scaled"


### PR DESCRIPTION
**Description of work:**

Fix for #1195 

The ghost plots are happening in both mac and linux (and probably windows too) when trying to modify a plot (from settings or quicksettings) and all opened plots are marked as kept. 
The way mslice is designed is that there is only one active plot at a given time, so if a plot is marked as kept, it automatically becomes inactive for the global figure manager, and any new cut or slice is displayed on a new plot window. But if all open plots are marked as `keep`, the figure manager will interpret that there are no active plots and set the active figure property to None (instead of the plot number). When a change that involves getting a handle of the active plot number (like changing the grid) is tried and all plots are `keep`, the global figure manager  creates an empty window plot. 

The fix that seems more correct for this design is to automatically mark any plot that is interacted with as active (`current`). This situation probably already presented before (as when bragg peaks are added to an open plot), as I only had to use the already implemented methods `report_as_current_and_return_previous_status` and `reset_current_figure_as_previous` before and after a plot interaction in the plot manager instances. 

bonus: There was a test that was failing on my local machine due to the relative folder path the python runner was using, I have changed it so that the path is insensitive to this by using pathlib.


**To test:**

- Follow #1195 test instructions, no ghost plots should appear when trying to change settings by clicking on the axes or on the settings (like axes limits or grid on/off).


<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
Fixes #1195 
