### PR TITLE
Fix __version__ reporting +uncommitted on clean builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,8 @@ ENV/
 # Data files
 *.nxs
 *.nxspe
+# Keep this tracked test file so the conda build tree stays clean (mantidproject/mslice#1210):
+!tests/testdata/MAR21335_Ei60meV.nxs
 
 # Diff files
 *.diff


### PR DESCRIPTION
**Description of work:**
mslice.__version__ has `+uncommitted` suffix (e.g. 2.16.0.dev8+uncommitted) even when built from a clean checkout, and it didn't match the conda package version. 

The root cause is that `tests/testdata/MAR21335_Ei60meV.nxs` is tracked in git, but the *.nxs rule in .gitignore matches it. When rattler-build copies the source into its build sandbox, it respects .gitignore so it skips the file. Inside the sandbox git then sees the file as deleted, the working tree looks dirty, and versioningit appends __version__ with +uncommitted. The conda package version is computed separately in the clean CI checkout, so only the internal __version__ was affected.

To fix the issue, the nxs test file is excluded in .gitignore so the tracked test file is no longer ignored, keeping the build tree clean.


**To test:**
1. Build the conda package as CI does (rattler-build ... --variant "version=$(python -m versioningit)").
2. Install into a fresh env and run python -c "import mslice; print(mslice.__version__)".
3. Expect 2.16.0.devN with no +uncommitted, matching conda list mslice.

Fixes #1210.
