### PR TITLE
Added the update-pixi-lockfile.yml workflow that will update the pixi.lock file weekly on the mslice repo

### DIFF
--- a/.github/workflows/update-pixi-lockfile.yml
+++ b/.github/workflows/update-pixi-lockfile.yml
@@ -1,0 +1,48 @@
+name: Update pixi lockfiles
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 6 * * 1
+
+env:
+  UPDATE_BRANCH: 'main'
+
+jobs:
+  pixi-update-lockfile:
+    if: github.repository_owner == 'mantidproject'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.UPDATE_BRANCH }}  # start from this branch
+
+      - uses: ./.github/actions/setup-pixi
+
+      - name: Update lockfiles
+        run: |
+          set -o pipefail
+          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          commit-message: Update pixi lockfile
+          title: Update pixi lockfile
+          body-path: diff.md
+          branch: update-pixi
+          base:  ${{ env.UPDATE_BRANCH }}
+          labels: |
+            pixi
+            maintenance
+            devops
+          delete-branch: true
+          add-paths: pixi.lock


### PR DESCRIPTION
**Description of work:**
This is another incremental transition to `pixi` after the previous work done in #1213 and #1219
The [update-pixi-lockfile.yml](https://github.com/mantidproject/mantid/blob/main/.github/workflows/update-pixi-lockfile.yml) that automatically updates the `pixi.lock` file is added to **mslice**. Tom suggested lowering the frequency of the updates from daily to weekly on **mslice** and using the `Github Actions` bot rather than using the `Mantid Builder` bot to create the PRs. 


**To test:**

<!-- Instructions for testing. -->

<!-- Replace #xxxx with the number of the issue this fixes.
      The issue will then be automatically closed when this is merged. -->
I tested the changes in this **PR** by merging this workflow into the `main` branch of my fork and then using `workflow_dispatch`. It creates the [PR](https://github.com/RabiyaF/mslice/pull/2) with the updates as expected. So, this can be merged and then I will run it on the `mslice` repo using `workflow_dispatch` as well.

**Additional Information:**
I have already created the labels required for the workflow. They are the same labels as the ones on this **PR**. I also changed the colour of the maintenance label from **#3F7EBA** to **#044124** because the dark text wasn't readable on that label. But this can be reverted.

**Future Work:**
I am creating an issue so that more work can be prioritised in a future sprint (#1221)

